### PR TITLE
Compile on older versions of gcc

### DIFF
--- a/Miner.hpp
+++ b/Miner.hpp
@@ -55,12 +55,28 @@ struct Task {
 			std::array<uint32_t, maxCandidatesPerCheckTask> factorOffsets;
 		} check;
 	};
+
+	static Task PresieveTask(uint64_t workIndex, uint64_t start, uint64_t end) {
+		Task task;
+		task.type = Presieve;
+		task.workIndex = workIndex;
+		task.presieve.start = start;
+		task.presieve.end = end;
+		return task;
+	}
+	static Task SieveTask(uint64_t workIndex, uint32_t id, uint64_t iteration) {
+		Task task;
+		task.type = Sieve;
+		task.workIndex = workIndex;
+		task.sieve.id = id;
+		task.sieve.iteration = iteration;
+		return task;
+	}
 };
 
 struct TaskDoneInfo {
 	Task::Type type;
 	union {
-		struct {} empty;
 		uint64_t workIndex;
 		uint64_t firstPrimeIndex;
 	};

--- a/Stats.cpp
+++ b/Stats.cpp
@@ -41,9 +41,9 @@ std::string Stats::formattedTime(const double &time) {
 	return oss.str();
 }
 std::string Stats::formattedClockTimeNow() {
-	const std::chrono::time_point now(std::chrono::system_clock::now());
-	const std::chrono::time_point seconds(std::chrono::time_point_cast<std::chrono::seconds>(now));
-	const std::chrono::duration milliseconds(std::chrono::duration_cast<std::chrono::milliseconds>(now - seconds));
+	const auto now(std::chrono::system_clock::now());
+	const auto seconds(std::chrono::time_point_cast<std::chrono::seconds>(now));
+	const auto milliseconds(std::chrono::duration_cast<std::chrono::milliseconds>(now - seconds));
 	const std::time_t timeT(std::chrono::system_clock::to_time_t(now));
 	const std::tm *timeTm(std::localtime(&timeT));
 	std::ostringstream oss;


### PR DESCRIPTION
I couldn't compile on Ubuntu 18.04 LTS as gcc there doesn't support the latest C++17 syntax.

Realise that this makes things a little less pretty, but this 18.04 is still well supported and it would be nice for the miner to compile on a wide range of OSes.