### PR TITLE
Feature improve throughput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Build artifacts
+*.o
+rieMiner
+rieMiner.exe
+
+# Per user configuration
+rieMiner.conf
+
+# Other
+rieMiner.exe.stackdump
+.*.swp

--- a/client.h
+++ b/client.h
@@ -11,9 +11,6 @@
 
 class WorkManager;
 
-enum JobType {TYPE_CHECK, TYPE_MOD, TYPE_SIEVE};
-#define WORK_INDEXES 32
-
 struct BlockHeader { // Total 1024 bits/128 bytes (256 hex chars)
 	uint32_t version;
 	uint8_t  previousblockhash[32]; // 256 bits

--- a/client.h
+++ b/client.h
@@ -12,7 +12,7 @@
 class WorkManager;
 
 enum JobType {TYPE_CHECK, TYPE_MOD, TYPE_SIEVE};
-#define WORK_INDEXES 64
+#define WORK_INDEXES 32
 
 struct BlockHeader { // Total 1024 bits/128 bytes (256 hex chars)
 	uint32_t version;

--- a/external/mod_1_4_win.asm
+++ b/external/mod_1_4_win.asm
@@ -120,18 +120,16 @@ PROLOGUE(rie_mod_1s_4p)
 
         mov     %rcx, %rdi
         mov     %rdx, %rsi
-        mov     %r8, %rdx
-        mov     %r9, %rcx
 
-	push	%rdx
-	mov	%rcx, %r14
-	mov	8(%rcx), R32(%r11)		C B1modb
-	mov	12(%rcx), R32(%rbx)		C B2modb
-	mov	16(%rcx), R32(%rbp)		C B3modb
-	mov	20(%rcx), R32(%r13)		C B4modb
-	mov	24(%rcx), R32(%r12)		C B5modb
+	push	%r8
+	mov	%r9, %r14
+	mov	8(%r9), R32(%r11)		C B1modb
+	mov	12(%r9), R32(%rbx)		C B2modb
+	mov	16(%r9), R32(%rbp)		C B3modb
+	mov	20(%r9), R32(%r13)		C B4modb
+	mov	24(%r9), R32(%r12)		C B5modb
 
-	mov	28(%rcx), R32(%r8)
+	mov	28(%r9), R32(%r8)
 	and	$0x1ffffff, R32(%r8)
 	jz	L(nohi)
 

--- a/main.cpp
+++ b/main.cpp
@@ -53,15 +53,17 @@ void WorkManager::submitWork(WorkData wd, uint32_t* nOffset, uint8_t length) {
 	_clientMutex.unlock();
 }
 
+bool WorkManager::getWork(WorkData& wd) {
+	_clientMutex.lock();
+	wd = _client->workData();
+	_clientMutex.unlock();
+	return wd.height != 0;
+}
+
 void WorkManager::minerThread() {
 	WorkData wd;
 	while (true) {
-		bool hasValidWork(false);
-		_clientMutex.lock();
-		wd = _client->workData(); // Get generated work data from client
-		_clientMutex.unlock();
-		if (wd.height > 0) hasValidWork = true;
-		if (!hasValidWork) usleep(1000*_workRefresh/2);
+		if (!getWork(wd)) usleep(1000*_workRefresh/2);
 		else _miner->process(wd);
 	}
 }

--- a/main.cpp
+++ b/main.cpp
@@ -114,7 +114,7 @@ void WorkManager::manage() {
 						_stats.updateHeight(_client->workData().height - 1);
 						std::cout << "-----------------------------------------------------------" << std::endl;
 						uint32_t startHeight(_client->workData().height);
-						std::cout << "[0000:00:00] Started mining at block " << startHeight << std::endl;
+						std::cout << "[0000:00:00] Started mining at block " << startHeight;
 						_stats.initHeight(startHeight);
 						_miningStarted = true;
 					}

--- a/main.h
+++ b/main.h
@@ -322,6 +322,7 @@ class WorkManager : public std::enable_shared_from_this<WorkManager> {
 	
 	void init();
 	void submitWork(WorkData wd, uint32_t* nOffset, uint8_t length);
+	bool getWork(WorkData& wd);
 	void manage();
 	Options options() const {return _options;}
 	uint32_t height() const {return _stats.height();}

--- a/miner.cpp
+++ b/miner.cpp
@@ -646,6 +646,9 @@ void Miner::process(WorkData block) {
 			w.testWork.n_indexes = 0;
 		}
 	}
+
+	for (int i(0) ; i < n_modWorkers ; i++)
+		_modDoneQueue.pop_front();
 	
 	outstandingTests -= _testDoneQueue.clear();
 	

--- a/miner.cpp
+++ b/miner.cpp
@@ -409,7 +409,10 @@ void Miner::_getTargetFromBlock(mpz_t z_target, const WorkData &block) {
 	uint64_t difficulty(mpz_sizeinbase(z_target, 2));
 	if (_manager->difficulty() != difficulty) {
 		bool save(true);
-		if (_manager->difficulty() == 1) save = false;
+		if (_manager->difficulty() == 1) {
+			std::cout << " difficulty " << difficulty << std::endl;
+			save = false;
+		}
 		_manager->updateDifficulty(difficulty, block.height);
 		if (save) _manager->saveTuplesCounts();
 	}
@@ -538,7 +541,6 @@ void Miner::process(WorkData block) {
 
 	uint64_t outstandingTests = 0;
 	for (uint64_t loop(0); loop < _parameters.maxIter; loop++) {
-		__sync_synchronize(); // gcc specific - memory barrier for checking height
 		if (block.height != _currentHeight)
 			break;
 		
@@ -600,6 +602,9 @@ void Miner::process(WorkData block) {
 
 		for (int i(0) ; i < n_sieveWorkers; i++)
 			_sieveDoneQueue.pop_front();
+
+		if (block.height != _currentHeight)
+			break;
 		
 		primeTestWork w;
 		w.testWork.n_indexes = 0;

--- a/miner.cpp
+++ b/miner.cpp
@@ -346,7 +346,7 @@ void Miner::_verifyThread() {
 			mpz_add(z_ploop, z_ploop, _workData[job.workDataIndex].z_verifyRemainderPrimorial);
 			mpz_add(z_ploop, z_ploop, _workData[job.workDataIndex].z_verifyTarget);
 
-			for (uint32_t idx(0) ; idx < job.testWork.numIndexes ; idx++) {
+			for (uint32_t idx(0) ; idx < job.testWork.n_indexes ; idx++) {
 				if (_currentHeight != _workData[job.workDataIndex].verifyBlock.height) break;
 
 				uint8_t tupleSize(0);
@@ -513,7 +513,7 @@ void Miner::process(WorkData block) {
 			_workData[_testDoneQueue.pop_front()].outstandingTests--;
 		}
 
-		std::cout << "Block timing: " << _modTime.count() << ", " << _sieveTime.count() << ", " << _verifyTime.count() << "  Tests out: " << _workData[0].outstandingTests << ", " << _workData[1].outstandingTests << std::endl;
+		//std::cout << "Block timing: " << _modTime.count() << ", " << _sieveTime.count() << ", " << _verifyTime.count() << "  Tests out: " << _workData[0].outstandingTests << ", " << _workData[1].outstandingTests << std::endl;
 
 	} while (_manager->getWork(_workData[workDataIndex].verifyBlock));
 
@@ -580,7 +580,7 @@ void Miner::_processOneBlock(uint32_t workDataIndex, uint8_t* sieve)
 	 * 3)	Sieve "so sparse they happen at most once" primes;
 	 * 4)	Scan sieve for candidates, test, report
 	 */
-	for (int i(0) ; i < _parameters.sieveWorkers * 2 ; i++)
+	for (int i(0) ; i < _parameters.sieveWorkers ; i++)
 		memset(_sieves[i], 0, _parameters.sieveSize/8);
 		
 	wi.type = TYPE_SIEVE;
@@ -681,7 +681,7 @@ void Miner::_processOneBlock(uint32_t workDataIndex, uint8_t* sieve)
 		}
 
 		primeTestWork w;
-		w.testWork.numIndexes = 0;
+		w.testWork.n_indexes = 0;
 		w.testWork.loop = loop;
 		w.type = TYPE_CHECK;
 		w.workDataIndex = workDataIndex;
@@ -700,10 +700,10 @@ void Miner::_processOneBlock(uint32_t workDataIndex, uint8_t* sieve)
 				uint32_t i((b*64) + lowsb);
 				sb &= sb - 1;
 				
-				w.testWork.indexes[w.testWork.numIndexes] = i;
-				w.testWork.numIndexes++;
+				w.testWork.indexes[w.testWork.n_indexes] = i;
+				w.testWork.n_indexes++;
 				
-				if (w.testWork.numIndexes == WORK_INDEXES) {
+				if (w.testWork.n_indexes == WORK_INDEXES) {
 					// Low overhead but still often enough
 					if (_workData[workDataIndex].verifyBlock.height != _currentHeight) {
 						reset = true;
@@ -711,7 +711,7 @@ void Miner::_processOneBlock(uint32_t workDataIndex, uint8_t* sieve)
 					}
 
 					_verifyWorkQueue.push_back(w);
-					w.testWork.numIndexes = 0;
+					w.testWork.n_indexes = 0;
 					_workData[workDataIndex].outstandingTests++;
 				}
 			}
@@ -720,7 +720,7 @@ void Miner::_processOneBlock(uint32_t workDataIndex, uint8_t* sieve)
 		verifySieve += _parameters.sieveWorkers;
 		if (verifySieve == _parameters.sieveWorkers * 2) verifySieve = 0;
 
-		if (w.testWork.numIndexes > 0) {
+		if (w.testWork.n_indexes > 0) {
 			_verifyWorkQueue.push_back(w);
 			_workData[workDataIndex].outstandingTests++;
 		}

--- a/miner.cpp
+++ b/miner.cpp
@@ -285,7 +285,9 @@ void Miner::_verifyThread() {
 			mpz_add(z_ploop, z_ploop, z_verifyRemainderPrimorial);
 			mpz_add(z_ploop, z_ploop, z_verifyTarget);
 
-			for (uint64_t idx(0) ; idx < job.testWork.n_indexes ; idx++) {
+			for (uint32_t idx(0) ; idx < job.testWork.n_indexes ; idx++) {
+				if (_currentHeight != job.testWork.block_height) break;
+
 				uint8_t tupleSize(0);
 				mpz_mul_ui(z_temp, _primorial, job.testWork.indexes[idx]);
 				mpz_add(z_temp, z_temp, z_ploop);
@@ -548,6 +550,7 @@ void Miner::process(WorkData block) {
 		primeTestWork w;
 		w.testWork.n_indexes = 0;
 		w.testWork.loop = loop;
+		w.testWork.block_height = block.height;
 		w.type = TYPE_CHECK;
 
 		bool reset(false);

--- a/miner.h
+++ b/miner.h
@@ -138,7 +138,7 @@ class Miner {
 	}
 	
 	void _putOffsetsInSegments(uint64_t *offsets, int n_offsets);
-	void _updateRemainders(uint32_t workDataIndex, uint64_t start_i, uint64_t end_i, bool usePrecomp);
+	void _updateRemainders(uint32_t workDataIndex, uint64_t start_i, uint64_t end_i);
 	void _processSieve(uint8_t *sieve, uint64_t start_i, uint64_t end_i);
 	void _processSieve6(uint8_t *sieve, uint64_t start_i, uint64_t end_i);
 	void _verifyThread();

--- a/miner.h
+++ b/miner.h
@@ -51,7 +51,8 @@ struct primeTestWork {
 	union {
 		struct {
 			uint64_t loop;
-			uint64_t n_indexes;
+			uint32_t block_height;
+			uint32_t n_indexes;
 			uint32_t indexes[WORK_INDEXES];
 		} testWork;
 		struct {

--- a/miner.h
+++ b/miner.h
@@ -41,7 +41,7 @@ struct MinerParameters {
 		sieve           = 2147483648;
 		sieveWorkers    = 2;
 		solo            = true;
-		sieveBits       = 25;
+		sieveBits       = 24;
 		sieveSize       = 1UL << sieveBits;
 		sieveWords      = sieveSize/64;
 		maxIncrements   = (1ULL << 29),

--- a/miner.h
+++ b/miner.h
@@ -14,10 +14,14 @@
 
 union xmmreg_t {
 	uint32_t v[4];
+	uint64_t v64[2];
 	__m128i m128;
 };
 
 #define PENDING_SIZE 16
+
+#define WORK_INDEXES 64
+enum JobType {TYPE_CHECK, TYPE_MOD, TYPE_SIEVE};
 
 struct MinerParameters {
 	uint64_t primorialNumber;
@@ -63,7 +67,7 @@ struct primeTestWork {
 		struct {
 			uint64_t start;
 			uint64_t end;
-			uint64_t sieveId;
+			uint32_t sieveId;
 		} sieveWork;
 	};
 };
@@ -75,8 +79,9 @@ class Miner {
 	MinerParameters _parameters;
 	
 	ts_queue<primeTestWork, 1024> _verifyWorkQueue;
-	ts_queue<int, 3096> _workerDoneQueue;
-	ts_queue<int, 3096> _testDoneQueue;
+	ts_queue<uint64_t, 1024> _modDoneQueue;
+	ts_queue<uint32_t, 128> _sieveDoneQueue;
+	ts_queue<int, 4096> _testDoneQueue;
 	mpz_t _primorial;
 	uint64_t _nPrimes, _entriesPerSegment, _primeTestStoreOffsetsSize, _startingPrimeIndex, _nDense, _nSparse;
 	uint8_t  **_sieves;

--- a/miner.h
+++ b/miner.h
@@ -41,7 +41,7 @@ struct MinerParameters {
 		sieve           = 2147483648;
 		sieveWorkers    = 2;
 		solo            = true;
-		sieveBits       = 24;
+		sieveBits       = 25;
 		sieveSize       = 1UL << sieveBits;
 		sieveWords      = sieveSize/64;
 		maxIncrements   = (1ULL << 29),

--- a/miner.h
+++ b/miner.h
@@ -58,7 +58,7 @@ struct primeTestWork {
 	union {
 		struct {
 			uint64_t loop;
-			uint32_t numIndexes;
+			uint32_t n_indexes;
 			uint32_t indexes[WORK_INDEXES];
 		} testWork;
 		struct {

--- a/miner.h
+++ b/miner.h
@@ -58,7 +58,6 @@ struct primeTestWork {
 	union {
 		struct {
 			uint64_t loop;
-			uint32_t blockHeight;
 			uint32_t numIndexes;
 			uint32_t indexes[WORK_INDEXES];
 		} testWork;
@@ -77,6 +76,7 @@ struct primeTestWork {
 struct MinerWorkData {
 	mpz_t z_verifyTarget, z_verifyRemainderPrimorial;
 	WorkData verifyBlock;
+	uint64_t outstandingTests = 0;
 };
 
 class Miner {
@@ -85,7 +85,7 @@ class Miner {
 	volatile uint32_t _currentHeight;
 	MinerParameters _parameters;
 	
-	ts_queue<primeTestWork, 1024> _verifyWorkQueue;
+	ts_queue<primeTestWork, 4096> _verifyWorkQueue;
 	ts_queue<uint64_t, 1024> _modDoneQueue;
 	ts_queue<uint32_t, 128> _sieveDoneQueue;
 	ts_queue<uint32_t, 4096> _testDoneQueue;
@@ -143,6 +143,7 @@ class Miner {
 	void _processSieve6(uint8_t *sieve, uint64_t start_i, uint64_t end_i);
 	void _verifyThread();
 	void _getTargetFromBlock(mpz_t z_target, const WorkData& block);
+	void _processOneBlock(uint32_t workDataIndex, uint8_t* sieve);
 	
 	public:
 	Miner(const std::shared_ptr<WorkManager> &manager) {


### PR DESCRIPTION
This pull request contains numerous improvements to increase the sieving throughput and so reduce idle CPU when using large numbers of threads.

This should make it reasonably efficient to run one instance with 16 threads at current riecoin mining difficulty, although at low difficulty or high sieve max the sieve can still struggle to keep up.  Let me know how it works for you.