### PR TITLE
Optimize remainder calculation with precomputation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Some parts were adapted from other projects:
 
 - dave-andersen's fastrie (https://github.com/dave-andersen/fastrie)
 	- Based on jh00's xptMiner
+- modified GMP code
 
 These parts are subject to their respective licenses.
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CXX    = g++
 M4     = m4
 AS     = as
 CFLAGS = -Wall -Wextra -std=gnu++11 -O3 -march=native
-LIBS   = -pthread -ljansson -lcurl -lgmp -lgmpxx -lcrypto
+LIBS   = -pthread -ljansson -lcurl -lcrypto -Wl,-Bstatic -lgmp -lgmpxx -Wl,-Bdynamic
 
 all: rieMiner
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ AS     = as
 CFLAGS = -Wall -Wextra -std=gnu++11 -O3 -march=native
 LIBS   = -pthread -ljansson -lcurl -lcrypto -Wl,-Bstatic -lgmp -lgmpxx -Wl,-Bdynamic
 
+msys_version := $(if $(findstring Msys, $(shell uname -o)),$(word 1, $(subst ., ,$(shell uname -r))),0)
+ifneq ($(msys_version), 0)
+	LIBS   += -lws2_32
+endif
+
 all: rieMiner
 
 release: CFLAGS += -DNDEBUG

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@ CXX    = g++
 M4     = m4
 AS     = as
 CFLAGS = -Wall -Wextra -std=gnu++11 -O3 -march=native
-LIBS   = -pthread -ljansson -lcurl -lcrypto -Wl,-Bstatic -lgmp -lgmpxx -Wl,-Bdynamic
 
 msys_version := $(if $(findstring Msys, $(shell uname -o)),$(word 1, $(subst ., ,$(shell uname -r))),0)
 ifneq ($(msys_version), 0)
-	LIBS   += -lws2_32
+LIBS   = -pthread -ljansson -lcurl -lcrypto -lgmp -lgmpxx -lws2_32
+MOD_1_4_ASM = mod_1_4_win.asm
+else
+LIBS   = -pthread -ljansson -lcurl -lcrypto -Wl,-Bstatic -lgmp -lgmpxx -Wl,-Bdynamic
+MOD_1_4_ASM = mod_1_4.asm
 endif
 
 all: rieMiner
@@ -38,8 +41,8 @@ client.o: client.cpp
 tools.o: tools.cpp
 	$(CXX) $(CFLAGS) -c -o tools.o tools.cpp
 
-mod_1_4.o: external/mod_1_4.asm
-	$(M4) external/mod_1_4.asm >mod_1_4.s
+mod_1_4.o: external/$(MOD_1_4_ASM)
+	$(M4) external/$(MOD_1_4_ASM) >mod_1_4.s
 	$(AS) mod_1_4.s -o mod_1_4.o
 	rm mod_1_4.s
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 CXX    = g++
+M4     = m4
+AS     = as
 CFLAGS = -Wall -Wextra -std=gnu++11 -O3 -march=native
 LIBS   = -pthread -ljansson -lcurl -lgmp -lgmpxx -lcrypto
 
@@ -10,7 +12,7 @@ release: rieMiner
 debug: CFLAGS += -g
 debug: rieMiner
 
-rieMiner: main.o miner.o stratumclient.o gbtclient.o client.o tools.o
+rieMiner: main.o miner.o stratumclient.o gbtclient.o client.o tools.o mod_1_4.o
 	$(CXX) $(CFLAGS) -o rieMiner $^ $(LIBS)
 
 main.o: main.cpp main.h miner.h client.h gbtclient.h stratumclient.h tools.h
@@ -30,6 +32,11 @@ client.o: client.cpp
 
 tools.o: tools.cpp
 	$(CXX) $(CFLAGS) -c -o tools.o tools.cpp
+
+mod_1_4.o: external/mod_1_4.asm
+	$(M4) external/mod_1_4.asm >mod_1_4.s
+	$(AS) mod_1_4.s -o mod_1_4.o
+	rm mod_1_4.s
 
 clean:
 	rm -rf rieMiner *.o

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pacman -S mingw64/mingw-w64-x86_64-curl
 
 Recommended: move the rieMiner's folder to the MSYS2 home directory.
 
-Edit the Makefile and add -lws2_32 at the end of the LIBS line, go to the rieMiner's directory with cd, and finally compile with make.
+Go to the rieMiner's directory with cd, and compile with make.
 
 #### Static building
 
