### PR TITLE
Apply proposed fix for pool inefficiency

### DIFF
--- a/Miner.cpp
+++ b/Miner.cpp
@@ -679,7 +679,7 @@ too for the one-in-a-whatever case that Fermat is wrong. */
 						tupleLength++;
 						_manager->incTupleCount(tupleLength);
 					}
-					else if (!_parameters.solo) {
+					else if (!_parameters.solo && tupleLength > 1) { // Conditions to be a share: 2 first numbers are prime and at least 4 primes in total
 						int candidatesRemaining(5 - i);
 						if ((tupleLength + candidatesRemaining) < 4) continue;
 					}


### PR DESCRIPTION
As I pointed out, Pooled Mining is something like 10% slower than Solo Mining. There is no issue at the miner end, but in order to fix this inefficiency, pools need to change the conditions of what makes as submission a share (currently, out of the 6 numbers of the constellation, first must be prime and there must be at least 4 primes). A way to virtually fix this is to require that the second number is also prime, and the Commit in this Pull Request does the adaptation at the miner end.
This Pull Request will be merged and a release will be done once pools are ready to change the share conditions.

Below is the explanation that I gave in Discord.

> Let's say a number from the constellation has 5% probability of being prime when using the current algorithm. Currently, the chosen 5% is actually close to real numbers (ratio ~20).
> In both Pooled and Solo Mining, if the first number is not prime (95% of the times), in both cases the miner will stop testing and go to the next candidate.
> Now if it is prime, the second number will be tested. If this one is not prime (cumulative probability is 5%*95% = 4.75%), the test will stop in Solo Mining (total 2 prime checks). But it will continue in Pooled Mining because there is still a chance that at least 4 are prime, even though the tuple is certainly not a constellation (to be a share, the requirement is that the first number is prime and that there are at least 4 primes in total). In this case, at least 2 more numbers will be checked (total at least 4 checks).
> The miner spends a good majority of the time to test if a number is prime, so we can say that if 4.75% of the time the miner makes 2 more "useless" checks, we lose about 9.5% of the performance. In other words, pool miners are working a good part of the time to find shares despite knowing that their share is not a constellation. So even though payouts will be fairly distributed, pools will find blocks less often than they should, rewards will be lower.
> Pools might consider to change the share requirements to make Pooled Mining more efficient. For example, requiring that the first 2 are prime will reduce the loss by an order of magnitude (there will also be less shares so maybe less overhead too). Modifying rieMiner for this seems to indeed reflect the speed benefit, Clo1 might confirm my explanations. In this case, all pools should apply the modification and a minor rieMiner release must happen at the same time.
> In the past, probably the requirement of "any of 4 prime" was done in order to avoid people optimizing the miner in order to find "true" 4-tuples much faster, without having to test the 2 last numbers.