### PR TITLE
Minor fixes

### DIFF
--- a/Miner.cpp
+++ b/Miner.cpp
@@ -86,9 +86,9 @@ void Miner::init() {
 		mpz_mul_ui(_primorial, _primorial, _parameters.primes[i]);
 	
 	// Estimate memory usage, precomputation only works up to p = 2^37
-	uint64_t primeMult(8 + 16*_parameters.sieveWorkers),
-	         memUsage(128ULL*1048576ULL + 650ULL*1048576ULL*_parameters.sieveWorkers + _nPrimes*primeMult),
-	         precompPrimes(std::min(_nPrimes, 5586502348UL));
+	uint64_t primeMult(16 + 8*_parameters.sieveWorkers),
+	         precompPrimes(std::min(_nPrimes, 5586502348UL)),
+		 memUsage(128ULL*1048576ULL + 650ULL*1048576ULL*_parameters.sieveWorkers + _nPrimes*primeMult + precompPrimes*8);
 	
 	std::cout << "Estimated memory usage: " << ((float) memUsage)/1048576. << " MiB" << std::endl;
 	std::cout << "Reduce Sieve option value to lower this, if needed." << std::endl;

--- a/Miner.cpp
+++ b/Miner.cpp
@@ -266,16 +266,16 @@ void Miner::_updateRemainders(uint32_t workDataIndex, uint64_t start_i, uint64_t
 				cnt = __builtin_clzll(p);
 				ps = p << cnt;
 				uint64_t remainder(rie_mod_1s_4p(tar->_mp_d, tar->_mp_size, ps, cnt, &_parameters.modPrecompute[i]));
-				DBG(if (remainder >> cnt != mpz_tdiv_ui(tar, p)) { printf("Remainder check fail %lu != %lu\n", remainder >> cnt, mpz_tdiv_ui(tar, p)); abort();});
+				DBG_VERIFY(if (remainder >> cnt != mpz_tdiv_ui(tar, p)) { printf("Remainder check fail %lu != %lu\n", remainder >> cnt, mpz_tdiv_ui(tar, p)); abort();});
 
 				uint64_t pa(ps - remainder);
 				uint64_t r, nh, nl;
 				umul_ppmm(nh, nl, pa, invert[0]);
 				udiv_rnnd_preinv(r, nh, nl, ps, _parameters.modPrecompute[i]);
 				index = r >> cnt;
-				DBG(if ((r >> cnt) != ((pa >> cnt)*invert[0]) % p) {  printf("Remainder check fail\n"); exit(-1);});
+				DBG_VERIFY(if (p < 0x100000000ull && (r >> cnt) != ((pa >> cnt)*invert[0]) % p) {  printf("Remainder check fail\n"); exit(-1);});
 			}
-			/*{
+			DBG_VERIFY(({
 				uint64_t remainder(mpz_tdiv_ui(tar, p)),
 				         pa(p - remainder),
 				         q, nh, nl, indexCheck;
@@ -283,7 +283,7 @@ void Miner::_updateRemainders(uint32_t workDataIndex, uint64_t start_i, uint64_t
 				umul_ppmm(nh, nl, pa, invert[0]);
 				udiv_qrnnd(q, indexCheck, nh, nl, p);
 				if (index != indexCheck) { printf("Index check fail, p=%ld, i=%ld, start_i=%ld\n", p, i, start_i); abort(); }
-			}*/
+			}));
 		}
 		else {
 			uint64_t remainder(mpz_tdiv_ui(tar, p)),

--- a/Miner.cpp
+++ b/Miner.cpp
@@ -665,13 +665,15 @@ void Miner::process(WorkData block) {
 	
 	uint32_t workDataIndex(0);
 	_workData[workDataIndex].verifyBlock = block;
+	uint32_t oldHeight = 0;
 	
 	do {
 		_modTime = _modTime.zero();
 		_sieveTime = _sieveTime.zero();
 		_verifyTime = _verifyTime.zero();
 		
-		_processOneBlock(workDataIndex);
+		_processOneBlock(workDataIndex, oldHeight != _workData[workDataIndex].verifyBlock.height);
+		oldHeight = _workData[workDataIndex].verifyBlock.height;
 
 		while (_workData[workDataIndex].outstandingTests > _maxWorkOut)
 			_workData[_workDoneQueue.pop_front()].outstandingTests--;
@@ -690,7 +692,7 @@ void Miner::process(WorkData block) {
 	}
 }
 
-void Miner::_processOneBlock(uint32_t workDataIndex) {
+void Miner::_processOneBlock(uint32_t workDataIndex, bool isNewHeight) {
 	mpz_t z_target, z_tmp, z_remainderPrimorial;
 	mpz_init(z_tmp);
 	mpz_init(z_remainderPrimorial);
@@ -757,7 +759,7 @@ void Miner::_processOneBlock(uint32_t workDataIndex) {
 			minWorkOut = std::min(minWorkOut, _verifyWorkQueue.size());
 		}
 
-		if (_currentHeight == _workData[workDataIndex].verifyBlock.height) {
+		if (_currentHeight == _workData[workDataIndex].verifyBlock.height && !isNewHeight) {
 			DBG(std::cout << "Min work outstanding during sieving: " << minWorkOut << std::endl;);
 			if (curWorkOut > _maxWorkOut - _parameters.threads*2) {
 				// If we are acheiving our work target, then adjust it towards the amount

--- a/Miner.cpp
+++ b/Miner.cpp
@@ -122,10 +122,14 @@ void Miner::init() {
 	uint64_t highSegmentEntries(0);
 	double highFloats(0.), tupleSizeAsDouble(_parameters.primeTupleOffset.size());
 	_primeTestStoreOffsetsSize = 0;
+	_sparseLimit = 0;
 	for (uint64_t i(5) ; i < _nPrimes ; i++) {
 		uint64_t p(_parameters.primes[i]);
 		if (p < _parameters.maxIncrements) _primeTestStoreOffsetsSize++;
-		else highFloats += ((tupleSizeAsDouble*_parameters.maxIncrements)/(double) p);
+		else {
+			if (_sparseLimit == 0) _sparseLimit = i & (~1ull);
+			highFloats += ((tupleSizeAsDouble*_parameters.maxIncrements)/(double) p);
+		}
 	}
 	
 	highSegmentEntries = ceil(highFloats);
@@ -139,21 +143,6 @@ void Miner::init() {
 	for (int i(0) ; i < _parameters.sieveWorkers ; i++) {
 		_sieves[i].id = i;
 		_sieves[i].segmentCounts.resize(_parameters.maxIter);
-	}
-
-	for (uint64_t i(_startingPrimeIndex) ; i < _nPrimes ; i++) {
-		uint64_t p(_parameters.primes[i]);
-		if (p < _parameters.denseLimit) _nDense++;
-		else if (p < _parameters.maxIncrements) _nSparse++;
-		else break;
-	}
-
-	uint64_t round(8 - ((_nDense + _parameters.primorialNumber) & 0x7));
-	_nDense += round;
-	_nSparse -= round;
-	if ((_nSparse - _nDense) & 1) {
-		if (_nSparse + _nDense + _parameters.primorialNumber < _nPrimes) _nSparse += 1;
-		else _nSparse -= 1;
 	}
 
 	try {
@@ -240,7 +229,7 @@ void Miner::_updateRemainders(uint32_t workDataIndex, uint64_t start_i, uint64_t
 		uint64_t p(_parameters.primes[i]);
 
 		// Also update the offsets unless once only
-		bool onceOnly(p >= _parameters.maxIncrements);
+		bool onceOnly(i >= _sparseLimit);
 
 		uint64_t invert[4];
 		invert[0] = _parameters.inverts[i];
@@ -480,9 +469,9 @@ void Miner::_runSieve(SieveInstance& sieve, uint32_t workDataIndex) {
 
 		// Main sieve
 		if (tupleSize == 6)
-			_processSieve6(sieve.sieve, sieve.offsets, start_i, _startingPrimeIndex + _nDense + _nSparse);
+			_processSieve6(sieve.sieve, sieve.offsets, start_i, _sparseLimit);
 		else
-			_processSieve(sieve.sieve, sieve.offsets, start_i, _startingPrimeIndex + _nDense + _nSparse);
+			_processSieve(sieve.sieve, sieve.offsets, start_i, _sparseLimit);
 
 		// Must now have all segments populated.
 		if (loop == 0) modLock.lock();
@@ -738,12 +727,12 @@ void Miner::_processOneBlock(uint32_t workDataIndex) {
 			wi.modWork.end = lim;
 			if (curWorkOut == 0) _verifyWorkQueue.push_back(wi);
 			else _verifyWorkQueue.push_front(wi);
-			if (wi.modWork.start < _startingPrimeIndex + _nDense + _nSparse) nLowModWorkers++;
+			if (wi.modWork.start < _sparseLimit) nLowModWorkers++;
 			else nModWorkers++;
 		}
 		while (nLowModWorkers > 0) {
 			uint64_t i(_modDoneQueue.pop_front());
-			if (i < _startingPrimeIndex + _nDense + _nSparse) nLowModWorkers--;
+			if (i < _sparseLimit) nLowModWorkers--;
 			else nModWorkers--;
 		}
 

--- a/Miner.hpp
+++ b/Miner.hpp
@@ -47,7 +47,6 @@ struct MinerParameters {
 		maxIncrements   = (1ULL << 29),
 		maxIter         = maxIncrements/sieveSize;
 		primorialOffset = {4209995887ull, 4209999247ull, 4210002607ull, 4210005967ull, 7452755407ull, 7452758767ull, 7452762127ull, 7452765487ull};
-		denseLimit      = 16384;
 		primeTupleOffset = {0, 4, 2, 4, 2, 4};
 	}
 };
@@ -98,7 +97,7 @@ class Miner {
 	tsQueue<uint64_t, 1024> _modDoneQueue;
 	tsQueue<int, 9216> _workDoneQueue;
 	mpz_t _primorial;
-	uint64_t _nPrimes, _entriesPerSegment, _primeTestStoreOffsetsSize, _startingPrimeIndex, _nDense, _nSparse;
+	uint64_t _nPrimes, _entriesPerSegment, _primeTestStoreOffsetsSize, _startingPrimeIndex, _sparseLimit;
 	std::vector<uint64_t> _halfPrimeTupleOffset, _primorialOffsetDiff, _primorialOffsetDiffToFirst;
 	SieveInstance* _sieves;
 
@@ -164,8 +163,7 @@ class Miner {
 		_entriesPerSegment = 0;
 		_primeTestStoreOffsetsSize = 0;
 		_startingPrimeIndex = 0;
-		_nDense  = 0;
-		_nSparse = 0;
+		_sparseLimit = 0;
 		_masterExists = false;
 	}
 	

--- a/Miner.hpp
+++ b/Miner.hpp
@@ -150,7 +150,7 @@ class Miner {
 	void _runSieve(SieveInstance& sieve, uint32_t workDataIndex);
 	void _verifyThread();
 	void _getTargetFromBlock(mpz_t z_target, const WorkData& block);
-	void _processOneBlock(uint32_t workDataIndex);
+	void _processOneBlock(uint32_t workDataIndex, bool isNewHeight);
 	
 	public:
 	Miner(const std::shared_ptr<WorkManager> &manager) {

--- a/main.cpp
+++ b/main.cpp
@@ -168,7 +168,6 @@ void Options::loadConf() {
 			if (line.size() != 0) {
 				parseLine(line, key, value);
 				if (key == "Debug") {
-					int tmp;
 					try {_debug = std::stoi(value);}
 					catch (...) {_debug = 0;}
 				}

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,7 @@
 	#include <winsock2.h>
 #endif
 
-bool DEBUG(false);
+int DEBUG(0);
 
 std::shared_ptr<WorkManager> manager;
 static std::string confPath("rieMiner.conf");
@@ -168,10 +168,9 @@ void Options::loadConf() {
 			if (line.size() != 0) {
 				parseLine(line, key, value);
 				if (key == "Debug") {
-					uint64_t tmp;
-					try {tmp = std::stoll(value);}
-					catch (...) {tmp = 0;}
-					_debug = (tmp == 1);
+					int tmp;
+					try {_debug = std::stoi(value);}
+					catch (...) {_debug = 0;}
 				}
 				else if (key == "Host") _host = value;
 				else if (key == "Port") {

--- a/main.hpp
+++ b/main.hpp
@@ -21,11 +21,12 @@
 #define FIXED(x) std::fixed << std::setprecision(x)
 #define FIXED(x) std::fixed << std::setprecision(x)
 
-extern bool DEBUG;
+extern int DEBUG;
 #define DBG(x) if (DEBUG) {x;};
+#define DBG_VERIFY(x) if (DEBUG > 1) { x; };
 
 class Options {
-	bool _debug;
+	int _debug;
 	std::string _host, _user, _pass, _protocol, _address, _tcFile;
 	uint16_t  _tuples, _sieveBits, _port, _threads, _sieveWorkers;
 	uint32_t _refresh, _testDiff, _testTime, _test2t;
@@ -36,7 +37,7 @@ class Options {
 	
 	public:
 	Options() { // Default options: Standard Benchmark with 8 threads
-		_debug     = false;
+		_debug     = 0;
 		_user      = "";
 		_pass      = "";
 		_host      = "127.0.0.1";


### PR DESCRIPTION
This is a couple of minor fixes:
- Remove the unused denseLimit and fix the theoretical problem with sparse limit handling if sparse limit - primorial number wasn't even.
- Fix bug where a block height change could trigger log about not enough work.  This should let you reinstate the warning message, but I'll leave it to you to decide if that should be shown in non-debug.
- Improve the accuracy of the memory estimate.