@@ -66,7 +66,7 @@ First, edit the Makefile add "-D CURL_STATICLIB" at the end of the CFLAGS line, 
 
 ```
 CFLAGS = -Wall -Wextra -std=gnu++11 -O3 -march=native -D CURL_STATICLIB
-LIBS   = -static -pthread -ljansson -lcurl -lgmp -lgmpxx -lcrypto -lws2_32
+LIBS   = -static -pthread -ljansson -lcurl -lgmp -lgmpxx -lcrypto
 ```
 
 Then, download the [latest official libcurl code](https://curl.haxx.se/download.html) on their website, under "Source Archives", and decompress the folder somewhere (for example, next to the rieMiner's one).

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ It is case sensitive, but spaces and invalid lines are ignored. **Do not put ; a
 * Sieve : size of the sieve table used for mining. Use a bigger number if you have more RAM, as you will obtain better results: this will usually reduce the ratio between the n-tuple and n+1-tuples counts. It can go up to 2^64 - 1, but setting this at more than a few billions will be too much and decrease performance. Default: 2^31;
 * Tuples : for solo mining, submit not only blocks (6-tuples) but also k-tuples of at least the given length. Its use will be explained later. Default: 6;
 * Refresh : refresh rate of the stats in seconds. 0 to disable them; will only notify when a k-tuple or share (k >= Tuples option value if solo mining) is found, or when the network finds a block. Default: 30;
+* MaxMemory : set an approximate limit on amount of memory to use. 0 for no limit. Default: 0;
 * TestDiff : only for Benchmark, sets the testing difficulty (must be from 265 to 32767). Default: 1600;
 * TestTime : only for Benchmark, sets the testing duration in s. 0 for no time limit. Default: 0;
 * Test3t : only for Benchmark, stops testing after finding this number of 3-tuples. 0 for no limit. Default: 1000;
@@ -146,7 +147,7 @@ Note that you must use different tuples counts files if you use different conste
 
 ### Memory problems
 
-If you have memory errors, try to lower the Sieve value.
+If you have memory errors, try to lower the Sieve value or set MaxMemory to control memory usage.
 
 ## Statistics
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ It is case sensitive, but spaces and invalid lines are ignored. **Do not put ; a
 * Sieve : size of the sieve table used for mining. Use a bigger number if you have more RAM, as you will obtain better results: this will usually reduce the ratio between the n-tuple and n+1-tuples counts. It can go up to 2^64 - 1, but setting this at more than a few billions will be too much and decrease performance. Default: 2^31;
 * Tuples : for solo mining, submit not only blocks (6-tuples) but also k-tuples of at least the given length. Its use will be explained later. Default: 6;
 * Refresh : refresh rate of the stats in seconds. 0 to disable them; will only notify when a k-tuple or share (k >= Tuples option value if solo mining) is found, or when the network finds a block. Default: 30;
-* MaxMemory : set an approximate limit on amount of memory to use. 0 for no limit. Default: 0;
+* MaxMemory : set an approximate limit on amount of memory to use in GiB. 0 for no limit. Default: 0;
 * TestDiff : only for Benchmark, sets the testing difficulty (must be from 265 to 32767). Default: 1600;
 * TestTime : only for Benchmark, sets the testing duration in s. 0 for no time limit. Default: 0;
 * Test3t : only for Benchmark, stops testing after finding this number of 3-tuples. 0 for no limit. Default: 1000;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Only x64 systems are supported since version 0.9β2.4.
 
 ### In Debian/Ubuntu x64
 
-You can compile this C++ program with g++ and make, install them if needed. Then, get if needed the following dependencies:
+You can compile this C++ program with g++, as, m4 and make, install them if needed. Then, get if needed the following dependencies:
 
 * Jansson
 * cURL
@@ -28,7 +28,7 @@ You can compile this C++ program with g++ and make, install them if needed. Then
 On a recent enough Debian or Ubuntu, you can easily install these by doing as root:
 
 ```bash
-apt install g++ make git libjansson-dev libcurl4-openssl-dev libssl-dev libgmp-dev
+apt install g++ make m4 git libjansson-dev libcurl4-openssl-dev libssl-dev libgmp-dev
 ```
 
 Then, just download the source files, go/cd to the directory, and do a simple make:

--- a/external/gmp_util.h
+++ b/external/gmp_util.h
@@ -1,0 +1,49 @@
+/* Useful utilities, copied from GMP
+   GMP code is used under the GNU GPLv2 license. */
+
+#pragma once
+
+#define add_ssaaaa(sh, sl, ah, al, bh, bl) \
+  __asm__ ("addq %5,%q1\n\tadcq %3,%q0"                                 \
+           : "=r" (sh), "=&r" (sl)                                      \
+           : "0"  ((uint64_t)(ah)), "rme" ((uint64_t)(bh)),             \
+             "%1" ((uint64_t)(al)), "rme" ((uint64_t)(bl)))
+#define sub_ddmmss(sh, sl, ah, al, bh, bl) \
+  __asm__ ("subq %5,%q1\n\tsbbq %3,%q0"                                 \
+           : "=r" (sh), "=&r" (sl)                                      \
+           : "0" ((uint64_t)(ah)), "rme" ((uint64_t)(bh)),              \
+             "1" ((uint64_t)(al)), "rme" ((uint64_t)(bl)))
+#define umul_ppmm(w1, w0, u, v) \
+  __asm__ ("mulq %3"                                                    \
+           : "=a" (w0), "=d" (w1)                                       \
+           : "%0" ((uint64_t)(u)), "rm" ((uint64_t)(v)))
+#define udiv_qrnnd(q, r, n1, n0, dx) /* d renamed to dx avoiding "=d" */\
+  __asm__ ("divq %4"                 /* stringification in K&R C */     \
+           : "=a" (q), "=d" (r)                                         \
+           : "0" ((uint64_t)(n0)), "1" ((uint64_t)(n1)), "rm" ((uint64_t)(dx)))
+
+/* Dividing (NH, NL) by D, returning the remainder only. Unlike
+   udiv_qrnnd_preinv, works also for the case NH == D, where the
+   quotient doesn't quite fit in a single limb. */
+#define udiv_rnnd_preinv(r, nh, nl, d, di)                              \
+  do {                                                                  \
+    mp_limb_t _qh, _ql, _r, _mask;                                      \
+    umul_ppmm (_qh, _ql, (nh), (di));                                   \
+    if (__builtin_constant_p (nl) && (nl) == 0)                         \
+      {                                                                 \
+        _r = ~(_qh + (nh)) * (d);                                       \
+        _mask = -(mp_limb_t) (_r > _ql); /* both > and >= are OK */     \
+        _r += _mask & (d);                                              \
+      }                                                                 \
+    else                                                                \
+      {                                                                 \
+        add_ssaaaa (_qh, _ql, _qh, _ql, (nh) + 1, (nl));                \
+        _r = (nl) - _qh * (d);                                          \
+        _mask = -(mp_limb_t) (_r > _ql); /* both > and >= are OK */     \
+        _r += _mask & (d);                                              \
+        if (__GMP_UNLIKELY (_r >= (d)))                                 \
+          _r -= (d);                                                    \
+      }                                                                 \
+    (r) = _r;                                                           \
+  } while (0)
+

--- a/external/mod_1_4.asm
+++ b/external/mod_1_4.asm
@@ -1,0 +1,295 @@
+dnl  AMD64 mpn_mod_1s_4p
+
+dnl  Contributed to the GNU project by Torbjorn Granlund.
+
+dnl  Copyright 2009-2012, 2014 Free Software Foundation, Inc.
+
+dnl  This file is derived from the GNU MP Library.
+dnl
+dnl  The GNU MP Library is free software; you can redistribute it and/or modify
+dnl  it under the terms of either:
+dnl
+dnl    * the GNU Lesser General Public License as published by the Free
+dnl      Software Foundation; either version 3 of the License, or (at your
+dnl      option) any later version.
+dnl
+dnl  or
+dnl
+dnl    * the GNU General Public License as published by the Free Software
+dnl      Foundation; either version 2 of the License, or (at your option) any
+dnl      later version.
+dnl
+dnl  or both in parallel, as here.
+dnl
+dnl  The GNU MP Library is distributed in the hope that it will be useful, but
+dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+dnl  for more details.
+dnl
+dnl  You should have received copies of the GNU General Public License and the
+dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
+dnl  see https://www.gnu.org/licenses/.
+
+define(`R32',
+        `ifelse($1,`%rax',`%eax',
+                $1,`%rbx',`%ebx',
+                $1,`%rcx',`%ecx',
+                $1,`%rdx',`%edx',
+                $1,`%rsi',`%esi',
+                $1,`%rdi',`%edi',
+                $1,`%rbp',`%ebp',
+                $1,`%r8',`%r8d',
+                $1,`%r9',`%r9d',
+                $1,`%r10',`%r10d',
+                $1,`%r11',`%r11d',
+                $1,`%r12',`%r12d',
+                $1,`%r13',`%r13d',
+                $1,`%r14',`%r14d',
+                $1,`%r15',`%r15d')')
+define(`R8',
+        `ifelse($1,`%rax',`%al',
+                $1,`%rbx',`%bl',
+                $1,`%rcx',`%cl',
+                $1,`%rdx',`%dl',
+                $1,`%rsi',`%sil',
+                $1,`%rdi',`%dil',
+                $1,`%rbp',`%bpl',
+                $1,`%r8',`%r8b',
+                $1,`%r9',`%r9b',
+                $1,`%r10',`%r10b',
+                $1,`%r11',`%r11b',
+                $1,`%r12',`%r12b',
+                $1,`%r13',`%r13b',
+                $1,`%r14',`%r14b',
+                $1,`%r15',`%r15b')')
+
+define(`PROLOGUE',
+`       .globl   $1
+        .type	$1,function
+$1:
+')
+
+define(C, `
+dnl')
+
+define(`L',
+`.L$1')
+
+define(ALIGN,
+`.align eval($1), 0x90')
+
+C	     cycles/limb
+C AMD K8,K9	 3
+C AMD K10	 3
+C Intel P4	15.5
+C Intel core2	 5
+C Intel corei	 4
+C Intel atom	23
+C VIA nano	 4.75
+
+	.text
+	ALIGN(16)
+PROLOGUE(rie_mod_1s_4p)
+	push	%r15
+	push	%r14
+	push	%r13
+	push	%r12
+	push	%rbp
+	push	%rbx
+
+	mov	%rdx, %r15
+	mov	%rcx, %r14
+	mov	16(%rcx), %r11		C B1modb
+	mov	24(%rcx), %rbx		C B2modb
+	mov	32(%rcx), %rbp		C B3modb
+	mov	40(%rcx), %r13		C B4modb
+	mov	48(%rcx), %r12		C B5modb
+	xor	R32(%r8), R32(%r8)
+	mov	R32(%rsi), R32(%rdx)
+	and	$3, R32(%rdx)
+	je	L(b0)
+	cmp	$2, R32(%rdx)
+	jc	L(b1)
+	je	L(b2)
+
+L(b3):	lea	-24(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %rax
+	mul	%r11
+	mov	(%rdi), %r9
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	16(%rdi), %rax
+	mul	%rbx
+	jmp	L(m0)
+
+	ALIGN(8)
+L(b0):	lea	-32(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %rax
+	mul	%r11
+	mov	(%rdi), %r9
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	16(%rdi), %rax
+	mul	%rbx
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	24(%rdi), %rax
+	mul	%rbp
+	jmp	L(m0)
+
+	ALIGN(8)
+L(b1):	lea	-8(%rdi,%rsi,8), %rdi
+	mov	(%rdi), %r9
+	jmp	L(m1)
+
+	ALIGN(8)
+L(b2):	lea	-16(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %r8
+	mov	(%rdi), %r9
+	jmp	L(m1)
+
+	ALIGN(16)
+L(top):	mov	-24(%rdi), %rax
+	mov	-32(%rdi), %r10
+	mul	%r11			C up[1] * B1modb
+	add	%rax, %r10
+	mov	-16(%rdi), %rax
+	mov	$0, R32(%rcx)
+	adc	%rdx, %rcx
+	mul	%rbx			C up[2] * B2modb
+	add	%rax, %r10
+	mov	-8(%rdi), %rax
+	adc	%rdx, %rcx
+	sub	$32, %rdi
+	mul	%rbp			C up[3] * B3modb
+	add	%rax, %r10
+	mov	%r13, %rax
+	adc	%rdx, %rcx
+	mul	%r9			C rl * B4modb
+	add	%rax, %r10
+	mov	%r12, %rax
+	adc	%rdx, %rcx
+	mul	%r8			C rh * B5modb
+	mov	%r10, %r9
+	mov	%rcx, %r8
+L(m0):	add	%rax, %r9
+	adc	%rdx, %r8
+L(m1):	sub	$4, %rsi
+	ja	L(top)
+
+L(end):	mov	8(%r14), R32(%rsi)
+	mov	%r8, %rax
+	mul	%r11
+	mov	%rax, %r8
+	add	%r9, %r8
+	adc	$0, %rdx
+	xor	R32(%rcx), R32(%rcx)
+	sub	R32(%rsi), R32(%rcx)
+	mov	%r8, %rdi
+	shr	R8(%rcx), %rdi
+	mov	R32(%rsi), R32(%rcx)
+	sal	R8(%rcx), %rdx
+	or	%rdx, %rdi
+	mov	%rdi, %rax
+	mulq	(%r14)
+	mov	%r15, %rbx
+	mov	%rax, %r9
+	sal	R8(%rcx), %r8
+	inc	%rdi
+	add	%r8, %r9
+	adc	%rdi, %rdx
+	imul	%rbx, %rdx
+	sub	%rdx, %r8
+	lea	(%r8,%rbx), %rax
+	cmp	%r8, %r9
+	cmovc	%rax, %r8
+	mov	%r8, %rax
+	sub	%rbx, %rax
+	cmovc	%r8, %rax
+dnl	shr	R8(%rcx), %rax
+	pop	%rbx
+	pop	%rbp
+	pop	%r12
+	pop	%r13
+	pop	%r14
+	pop	%r15
+	ret
+
+	ALIGN(16)
+PROLOGUE(rie_mod_1s_4p_cps)
+	push	%rbp
+	bsr	%rsi, %rcx
+	push	%rbx
+	mov	%rdi, %rbx
+	push	%r12
+	xor	$63, R32(%rcx)
+	mov	%rsi, %r12
+	mov	R32(%rcx), R32(%rbp)	C preserve cnt over call
+	sal	R8(%rcx), %r12		C b << cnt
+	mov	%r12, %rdi		C pass parameter
+dnl	ASSERT(nz, `test $15, %rsp')
+	call	__gmpn_invert_limb
+	mov	%r12, %r8
+	mov	%rax, %r11
+	mov	%rax, (%rbx)		C store bi
+	mov	%rbp, 8(%rbx)		C store cnt
+	neg	%r8
+	mov	R32(%rbp), R32(%rcx)
+	mov	$1, R32(%rsi)
+	shld	R8(%rcx), %rax, %rsi	C FIXME: Slow on Atom and Nano
+	imul	%r8, %rsi
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	%rsi, 16(%rbx)		C store B1modb
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	%rsi, 24(%rbx)		C store B2modb
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	%rsi, 32(%rbx)		C store B3modb
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	%rsi, 40(%rbx)		C store B4modb
+
+	not	%rdx
+	imul	%r12, %rdx
+	add	%rdx, %r12
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %r12
+
+	shr	R8(%rcx), %r12
+	mov	%r12, 48(%rbx)		C store B5modb
+
+	pop	%r12
+	pop	%rbx
+	pop	%rbp
+	ret

--- a/external/mod_1_4.asm
+++ b/external/mod_1_4.asm
@@ -98,14 +98,41 @@ PROLOGUE(rie_mod_1s_4p)
 
 	push	%rdx
 	mov	%rcx, %r14
-	mov	8(%rcx), %r11		C B1modb
-	shl     $8, %r11                C Mask out cnt
-	shr     $8, %r11
-	mov	16(%rcx), %rbx		C B2modb
-	mov	24(%rcx), %rbp		C B3modb
-	mov	32(%rcx), %r13		C B4modb
-	mov	40(%rcx), %r12		C B5modb
+	mov	8(%rcx), R32(%r11)		C B1modb
+	mov	12(%rcx), R32(%rbx)		C B2modb
+	mov	16(%rcx), R32(%rbp)		C B3modb
+	mov	20(%rcx), R32(%r13)		C B4modb
+	mov	24(%rcx), R32(%r12)		C B5modb
+
+	mov	28(%rcx), R32(%r8)
+	and	$0x1ffffff, R32(%r8)
+	jz	L(nohi)
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x1f, R32(%rdx)
+	shl	$32, %rdx
+	or	%rdx, %r11
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x3e0, R32(%rdx)
+	shl	$27, %rdx
+	or	%rdx, %rbx
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x7c00, R32(%rdx)
+	shl	$22, %rdx
+	or	%rdx, %rbp
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0xf8000, R32(%rdx)
+	shl	$17, %rdx
+	or	%rdx, %r13
+
+	shl	$12, %r8
+	or	%r8, %r12
+
 	xor	R32(%r8), R32(%r8)
+L(nohi):
 	mov	R32(%rsi), R32(%rdx)
 	and	$3, R32(%rdx)
 	je	L(b0)
@@ -178,8 +205,8 @@ L(m0):	add	%rax, %r9
 L(m1):	sub	$4, %rsi
 	ja	L(top)
 
-L(end):	mov	12(%r14), R32(%rsi)
-	shr	$24, R32(%rsi)
+L(end):	mov	28(%r14), R32(%rsi)
+	shr	$25, R32(%rsi)
 	mov	%r8, %rax
 	mul	%r11
 	mov	%rax, %r8
@@ -235,7 +262,7 @@ dnl	ASSERT(nz, `test $15, %rsp')
 	mov	%rax, (%rbx)		C store bi
 	neg	%r8
 	mov	R32(%rbp), R32(%rcx)
-	shl     $56, %rbp
+	shl     $25, R32(%rbp)
 	mov	$1, R32(%rsi)
 	shld	R8(%rcx), %rax, %rsi	C FIXME: Slow on Atom and Nano
 	imul	%r8, %rsi
@@ -243,8 +270,9 @@ dnl	ASSERT(nz, `test $15, %rsp')
 
 	add	%rsi, %rdx
 	shr	R8(%rcx), %rsi
-	or      %rbp, %rsi
-	mov	%rsi, 8(%rbx)		C store B1modb
+	mov	R32(%rsi), 8(%rbx)		C store B1modb
+	shr	$32, %rsi
+	or	R32(%rsi), R32(%rbp)
 
 	not	%rdx
 	imul	%r12, %rdx
@@ -256,7 +284,10 @@ dnl	ASSERT(nz, `test $15, %rsp')
 
 	add	%rsi, %rdx
 	shr	R8(%rcx), %rsi
-	mov	%rsi, 16(%rbx)		C store B2modb
+	mov	R32(%rsi), 12(%rbx)		C store B2modb
+	shr	$27, %rsi
+	and	$0x3e0, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
 
 	not	%rdx
 	imul	%r12, %rdx
@@ -268,7 +299,10 @@ dnl	ASSERT(nz, `test $15, %rsp')
 
 	add	%rsi, %rdx
 	shr	R8(%rcx), %rsi
-	mov	%rsi, 24(%rbx)		C store B3modb
+	mov	R32(%rsi), 16(%rbx)		C store B3modb
+	shr	$22, %rsi
+	and	$0x7c00, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
 
 	not	%rdx
 	imul	%r12, %rdx
@@ -280,7 +314,10 @@ dnl	ASSERT(nz, `test $15, %rsp')
 
 	add	%rsi, %rdx
 	shr	R8(%rcx), %rsi
-	mov	%rsi, 32(%rbx)		C store B4modb
+	mov	R32(%rsi), 20(%rbx)		C store B4modb
+	shr	$17, %rsi
+	and	$0xf8000, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
 
 	not	%rdx
 	imul	%r12, %rdx
@@ -289,7 +326,11 @@ dnl	ASSERT(nz, `test $15, %rsp')
 	cmovnc	%rdx, %r12
 
 	shr	R8(%rcx), %r12
-	mov	%r12, 40(%rbx)		C store B5modb
+	mov	R32(%r12), 24(%rbx)		C store B5modb
+	shr	$12, %r12
+	and	$0x1f00000, R32(%r12)
+	or	R32(%r12), R32(%rbp)
+	mov	R32(%rbp), 28(%rbx)
 
 	pop	%r12
 	pop	%rbx

--- a/external/mod_1_4_win.asm
+++ b/external/mod_1_4_win.asm
@@ -1,0 +1,430 @@
+dnl  AMD64 mpn_mod_1s_4p
+
+dnl  Contributed to the GNU project by Torbjorn Granlund.
+
+dnl  Copyright 2009-2012, 2014 Free Software Foundation, Inc.
+
+dnl  This file is derived from the GNU MP Library.
+dnl
+dnl  The GNU MP Library is free software; you can redistribute it and/or modify
+dnl  it under the terms of either:
+dnl
+dnl    * the GNU Lesser General Public License as published by the Free
+dnl      Software Foundation; either version 3 of the License, or (at your
+dnl      option) any later version.
+dnl
+dnl  or
+dnl
+dnl    * the GNU General Public License as published by the Free Software
+dnl      Foundation; either version 2 of the License, or (at your option) any
+dnl      later version.
+dnl
+dnl  or both in parallel, as here.
+dnl
+dnl  The GNU MP Library is distributed in the hope that it will be useful, but
+dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+dnl  for more details.
+dnl
+dnl  You should have received copies of the GNU General Public License and the
+dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
+dnl  see https://www.gnu.org/licenses/.
+
+define(`R32',
+        `ifelse($1,`%rax',`%eax',
+                $1,`%rbx',`%ebx',
+                $1,`%rcx',`%ecx',
+                $1,`%rdx',`%edx',
+                $1,`%rsi',`%esi',
+                $1,`%rdi',`%edi',
+                $1,`%rbp',`%ebp',
+                $1,`%r8',`%r8d',
+                $1,`%r9',`%r9d',
+                $1,`%r10',`%r10d',
+                $1,`%r11',`%r11d',
+                $1,`%r12',`%r12d',
+                $1,`%r13',`%r13d',
+                $1,`%r14',`%r14d',
+                $1,`%r15',`%r15d')')
+define(`R8',
+        `ifelse($1,`%rax',`%al',
+                $1,`%rbx',`%bl',
+                $1,`%rcx',`%cl',
+                $1,`%rdx',`%dl',
+                $1,`%rsi',`%sil',
+                $1,`%rdi',`%dil',
+                $1,`%rbp',`%bpl',
+                $1,`%r8',`%r8b',
+                $1,`%r9',`%r9b',
+                $1,`%r10',`%r10b',
+                $1,`%r11',`%r11b',
+                $1,`%r12',`%r12b',
+                $1,`%r13',`%r13b',
+                $1,`%r14',`%r14b',
+                $1,`%r15',`%r15b')')
+
+define(m4_incr_or_decr,
+`ifelse(eval($1<$2),1,incr($1),decr($1))')
+
+define(`forloop',
+`pushdef(`$1',eval(`$2'))dnl
+pushdef(`forloop_first',1)dnl
+pushdef(`forloop_last',0)dnl
+forloop_internal(`$1',eval(`$3'),`$4')`'dnl
+popdef(`forloop_first')dnl
+popdef(`forloop_last')dnl
+popdef(`$1')')
+
+dnl  Called: forloop_internal(`var',last,statement)
+define(`forloop_internal',
+`ifelse($1,$2,
+`define(`forloop_last',1)$3',
+`$3`'dnl
+define(`forloop_first',0)dnl
+define(`$1',m4_incr_or_decr($1,$2))dnl
+forloop_internal(`$1',$2,`$3')')')
+
+define(`PROLOGUE',
+`       .globl   $1
+$1:
+')
+
+define(C, `
+dnl')
+
+define(`L',
+`.L$1')
+
+define(ALIGN,
+`.align eval($1), 0x90')
+
+C	     cycles/limb
+C AMD K8,K9	 3
+C AMD K10	 3
+C Intel P4	15.5
+C Intel core2	 5
+C Intel corei	 4
+C Intel atom	23
+C VIA nano	 4.75
+
+	.text
+	ALIGN(16)
+PROLOGUE(rie_mod_1s_4p)
+	push	%rdi
+	push	%rsi
+	push	%r14
+	push	%r13
+	push	%r12
+	push	%rbp
+	push	%rbx
+
+        mov     %rcx, %rdi
+        mov     %rdx, %rsi
+        mov     %r8, %rdx
+        mov     %r9, %rcx
+
+	push	%rdx
+	mov	%rcx, %r14
+	mov	8(%rcx), R32(%r11)		C B1modb
+	mov	12(%rcx), R32(%rbx)		C B2modb
+	mov	16(%rcx), R32(%rbp)		C B3modb
+	mov	20(%rcx), R32(%r13)		C B4modb
+	mov	24(%rcx), R32(%r12)		C B5modb
+
+	mov	28(%rcx), R32(%r8)
+	and	$0x1ffffff, R32(%r8)
+	jz	L(nohi)
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x1f, R32(%rdx)
+	shl	$32, %rdx
+	or	%rdx, %r11
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x3e0, R32(%rdx)
+	shl	$27, %rdx
+	or	%rdx, %rbx
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0x7c00, R32(%rdx)
+	shl	$22, %rdx
+	or	%rdx, %rbp
+
+	mov	R32(%r8), R32(%rdx)
+	and	$0xf8000, R32(%rdx)
+	shl	$17, %rdx
+	or	%rdx, %r13
+
+	shl	$12, %r8
+	or	%r8, %r12
+
+	xor	R32(%r8), R32(%r8)
+L(nohi):
+	mov	R32(%rsi), R32(%rdx)
+	and	$3, R32(%rdx)
+	je	L(b0)
+	cmp	$2, R32(%rdx)
+	jc	L(b1)
+	je	L(b2)
+
+L(b3):	lea	-24(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %rax
+	mul	%r11
+	mov	(%rdi), %r9
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	16(%rdi), %rax
+	mul	%rbx
+	jmp	L(m0)
+
+	ALIGN(8)
+L(b0):	lea	-32(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %rax
+	mul	%r11
+	mov	(%rdi), %r9
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	16(%rdi), %rax
+	mul	%rbx
+	add	%rax, %r9
+	adc	%rdx, %r8
+	mov	24(%rdi), %rax
+	mul	%rbp
+	jmp	L(m0)
+
+	ALIGN(8)
+L(b1):	lea	-8(%rdi,%rsi,8), %rdi
+	mov	(%rdi), %r9
+	jmp	L(m1)
+
+	ALIGN(8)
+L(b2):	lea	-16(%rdi,%rsi,8), %rdi
+	mov	8(%rdi), %r8
+	mov	(%rdi), %r9
+	jmp	L(m1)
+
+	ALIGN(16)
+L(top):	mov	-24(%rdi), %rax
+	mov	-32(%rdi), %r10
+	mul	%r11			C up[1] * B1modb
+	add	%rax, %r10
+	mov	-16(%rdi), %rax
+	mov	$0, R32(%rcx)
+	adc	%rdx, %rcx
+	mul	%rbx			C up[2] * B2modb
+	add	%rax, %r10
+	mov	-8(%rdi), %rax
+	adc	%rdx, %rcx
+	sub	$32, %rdi
+	mul	%rbp			C up[3] * B3modb
+	add	%rax, %r10
+	mov	%r13, %rax
+	adc	%rdx, %rcx
+	mul	%r9			C rl * B4modb
+	add	%rax, %r10
+	mov	%r12, %rax
+	adc	%rdx, %rcx
+	mul	%r8			C rh * B5modb
+	mov	%r10, %r9
+	mov	%rcx, %r8
+L(m0):	add	%rax, %r9
+	adc	%rdx, %r8
+L(m1):	sub	$4, %rsi
+	ja	L(top)
+
+L(end):	mov	28(%r14), R32(%rsi)
+	shr	$25, R32(%rsi)
+	mov	%r8, %rax
+	mul	%r11
+	mov	%rax, %r8
+	add	%r9, %r8
+	adc	$0, %rdx
+	xor	R32(%rcx), R32(%rcx)
+	sub	R32(%rsi), R32(%rcx)
+	mov	%r8, %rdi
+	shr	R8(%rcx), %rdi
+	mov	R32(%rsi), R32(%rcx)
+	sal	R8(%rcx), %rdx
+	or	%rdx, %rdi
+	mov	%rdi, %rax
+	mulq	(%r14)
+	pop	%rbx
+	mov	%rax, %r9
+	sal	R8(%rcx), %r8
+	inc	%rdi
+	add	%r8, %r9
+	adc	%rdi, %rdx
+	imul	%rbx, %rdx
+	sub	%rdx, %r8
+	lea	(%r8,%rbx), %rax
+	cmp	%r8, %r9
+	cmovc	%rax, %r8
+	mov	%r8, %rax
+	sub	%rbx, %rax
+	cmovc	%r8, %rax
+dnl	shr	R8(%rcx), %rax
+	pop	%rbx
+	pop	%rbp
+	pop	%r12
+	pop	%r13
+	pop	%r14
+	pop	%rsi
+	pop	%rdi
+	ret
+
+	ALIGN(2)
+rie_invert_limb_table:
+forloop(i,256,512-1,dnl
+`       .value  eval(0x7fd00/i)
+')dnl
+
+
+	ALIGN(16)
+PROLOGUE(rie_mod_1s_4p_cps)
+	push	%rdi
+	push	%rsi
+	mov	%rcx, %rdi
+	mov	%rdx, %rsi
+
+	push	%rbp
+	bsr	%rsi, %rcx
+	push	%rbx
+	mov	%rdi, %rbx
+	push	%r12
+	xor	$63, R32(%rcx)
+	mov	%rsi, %r12
+	mov	R32(%rcx), R32(%rbp)	C preserve cnt over call
+	sal	R8(%rcx), %r12		C b << cnt
+	mov	%r12, %rdi		C pass parameter
+dnl	ASSERT(nz, `test $15, %rsp')
+dnl	call	__gmpn_invert_limb
+
+        mov     %rdi, %rax              C                        0       0       0
+        shr     $55, %rax               C                        1       1       1
+        movabs  $-512+rie_invert_limb_table, %r8
+        movzwl  (%r8,%rax,2), R32(%rcx) C       %rcx = v0
+
+        C v1 = (v0 << 11) - (v0*v0*d40 >> 40) - 1
+        mov     %rdi, %rsi              C                        0       0       0
+        mov     R32(%rcx), R32(%rax)    C                        4       5       5
+        imul    R32(%rcx), R32(%rcx)    C                        4       5       5
+        shr     $24, %rsi               C                        1       1       1
+        inc     %rsi                    C       %rsi = d40
+        imul    %rsi, %rcx              C                        8      10       8
+        shr     $40, %rcx               C                       12      15      11
+        sal     $11, R32(%rax)          C                        5       6       6
+        dec     R32(%rax)
+        sub     R32(%rcx), R32(%rax)    C       %rax = v1
+
+        C v2 = (v1 << 13) + (v1 * (2^60 - v1*d40) >> 47)
+        mov     $0x1000000000000000, %rcx
+        imul    %rax, %rsi              C                       14      17      13
+        sub     %rsi, %rcx
+        imul    %rax, %rcx
+        sal     $13, %rax
+        shr     $47, %rcx
+        add     %rax, %rcx              C       %rcx = v2
+
+        C v3 = (v2 << 31) + (v2 * (2^96 - v2 * d63 + ((v2 >> 1) & mask)) >> 65
+        mov     %rdi, %rsi              C                        0       0       0
+        shr     %rsi                    C d/2
+        sbb     %rax, %rax              C -d0 = -(d mod 2)
+        sub     %rax, %rsi              C d63 = ceil(d/2)
+        imul    %rcx, %rsi              C v2 * d63
+        and     %rcx, %rax              C v2 * d0
+        shr     %rax                    C (v2>>1) * d0
+        sub     %rsi, %rax              C (v2>>1) * d0 - v2 * d63
+        mul     %rcx
+        sal     $31, %rcx
+        shr     %rdx
+        add     %rdx, %rcx              C       %rcx = v3
+
+        mov     %rdi, %rax
+        mul     %rcx
+        add     %rdi, %rax
+        mov     %rcx, %rax
+        adc     %rdi, %rdx
+        sub     %rdx, %rax
+
+
+	mov	%r12, %r8
+	mov	%rax, %r11
+	mov	%rax, (%rbx)		C store bi
+	neg	%r8
+	mov	R32(%rbp), R32(%rcx)
+	shl     $25, R32(%rbp)
+	mov	$1, R32(%rsi)
+	shld	R8(%rcx), %rax, %rsi	C FIXME: Slow on Atom and Nano
+	imul	%r8, %rsi
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	R32(%rsi), 8(%rbx)		C store B1modb
+	shr	$32, %rsi
+	or	R32(%rsi), R32(%rbp)
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	R32(%rsi), 12(%rbx)		C store B2modb
+	shr	$27, %rsi
+	and	$0x3e0, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	R32(%rsi), 16(%rbx)		C store B3modb
+	shr	$22, %rsi
+	and	$0x7c00, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
+
+	not	%rdx
+	imul	%r12, %rdx
+	lea	(%rdx,%r12), %rsi
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %rsi
+	mov	%r11, %rax
+	mul	%rsi
+
+	add	%rsi, %rdx
+	shr	R8(%rcx), %rsi
+	mov	R32(%rsi), 20(%rbx)		C store B4modb
+	shr	$17, %rsi
+	and	$0xf8000, R32(%rsi)
+	or	R32(%rsi), R32(%rbp)
+
+	not	%rdx
+	imul	%r12, %rdx
+	add	%rdx, %r12
+	cmp	%rdx, %rax
+	cmovnc	%rdx, %r12
+
+	shr	R8(%rcx), %r12
+	mov	R32(%r12), 24(%rbx)		C store B5modb
+	shr	$12, %r12
+	and	$0x1f00000, R32(%r12)
+	or	R32(%r12), R32(%rbp)
+	mov	R32(%rbp), 28(%rbx)
+
+	pop	%r12
+	pop	%rbx
+	pop	%rbp
+	pop	%rsi
+	pop	%rdi
+	ret

--- a/main.cpp
+++ b/main.cpp
@@ -350,6 +350,11 @@ void Options::loadConf() {
 					try {_pOff = std::stoll(value);}
 					catch (...) {_pOff = 16057;}
 				}
+				else if (key == "MaxMemory") {
+					try {_maxMem = std::stoll(value);}
+					catch (...) {_maxMem = 0;}
+					if (_maxMem > 0 && _maxMem < 1024 * 1024 * 1024) _maxMem = 1024 * 1024 * 1024;
+				}
 				else if (key == "ConsType") {
 					for (uint16_t i(0) ; i < value.size() ; i++) {if (value[i] == ',') value[i] = ' ';}
 					std::stringstream offsets(value);
@@ -391,6 +396,8 @@ void Options::loadConf() {
 		std::cout << "Payout address = " << _address << std::endl;
 	std::cout << "Threads = " << _threads << std::endl;
 	std::cout << "Sieve max = " << _sieve << std::endl;
+	if (_maxMem != 0)
+		std::cout << "Max Memory = " << _maxMem << std::endl;
 	if (_protocol == "Benchmark")
 		std::cout << "Will notify tuples of at least length = " << (uint16_t) _tuples << std::endl;
 	else if (_protocol != "Stratum")

--- a/main.cpp
+++ b/main.cpp
@@ -353,7 +353,7 @@ void Options::loadConf() {
 				else if (key == "MaxMemory") {
 					try {_maxMem = std::stoll(value);}
 					catch (...) {_maxMem = 0;}
-					if (_maxMem > 0 && _maxMem < 1024 * 1024 * 1024) _maxMem = 1024 * 1024 * 1024;
+					_maxMem *= 1024 * 1024 * 1024;
 				}
 				else if (key == "ConsType") {
 					for (uint16_t i(0) ; i < value.size() ; i++) {if (value[i] == ',') value[i] = ' ';}

--- a/main.h
+++ b/main.h
@@ -255,6 +255,7 @@ class Options {
 	uint16_t _port, _threads;
 	uint32_t _refresh, _testDiff, _testTime, _test3t;
 	uint64_t _sieve, _pn, _pOff;
+	uint64_t _maxMem;
 	std::vector<uint64_t> _consType;
 	
 	void parseLine(std::string, std::string&, std::string&) const;
@@ -277,6 +278,7 @@ class Options {
 		_test3t   = 1000;
 		_pn       = 40; // Primorial Number
 		_pOff     = 16057; // Primorial Offset
+		_maxMem   = 0;
 		_consType = {0, 4, 2, 4, 2, 4}; // What type of constellations are we mining (offsets)
 	}
 	
@@ -299,6 +301,7 @@ class Options {
 	uint32_t test3t() const {return _test3t;}
 	uint64_t pn() const {return _pn;}
 	uint64_t pOff() const {return _pOff;}
+	uint64_t maxMem() const {return _maxMem;}
 	std::vector<uint64_t> consType() const {return _consType;}
 };
 

--- a/miner.cpp
+++ b/miner.cpp
@@ -58,6 +58,7 @@ void Miner::init() {
 	for (uint64_t i(1) ; i < _parameters.primorialNumber ; i++)
 		mpz_mul_ui(_primorial, _primorial, _parameters.primes[i]);
 	
+	// Consider requested memory limit
 	uint64_t maxMemory(_manager->options().maxMem()),
 	         precompPrimes;
 	if (maxMemory < 1000000000)
@@ -74,6 +75,9 @@ void Miner::init() {
 		else
 			precompPrimes = std::min(_nPrimes, (maxMemory - _nPrimes * 24) / 32);
 	}
+
+	// Precomputation only works up to p=2^37
+	precompPrimes = std::min(precompPrimes, 5586502348UL);
 
 	_parameters.inverts.resize(_nPrimes);
 	_parameters.modPrecompute.resize(precompPrimes * 4);

--- a/miner.h
+++ b/miner.h
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <math.h>
 #include <immintrin.h>
+#include <chrono>
 #include "main.h"
 #include "client.h"
 #include "tools.h"
@@ -81,6 +82,8 @@ class Miner {
 	uint32_t **_segmentHits;
 	std::vector<uint64_t> _segmentCounts;
 	std::vector<uint64_t> _halfPrimeTupleOffset;
+
+	std::chrono::microseconds _modTime, _sieveTime, _verifyTime;
 	
 	bool _masterExists;
 	std::mutex _masterLock, _bucketLock;
@@ -122,7 +125,7 @@ class Miner {
 	}
 	
 	void _putOffsetsInSegments(uint64_t *offsets, int n_offsets);
-	void _updateRemainders(uint64_t start_i, uint64_t end_i);
+	void _updateRemainders(uint64_t start_i, uint64_t end_i, bool usePrecomp);
 	void _processSieve(uint8_t *sieve, uint64_t start_i, uint64_t end_i);
 	void _processSieve6(uint8_t *sieve, uint64_t start_i, uint64_t end_i);
 	void _verifyThread();

--- a/miner.h
+++ b/miner.h
@@ -26,7 +26,7 @@ struct MinerParameters {
 	bool solo;
 	int sieveWorkers;
 	uint64_t sieveBits, sieveSize, sieveWords, maxIncrements, maxIter, primorialOffset, denseLimit;
-	std::vector<uint64_t> primes, inverts, primeTupleOffset;
+	std::vector<uint64_t> primes, inverts, modPrecompute, primeTupleOffset;
 	
 	MinerParameters() {
 		primorialNumber = 40;


### PR DESCRIPTION
This change adds modified GMP code to perform remainder calculation using precomputed data, speeding up the updateRemainders part of the mining process.

As this data uses significant extra memory, I've added a MaxMemory configuration variable.  This allows approximate control over the memory usage, limiting the number of primes used or the amount of data precomputed in order to stay within the given amount.

In order to aid profiling, I've also added timing of the 3 types of mining work (the report is commented out by default).

Finally, this change fixes the calculation for p > 2^32.