### PR TITLE
Separate 32 bit and 64 bit prime tables, plus other minor improvements

### DIFF
--- a/Miner.cpp
+++ b/Miner.cpp
@@ -665,7 +665,7 @@ void Miner::_doSieveTask(Task task) {
 	if (sieveIteration == 0) presieveLock.lock();
 	
 	// Eliminate these factors.
-	for (uint64_t i(0) ; i < sieve.additionalFactorsToEliminateCounts[sieveIteration] ; i++)
+	for (uint64_t i(0), count(sieve.additionalFactorsToEliminateCounts[sieveIteration]); i < count ; i++)
 		_addToSieveCache(sieve.factorsTable, sieveCache, sieveCachePos, sieve.additionalFactorsToEliminate[sieveIteration][i]);
 	_endSieveCache(sieve.factorsTable, sieveCache);
 	

--- a/Miner.cpp
+++ b/Miner.cpp
@@ -14,7 +14,7 @@ extern "C" {
 	mp_limb_t rie_mod_1s_2p_8times(mp_srcptr ap, mp_size_t n, uint32_t* ps, uint32_t cnt, uint64_t* cps, uint64_t* remainders);
 }
 
-constexpr uint64_t nPrimesTo2p32(203280222);
+constexpr uint64_t nPrimesTo2p32(203280221);
 constexpr int factorsCacheSize(16384);
 constexpr uint16_t maxSieveWorkers(16); // There is a noticeable performance penalty using Vector so we are using Arrays.
 thread_local uint64_t** factorsCache{nullptr};

--- a/Miner.hpp
+++ b/Miner.hpp
@@ -160,7 +160,7 @@ class Miner {
 	}
 	uint64_t _getModularInverse(uint64_t i) const {
 		if (i < _nPrimes32) return _modularInverses32[i];
-		else return _modularInverses64[i];
+		else return _modularInverses64[i - _nPrimes32];
 	}
 public:
 	Miner(const Options &options) :

--- a/Miner.hpp
+++ b/Miner.hpp
@@ -111,8 +111,9 @@ class Miner {
 	CpuID _cpuInfo;
 	// Miner data (generated in init)
 	mpz_class _primorial;
-	uint64_t _nPrimes, _factorMax, _primesIndexThreshold;
-	std::vector<uint64_t> _primes, _modularInverses, _modPrecompute;
+	uint64_t _nPrimes, _nPrimes32, _factorMax, _primesIndexThreshold;
+	std::vector<uint32_t> _primes32, _modularInverses32;
+	std::vector<uint64_t> _primes64, _modularInverses64, _modPrecompute;
 	std::vector<mpz_class> _primorialOffsets;
 	std::vector<uint64_t> _halfPattern, _primorialOffsetDiff;
 	// Miner state variables
@@ -152,6 +153,15 @@ class Miner {
 	void _doTasks(uint16_t);
 	void _manageTasks();
 	void _suggestLessMemoryIntensiveOptions(const uint64_t, const uint16_t)  const;
+
+	uint64_t _getPrime(uint64_t i) const { 
+		if (i < _nPrimes32) return _primes32[i];
+		else return _primes64[i - _nPrimes32];
+	}
+	uint64_t _getModularInverse(uint64_t i) const {
+		if (i < _nPrimes32) return _modularInverses32[i];
+		else return _modularInverses64[i];
+	}
 public:
 	Miner(const Options &options) :
 		_mode(options.mode()), _parameters(MinerParameters()),

--- a/ispc/fermat.cpp
+++ b/ispc/fermat.cpp
@@ -88,9 +88,12 @@ static uint32_t setup_fermat(uint32_t N_Size, int num, const mp_limb_t* M, mp_li
 			mp = mshifted;
 		}
 
-		for (int i = 0; i < mn; ++i) rp[i] = 0;
-		rp[mn] = 1 << minv.shift;
-		mpn_div_r_preinv_ns(rp, mn+1, mp, mn, &minv);
+		for (int i = 0; i < mn + 9; ++i) rp[i] = 0;
+		mp_limb_t x = mp[mn - 1] >> 24;
+		x += minv.shift;
+		int i = x >> 5;
+		rp[mn + i] = 1 << (x & 0x1f);
+		mpn_div_r_preinv_ns(rp, mn+i+1, mp, mn, &minv);
 
 		if (minv.shift > 0)
 		{
@@ -133,7 +136,7 @@ void fermatTest(int N_Size, int listSize, uint32_t* M, uint32_t* is_prime, bool 
 	}
 
 	uint32_t MI[MAX_N_SIZE];
-	uint32_t R[MAX_N_SIZE * JOB_SIZE + 5];
+	uint32_t R[MAX_N_SIZE * JOB_SIZE + 9];
 
 	while (listSize > 0)
 	{

--- a/ispc/primetest.ispc
+++ b/ispc/primetest.ispc
@@ -263,7 +263,15 @@ export void fermat_test(uniform uint M_in[], uniform uint Mi_in[], uniform uint 
 	const uniform uint highbit = ((uint)1) << 31;
 	uniform uint startbit;
 	uniform int en = N_Size;
-	startbit = highbit >> shft;
+	if (shft < 24)
+	{
+		startbit = highbit >> (shft + 8);
+	}
+	else
+	{
+		startbit = highbit >> (shft - 24);
+		en--;
+	}
 
 	const uint mi = Mi_in[programIndex];
 

--- a/ispc/primetest.s
+++ b/ispc/primetest.s
@@ -1,16 +1,9 @@
 	.text
 	.file	"primetest.ispc"
-	.section	.rodata.cst32,"aM",@progbits,32
-	.p2align	5               # -- Begin function squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
+	.section	.rodata.cst8,"aM",@progbits,8
+	.p2align	3               # -- Begin function squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
 .LCPI0_0:
-	.long	0                       # 0x0
-	.long	2                       # 0x2
-	.long	4                       # 0x4
-	.long	6                       # 0x6
-	.long	4                       # 0x4
-	.long	6                       # 0x6
-	.long	6                       # 0x6
-	.long	7                       # 0x7
+	.quad	4294967294              # 0xfffffffe
 	.text
 	.p2align	4, 0x90
 	.type	squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu,@function
@@ -27,7 +20,7 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	subq	$16384, %rsp            # imm = 0x4000
                                         # kill: def $edx killed $edx def $rdx
 	movl	%edx, %r8d
-	decl	%r8d
+	addl	$-1, %r8d
 	je	.LBB0_1
 # %bb.2:                                # %for_loop.lr.ph
 	vpxor	%xmm4, %xmm4, %xmm4
@@ -45,31 +38,33 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm7, %xmm7, %xmm7
 	vpxor	%xmm8, %xmm8, %xmm8
-	jmp	.LBB0_6
+	testl	%eax, %eax
+	jne	.LBB0_7
+	jmp	.LBB0_9
 .LBB0_1:                                # %for_exit24.thread
 	movl	%r8d, %eax
 	shlq	$7, %rax
-	vpxor	%xmm15, %xmm15, %xmm15
-	vmovdqa	%ymm15, 224(%rsp,%rax)
-	vmovdqa	%ymm15, 192(%rsp,%rax)
-	vmovdqa	%ymm15, 160(%rsp,%rax)
-	vmovdqa	%ymm15, 128(%rsp,%rax)
-	vmovdqu	(%rsi), %ymm2
-	vmovdqu	32(%rsi), %ymm3
-	vmovdqu	64(%rsi), %ymm0
-	vmovdqu	96(%rsi), %ymm1
+	vpxor	%xmm6, %xmm6, %xmm6
+	vmovdqa	%ymm6, 224(%rsp,%rax)
+	vmovdqa	%ymm6, 192(%rsp,%rax)
+	vmovdqa	%ymm6, 160(%rsp,%rax)
+	vmovdqa	%ymm6, 128(%rsp,%rax)
+	vpblendd	$85, (%rsi), %ymm6, %ymm1 # ymm1 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 32(%rsi), %ymm6, %ymm3 # ymm3 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 64(%rsi), %ymm6, %ymm2 # ymm2 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 96(%rsi), %ymm6, %ymm0 # ymm0 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
 	vpmuludq	%ymm0, %ymm0, %ymm0
-	vpmuludq	%ymm1, %ymm1, %ymm14
 	vpmuludq	%ymm2, %ymm2, %ymm2
 	vpmuludq	%ymm3, %ymm3, %ymm3
-	vpblendd	$170, %ymm15, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm14, %ymm7 # ymm7 = ymm14[0],ymm15[1],ymm14[2],ymm15[3],ymm14[4],ymm15[5],ymm14[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vmovdqu	%ymm8, 64(%rdi)
-	vmovdqu	%ymm7, 96(%rdi)
-	vmovdqu	%ymm5, (%rdi)
-	vmovdqu	%ymm4, 32(%rdi)
+	vpmuludq	%ymm1, %ymm1, %ymm1
+	vpblendd	$170, %ymm6, %ymm1, %ymm4 # ymm4 = ymm1[0],ymm6[1],ymm1[2],ymm6[3],ymm1[4],ymm6[5],ymm1[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm6[1],ymm3[2],ymm6[3],ymm3[4],ymm6[5],ymm3[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm6[1],ymm2[2],ymm6[3],ymm2[4],ymm6[5],ymm2[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm6[1],ymm0[2],ymm6[3],ymm0[4],ymm6[5],ymm0[6],ymm6[7]
+	vmovdqu	%ymm8, 96(%rdi)
+	vmovdqu	%ymm7, 64(%rdi)
+	vmovdqu	%ymm5, 32(%rdi)
+	vmovdqu	%ymm4, (%rdi)
 	jmp	.LBB0_19
 .LBB0_4:                                # %for_loop.lr.ph.new
 	movl	%r8d, %r9d
@@ -88,79 +83,79 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpmuludq	-192(%rsi,%rcx), %ymm1, %ymm10
 	vpaddq	%ymm8, %ymm9, %ymm8
 	vpaddq	%ymm7, %ymm10, %ymm7
-	vpmuludq	-224(%rsi,%rcx), %ymm2, %ymm9
-	vpaddq	%ymm6, %ymm9, %ymm6
 	vpmuludq	-256(%rsi,%rcx), %ymm3, %ymm9
 	vpaddq	%ymm4, %ymm9, %ymm4
+	vpmuludq	-224(%rsi,%rcx), %ymm2, %ymm9
+	vpaddq	%ymm6, %ymm9, %ymm6
 	vpblendd	$170, %ymm5, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vmovdqa	%ymm12, -256(%rsp,%rcx)
-	vmovdqa	%ymm11, -224(%rsp,%rcx)
+	vpblendd	$170, %ymm5, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vmovdqa	%ymm12, -224(%rsp,%rcx)
+	vmovdqa	%ymm11, -256(%rsp,%rcx)
 	vmovdqa	%ymm10, -192(%rsp,%rcx)
 	vmovdqa	%ymm9, -160(%rsp,%rcx)
 	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm8, %ymm8
 	vpmuludq	-64(%rsi,%rcx), %ymm1, %ymm9
-	vpmuludq	-96(%rsi,%rcx), %ymm2, %ymm10
+	vpmuludq	-128(%rsi,%rcx), %ymm3, %ymm10
 	vpaddq	%ymm7, %ymm9, %ymm7
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpmuludq	-128(%rsi,%rcx), %ymm3, %ymm9
-	vpaddq	%ymm4, %ymm9, %ymm4
+	vpaddq	%ymm4, %ymm10, %ymm4
+	vpmuludq	-96(%rsi,%rcx), %ymm2, %ymm9
+	vpaddq	%ymm6, %ymm9, %ymm6
 	vpmuludq	-32(%rsi,%rcx), %ymm0, %ymm9
 	vpaddq	%ymm8, %ymm9, %ymm8
 	vpblendd	$170, %ymm5, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
 	vmovdqa	%ymm12, -32(%rsp,%rcx)
-	vmovdqa	%ymm11, -128(%rsp,%rcx)
-	vmovdqa	%ymm10, -96(%rsp,%rcx)
+	vmovdqa	%ymm11, -96(%rsp,%rcx)
+	vmovdqa	%ymm10, -128(%rsp,%rcx)
 	vmovdqa	%ymm9, -64(%rsp,%rcx)
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm8, %ymm8
-	vpmuludq	64(%rsi,%rcx), %ymm1, %ymm9
-	vpmuludq	32(%rsi,%rcx), %ymm2, %ymm10
-	vpaddq	%ymm7, %ymm9, %ymm7
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpmuludq	(%rsi,%rcx), %ymm3, %ymm9
-	vpaddq	%ymm4, %ymm9, %ymm4
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
 	vpmuludq	96(%rsi,%rcx), %ymm0, %ymm9
-	vpaddq	%ymm8, %ymm9, %ymm8
-	vpblendd	$170, %ymm5, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vmovdqa	%ymm12, 96(%rsp,%rcx)
-	vmovdqa	%ymm11, (%rsp,%rcx)
-	vmovdqa	%ymm10, 32(%rsp,%rcx)
-	vmovdqa	%ymm9, 64(%rsp,%rcx)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm7, %ymm7
-	addq	$4, %rbx
-	vpmuludq	160(%rsi,%rcx), %ymm2, %ymm9
-	vpaddq	%ymm6, %ymm9, %ymm6
-	vpmuludq	128(%rsi,%rcx), %ymm3, %ymm9
-	vpaddq	%ymm4, %ymm9, %ymm4
-	vpmuludq	224(%rsi,%rcx), %ymm0, %ymm9
-	vpmuludq	192(%rsi,%rcx), %ymm1, %ymm10
+	vpmuludq	64(%rsi,%rcx), %ymm1, %ymm10
 	vpaddq	%ymm8, %ymm9, %ymm8
 	vpaddq	%ymm7, %ymm10, %ymm7
-	vpblendd	$170, %ymm5, %ymm6, %ymm9 # ymm9 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vpmuludq	(%rsi,%rcx), %ymm3, %ymm9
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpmuludq	32(%rsi,%rcx), %ymm2, %ymm9
+	vpaddq	%ymm6, %ymm9, %ymm6
+	vpblendd	$170, %ymm5, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vmovdqa	%ymm12, 32(%rsp,%rcx)
+	vmovdqa	%ymm11, (%rsp,%rcx)
+	vmovdqa	%ymm10, 64(%rsp,%rcx)
+	vmovdqa	%ymm9, 96(%rsp,%rcx)
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm8, %ymm8
+	addq	$4, %rbx
+	vpmuludq	192(%rsi,%rcx), %ymm1, %ymm9
+	vpaddq	%ymm7, %ymm9, %ymm7
+	vpmuludq	128(%rsi,%rcx), %ymm3, %ymm9
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpmuludq	160(%rsi,%rcx), %ymm2, %ymm9
+	vpmuludq	224(%rsi,%rcx), %ymm0, %ymm10
+	vpaddq	%ymm6, %ymm9, %ymm6
+	vpaddq	%ymm8, %ymm10, %ymm8
+	vpblendd	$170, %ymm5, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vmovdqa	%ymm12, 192(%rsp,%rcx)
-	vmovdqa	%ymm11, 224(%rsp,%rcx)
+	vpblendd	$170, %ymm5, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
+	vmovdqa	%ymm12, 224(%rsp,%rcx)
+	vmovdqa	%ymm11, 160(%rsp,%rcx)
 	vmovdqa	%ymm10, 128(%rsp,%rcx)
-	vmovdqa	%ymm9, 160(%rsp,%rcx)
+	vmovdqa	%ymm9, 192(%rsp,%rcx)
 	vpsrlq	$32, %ymm8, %ymm8
 	vpsrlq	$32, %ymm7, %ymm7
 	vpsrlq	$32, %ymm6, %ymm6
@@ -168,11 +163,12 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	addq	$512, %rcx              # imm = 0x200
 	cmpl	%ebx, %r9d
 	jne	.LBB0_5
-.LBB0_6:                                # %for_test.for_exit_crit_edge.unr-lcssa
+# %bb.6:                                # %for_test.for_exit_crit_edge.unr-lcssa
 	testl	%eax, %eax
 	je	.LBB0_9
-# %bb.7:                                # %for_loop.epil.preheader
+.LBB0_7:                                # %for_loop.epil.preheader
 	shlq	$7, %rbx
+	negl	%eax
 	vpxor	%xmm5, %xmm5, %xmm5
 	.p2align	4, 0x90
 .LBB0_8:                                # %for_loop.epil
@@ -181,16 +177,16 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpaddq	%ymm8, %ymm9, %ymm8
 	vpmuludq	192(%rsi,%rbx), %ymm1, %ymm9
 	vpaddq	%ymm7, %ymm9, %ymm7
-	vpmuludq	160(%rsi,%rbx), %ymm2, %ymm9
-	vpmuludq	128(%rsi,%rbx), %ymm3, %ymm10
-	vpaddq	%ymm6, %ymm9, %ymm6
-	vpaddq	%ymm4, %ymm10, %ymm4
+	vpmuludq	128(%rsi,%rbx), %ymm3, %ymm9
+	vpmuludq	160(%rsi,%rbx), %ymm2, %ymm10
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpaddq	%ymm6, %ymm10, %ymm6
 	vpblendd	$170, %ymm5, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vmovdqa	%ymm12, 128(%rsp,%rbx)
-	vmovdqa	%ymm11, 160(%rsp,%rbx)
+	vpblendd	$170, %ymm5, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vmovdqa	%ymm12, 160(%rsp,%rbx)
+	vmovdqa	%ymm11, 128(%rsp,%rbx)
 	vmovdqa	%ymm10, 192(%rsp,%rbx)
 	vmovdqa	%ymm9, 224(%rsp,%rbx)
 	vpsrlq	$32, %ymm4, %ymm4
@@ -198,10 +194,10 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpsrlq	$32, %ymm7, %ymm7
 	vpsrlq	$32, %ymm8, %ymm8
 	subq	$-128, %rbx
-	decl	%eax
+	addl	$1, %eax
 	jne	.LBB0_8
 .LBB0_9:                                # %for_exit
-	movl	%r8d, (%rsp)            # 4-byte Spill
+	movl	%r8d, 108(%rsp)         # 4-byte Spill
 	movl	%r8d, %r9d
 	movq	%r9, %rax
 	shlq	$7, %rax
@@ -214,39 +210,30 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 # %bb.10:                               # %for_test30.preheader.lr.ph
 	leal	-3(%rdx), %r14d
 	movl	%edx, %eax
-	movq	%rax, 64(%rsp)          # 8-byte Spill
-	leaq	128(%rsi), %rax
-	movq	%rax, 32(%rsp)          # 8-byte Spill
+	movq	%rax, 120(%rsp)         # 8-byte Spill
+	movq	%rsi, %rax
+	subq	$-128, %rax
+	movq	%rax, 112(%rsp)         # 8-byte Spill
 	movl	$2, %r13d
 	xorl	%r12d, %r12d
 	vpxor	%xmm0, %xmm0, %xmm0
-	movq	%rdx, %r10
-	jmp	.LBB0_11
+	movq	%rdx, %r11
 	.p2align	4, 0x90
-.LBB0_17:                               # %for_exit33
-                                        #   in Loop: Header=BB0_11 Depth=1
-	movq	%r10, %rdx
-	addl	%edx, %ecx
-	shlq	$7, %rcx
-	vmovdqa	%ymm5, 224(%rsp,%rcx)
-	vmovdqa	%ymm6, 192(%rsp,%rcx)
-	vmovdqa	%ymm7, 160(%rsp,%rcx)
-	vmovdqa	%ymm8, 128(%rsp,%rcx)
-	incq	%r13
-	incq	%r12
-	cmpl	%r15d, %r12d
-	je	.LBB0_18
-.LBB0_11:                               # %for_loop31.lr.ph
+.LBB0_11:                               # %for_loop32.lr.ph
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_16 Depth 2
 	movl	%r15d, %ebx
 	subl	%r12d, %ebx
 	movq	%r13, %rax
 	shlq	$7, %rax
-	vpblendd	$85, -32(%rax,%rsi), %ymm0, %ymm1 # ymm1 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
-	vpblendd	$85, -64(%rax,%rsi), %ymm0, %ymm2 # ymm2 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
-	vpblendd	$85, -96(%rax,%rsi), %ymm0, %ymm3 # ymm3 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
-	vpblendd	$85, -128(%rax,%rsi), %ymm0, %ymm4 # ymm4 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
+#	vpblendd	$85, -32(%rsi,%rax), %ymm0, %ymm1 # ymm1 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
+#	vpblendd	$85, -64(%rsi,%rax), %ymm0, %ymm2 # ymm2 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
+#	vpblendd	$85, -96(%rsi,%rax), %ymm0, %ymm3 # ymm3 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
+#	vpblendd	$85, -128(%rsi,%rax), %ymm0, %ymm4 # ymm4 = mem[0],ymm0[1],mem[2],ymm0[3],mem[4],ymm0[5],mem[6],ymm0[7]
+    vmovdqa -32(%rsi,%rax), %ymm1
+    vmovdqa -64(%rsi,%rax), %ymm2
+    vmovdqa -96(%rsi,%rax), %ymm3
+    vmovdqa -128(%rsi,%rax), %ymm4
 	leaq	-2(%r13), %rcx
 	testb	$1, %bl
 	jne	.LBB0_13
@@ -257,257 +244,272 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm5, %xmm5, %xmm5
 	cmpl	%r12d, %r14d
-	je	.LBB0_17
-	jmp	.LBB0_15
+	jne	.LBB0_15
+	jmp	.LBB0_17
 	.p2align	4, 0x90
-.LBB0_13:                               # %for_loop31.prol.preheader
+.LBB0_13:                               # %for_loop32.prol.preheader
                                         #   in Loop: Header=BB0_11 Depth=1
-	vpmuludq	32(%rsi,%rax), %ymm3, %ymm5
-	vpmuludq	(%rsi,%rax), %ymm4, %ymm6
-	vpmuludq	96(%rsi,%rax), %ymm1, %ymm7
-	vpmuludq	64(%rsi,%rax), %ymm2, %ymm8
+	vpmuludq	(%rsi,%rax), %ymm4, %ymm5
+	vpmuludq	32(%rsi,%rax), %ymm3, %ymm6
+	vpmuludq	64(%rsi,%rax), %ymm2, %ymm7
+	vpmuludq	96(%rsi,%rax), %ymm1, %ymm8
 	leal	(%rcx,%r13), %eax
 	shlq	$7, %rax
-	vpaddq	192(%rsp,%rax), %ymm8, %ymm8
-	vpaddq	224(%rsp,%rax), %ymm7, %ymm7
-	vpaddq	128(%rsp,%rax), %ymm6, %ymm9
-	vpaddq	160(%rsp,%rax), %ymm5, %ymm10
+	vpaddq	224(%rsp,%rax), %ymm8, %ymm8
+	vpaddq	192(%rsp,%rax), %ymm7, %ymm7
+	vpaddq	160(%rsp,%rax), %ymm6, %ymm9
+	vpaddq	128(%rsp,%rax), %ymm5, %ymm10
 	vpblendd	$170, %ymm0, %ymm9, %ymm5 # ymm5 = ymm9[0],ymm0[1],ymm9[2],ymm0[3],ymm9[4],ymm0[5],ymm9[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm7, %ymm6 # ymm6 = ymm7[0],ymm0[1],ymm7[2],ymm0[3],ymm7[4],ymm0[5],ymm7[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm0[1],ymm8[2],ymm0[3],ymm8[4],ymm0[5],ymm8[6],ymm0[7]
-	vmovdqa	%ymm11, 192(%rsp,%rax)
-	vmovdqa	%ymm6, 224(%rsp,%rax)
-	vmovdqa	%ymm5, 128(%rsp,%rax)
-	vpblendd	$170, %ymm0, %ymm10, %ymm5 # ymm5 = ymm10[0],ymm0[1],ymm10[2],ymm0[3],ymm10[4],ymm0[5],ymm10[6],ymm0[7]
+	vmovdqa	%ymm11, 224(%rsp,%rax)
+	vmovdqa	%ymm6, 192(%rsp,%rax)
 	vmovdqa	%ymm5, 160(%rsp,%rax)
-	vpsrlq	$32, %ymm7, %ymm5
-	vpsrlq	$32, %ymm8, %ymm6
-	vpsrlq	$32, %ymm10, %ymm7
-	vpsrlq	$32, %ymm9, %ymm8
+	vpblendd	$170, %ymm0, %ymm10, %ymm5 # ymm5 = ymm10[0],ymm0[1],ymm10[2],ymm0[3],ymm10[4],ymm0[5],ymm10[6],ymm0[7]
+	vmovdqa	%ymm5, 128(%rsp,%rax)
+	vpsrlq	$32, %ymm8, %ymm5
+	vpsrlq	$32, %ymm7, %ymm6
+	vpsrlq	$32, %ymm9, %ymm7
+	vpsrlq	$32, %ymm10, %ymm8
 	leaq	1(%r13), %rbx
 	cmpl	%r12d, %r14d
 	je	.LBB0_17
-.LBB0_15:                               # %for_loop31.preheader
+.LBB0_15:                               # %for_loop32.preheader
                                         #   in Loop: Header=BB0_11 Depth=1
-	movq	64(%rsp), %rax          # 8-byte Reload
+	movq	120(%rsp), %rax         # 8-byte Reload
 	subq	%rbx, %rax
 	leaq	(%rbx,%r12), %r8
 	shlq	$7, %rbx
-	addq	32(%rsp), %rbx          # 8-byte Folded Reload
+	addq	112(%rsp), %rbx         # 8-byte Folded Reload
 	.p2align	4, 0x90
-.LBB0_16:                               # %for_loop31
+.LBB0_16:                               # %for_loop32
                                         #   Parent Loop BB0_11 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	vpmuludq	-128(%rbx), %ymm4, %ymm9
 	vpmuludq	-96(%rbx), %ymm3, %ymm10
 	vpmuludq	-64(%rbx), %ymm2, %ymm11
 	vpmuludq	-32(%rbx), %ymm1, %ymm12
-	movl	%r8d, %r11d
-	shlq	$7, %r11
-	vpaddq	128(%rsp,%r11), %ymm8, %ymm8
+	movl	%r8d, %r10d
+	shlq	$7, %r10
+	vpaddq	128(%rsp,%r10), %ymm8, %ymm8
 	vpaddq	%ymm9, %ymm8, %ymm8
-	vpaddq	160(%rsp,%r11), %ymm7, %ymm7
-	vpaddq	%ymm7, %ymm10, %ymm7
-	vpaddq	192(%rsp,%r11), %ymm6, %ymm6
-	vpaddq	224(%rsp,%r11), %ymm5, %ymm5
-	vpaddq	%ymm6, %ymm11, %ymm6
-	vpaddq	%ymm5, %ymm12, %ymm5
+	vpaddq	160(%rsp,%r10), %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm7, %ymm7
+	vpaddq	192(%rsp,%r10), %ymm6, %ymm6
+	vpaddq	224(%rsp,%r10), %ymm5, %ymm5
+	vpaddq	%ymm11, %ymm6, %ymm6
+	vpaddq	%ymm12, %ymm5, %ymm5
 	vpblendd	$170, %ymm0, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm0[1],ymm8[2],ymm0[3],ymm8[4],ymm0[5],ymm8[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm0[1],ymm7[2],ymm0[3],ymm7[4],ymm0[5],ymm7[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm0[1],ymm6[2],ymm0[3],ymm6[4],ymm0[5],ymm6[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm5, %ymm12 # ymm12 = ymm5[0],ymm0[1],ymm5[2],ymm0[3],ymm5[4],ymm0[5],ymm5[6],ymm0[7]
-	vmovdqa	%ymm12, 224(%rsp,%r11)
-	vmovdqa	%ymm11, 192(%rsp,%r11)
-	vmovdqa	%ymm10, 160(%rsp,%r11)
-	vmovdqa	%ymm9, 128(%rsp,%r11)
-	vpsrlq	$32, %ymm5, %ymm5
+	vmovdqa	%ymm12, 224(%rsp,%r10)
+	vmovdqa	%ymm11, 192(%rsp,%r10)
+	vmovdqa	%ymm10, 160(%rsp,%r10)
+	vmovdqa	%ymm9, 128(%rsp,%r10)
 	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm8, %ymm8
+	vpsrlq	$32, %ymm5, %ymm5
+#	vpsrlq	$32, %ymm7, %ymm7
+#	vpsrlq	$32, %ymm8, %ymm8
+	vpsrldq	$4, %ymm7, %ymm7
+	vpsrldq	$4, %ymm8, %ymm8
+	vpblendd	$170, %ymm0, %ymm7, %ymm7
+	vpblendd	$170, %ymm0, %ymm8, %ymm8
 	vpmuludq	(%rbx), %ymm4, %ymm9
 	vpmuludq	32(%rbx), %ymm3, %ymm10
-	vpmuludq	64(%rbx), %ymm2, %ymm11
-	vpmuludq	96(%rbx), %ymm1, %ymm12
+	vpmuludq	96(%rbx), %ymm1, %ymm11
+	vpmuludq	64(%rbx), %ymm2, %ymm12
 	leal	1(%r8), %edx
 	shlq	$7, %rdx
 	vpaddq	128(%rsp,%rdx), %ymm8, %ymm8
 	vpaddq	160(%rsp,%rdx), %ymm7, %ymm7
 	vpaddq	%ymm9, %ymm8, %ymm8
-	vpaddq	%ymm7, %ymm10, %ymm7
-	vpaddq	192(%rsp,%rdx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm11, %ymm6
+	vpaddq	%ymm10, %ymm7, %ymm7
 	vpaddq	224(%rsp,%rdx), %ymm5, %ymm5
-	vpaddq	%ymm5, %ymm12, %ymm5
+	vpaddq	%ymm11, %ymm5, %ymm5
+	vpaddq	192(%rsp,%rdx), %ymm6, %ymm6
+	vpaddq	%ymm12, %ymm6, %ymm6
 	vpblendd	$170, %ymm0, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm0[1],ymm8[2],ymm0[3],ymm8[4],ymm0[5],ymm8[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm0[1],ymm7[2],ymm0[3],ymm7[4],ymm0[5],ymm7[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm0[1],ymm6[2],ymm0[3],ymm6[4],ymm0[5],ymm6[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm5, %ymm12 # ymm12 = ymm5[0],ymm0[1],ymm5[2],ymm0[3],ymm5[4],ymm0[5],ymm5[6],ymm0[7]
-	vmovdqa	%ymm12, 224(%rsp,%rdx)
-	vmovdqa	%ymm11, 192(%rsp,%rdx)
+	vpblendd	$170, %ymm0, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm0[1],ymm5[2],ymm0[3],ymm5[4],ymm0[5],ymm5[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm0[1],ymm6[2],ymm0[3],ymm6[4],ymm0[5],ymm6[6],ymm0[7]
+	vmovdqa	%ymm12, 192(%rsp,%rdx)
+	vmovdqa	%ymm11, 224(%rsp,%rdx)
 	vmovdqa	%ymm10, 160(%rsp,%rdx)
 	vmovdqa	%ymm9, 128(%rsp,%rdx)
 	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm8, %ymm8
+#	vpsrlq	$32, %ymm7, %ymm7
+#	vpsrlq	$32, %ymm8, %ymm8
+	vpsrldq	$4, %ymm7, %ymm7
+	vpsrldq	$4, %ymm8, %ymm8
+	vpblendd	$170, %ymm0, %ymm7, %ymm7
+	vpblendd	$170, %ymm0, %ymm8, %ymm8
 	addq	$2, %r8
 	addq	$256, %rbx              # imm = 0x100
 	addq	$-2, %rax
 	jne	.LBB0_16
-	jmp	.LBB0_17
+.LBB0_17:                               # %for_exit33
+                                        #   in Loop: Header=BB0_11 Depth=1
+	movq	%r11, %rdx
+	addl	%edx, %ecx
+	shlq	$7, %rcx
+	vmovdqa	%ymm5, 224(%rsp,%rcx)
+	vmovdqa	%ymm6, 192(%rsp,%rcx)
+	vmovdqa	%ymm7, 160(%rsp,%rcx)
+	vmovdqa	%ymm8, 128(%rsp,%rcx)
+	addq	$1, %r13
+	addq	$1, %r12
+	cmpl	%r15d, %r12d
+	jne	.LBB0_11
 .LBB0_18:                               # %for_exit24
-	vmovdqu	(%rsi), %ymm2
-	vmovdqu	32(%rsi), %ymm3
-	vmovdqu	64(%rsi), %ymm0
-	vmovdqu	96(%rsi), %ymm1
+	vpxor	%xmm6, %xmm6, %xmm6
+	vpblendd	$85, (%rsi), %ymm6, %ymm1 # ymm1 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 32(%rsi), %ymm6, %ymm3 # ymm3 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 64(%rsi), %ymm6, %ymm2 # ymm2 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
+	vpblendd	$85, 96(%rsi), %ymm6, %ymm0 # ymm0 = mem[0],ymm6[1],mem[2],ymm6[3],mem[4],ymm6[5],mem[6],ymm6[7]
 	vpmuludq	%ymm0, %ymm0, %ymm0
-	vpmuludq	%ymm1, %ymm1, %ymm14
 	vpmuludq	%ymm2, %ymm2, %ymm2
 	vpmuludq	%ymm3, %ymm3, %ymm3
-	vpxor	%xmm15, %xmm15, %xmm15
-	vpblendd	$170, %ymm15, %ymm2, %ymm4 # ymm4 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm14, %ymm5 # ymm5 = ymm14[0],ymm15[1],ymm14[2],ymm15[3],ymm14[4],ymm15[5],ymm14[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vmovdqu	%ymm7, 64(%rdi)
-	vmovdqu	%ymm5, 96(%rdi)
-	vmovdqu	%ymm4, (%rdi)
-	vpblendd	$170, %ymm15, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
+	vpmuludq	%ymm1, %ymm1, %ymm1
+	vpblendd	$170, %ymm6, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm6[1],ymm3[2],ymm6[3],ymm3[4],ymm6[5],ymm3[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm6[1],ymm2[2],ymm6[3],ymm2[4],ymm6[5],ymm2[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm6[1],ymm0[2],ymm6[3],ymm0[4],ymm6[5],ymm0[6],ymm6[7]
+	vmovdqu	%ymm7, 96(%rdi)
+	vmovdqu	%ymm5, 64(%rdi)
 	vmovdqu	%ymm4, 32(%rdi)
-	cmpl	$0, (%rsp)              # 4-byte Folded Reload
+	vpblendd	$170, %ymm6, %ymm1, %ymm4 # ymm4 = ymm1[0],ymm6[1],ymm1[2],ymm6[3],ymm1[4],ymm6[5],ymm1[6],ymm6[7]
+	vmovdqu	%ymm4, (%rdi)
+	cmpl	$0, 108(%rsp)           # 4-byte Folded Reload
 	je	.LBB0_19
-# %bb.20:                               # %for_loop88.preheader
+# %bb.20:                               # %for_loop89.preheader
 	addq	%r9, %r9
 	subq	$-128, %rsi
+	vpxor	%xmm4, %xmm4, %xmm4
 	xorl	%eax, %eax
-	vpxor	%xmm15, %xmm15, %xmm15
+	vpbroadcastq	.LCPI0_0(%rip), %ymm5 # ymm5 = [4294967294,4294967294,4294967294,4294967294]
+	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm7, %xmm7, %xmm7
 	vpxor	%xmm8, %xmm8, %xmm8
 	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB0_21:                               # %for_loop88
+.LBB0_21:                               # %for_loop89
                                         # =>This Inner Loop Header: Depth=1
 	movl	%eax, %ecx
 	shlq	$7, %rcx
-	vmovdqa	128(%rsp,%rcx), %ymm5
-	vmovdqa	160(%rsp,%rcx), %ymm12
-	vmovdqa	192(%rsp,%rcx), %ymm11
+	vmovdqa	128(%rsp,%rcx), %ymm10
+	vmovdqa	160(%rsp,%rcx), %ymm11
+	vmovdqa	192(%rsp,%rcx), %ymm12
 	vmovdqa	224(%rsp,%rcx), %ymm13
-	vpsrlq	$32, %ymm14, %ymm1
-	vpaddq	%ymm1, %ymm9, %ymm1
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	%ymm2, %ymm15, %ymm2
+	vpsrlq	$32, %ymm0, %ymm0
+	vpaddq	%ymm9, %ymm0, %ymm0
 	vpsrlq	$32, %ymm3, %ymm3
 	vpaddq	%ymm7, %ymm3, %ymm3
-	vpsrlq	$32, %ymm0, %ymm0
-	vpaddq	%ymm0, %ymm8, %ymm0
-	vmovdqa	.LCPI0_0(%rip), %ymm10  # ymm10 = [0,2,4,6,4,6,6,7]
-	vpermd	%ymm13, %ymm10, %ymm6
-	vpermd	%ymm5, %ymm10, %ymm8
-	vpermd	%ymm12, %ymm10, %ymm9
-	vpermd	%ymm11, %ymm10, %ymm7
-	vpaddd	%xmm7, %xmm7, %xmm7
-	vpmovzxdq	%xmm7, %ymm7    # ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero
-	vpaddq	%ymm7, %ymm0, %ymm7
-	vmovdqa	%ymm7, 96(%rsp)         # 32-byte Spill
-	vpaddd	%xmm9, %xmm9, %xmm0
-	vpmovzxdq	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
-	vpaddq	%ymm0, %ymm3, %ymm0
-	vpaddd	%xmm8, %xmm8, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpaddq	%ymm3, %ymm2, %ymm2
-	vpaddd	%xmm6, %xmm6, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpaddq	%ymm3, %ymm1, %ymm6
-	vmovdqa	%ymm6, 64(%rsp)         # 32-byte Spill
+	vpsrlq	$32, %ymm1, %ymm1
+	vpaddq	%ymm6, %ymm1, %ymm1
+	vpsrlq	$32, %ymm2, %ymm2
+	vpaddq	%ymm8, %ymm2, %ymm2
+#	vpaddq	%ymm13, %ymm13, %ymm6
+#	vpaddq	%ymm11, %ymm11, %ymm7
+#	vpaddq	%ymm10, %ymm10, %ymm8
+#	vpaddq	%ymm12, %ymm12, %ymm9
+	vpaddd	%ymm13, %ymm13, %ymm6
+	vpaddd	%ymm11, %ymm11, %ymm7
+	vpaddd	%ymm10, %ymm10, %ymm8
+	vpaddd	%ymm12, %ymm12, %ymm9
+#	vpand	%ymm5, %ymm9, %ymm9
+	vpaddq	%ymm9, %ymm2, %ymm2
+#	vpand	%ymm5, %ymm8, %ymm8
+	vpaddq	%ymm8, %ymm1, %ymm1
+#	vpand	%ymm5, %ymm7, %ymm7
+	vpaddq	%ymm7, %ymm3, %ymm3
+#	vpand	%ymm5, %ymm6, %ymm6
+	vpaddq	%ymm6, %ymm0, %ymm0
 	leal	1(%rax), %ecx
 	shlq	$7, %rcx
-	vpblendd	$170, %ymm4, %ymm0, %ymm1 # ymm1 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
-	vpblendd	$170, %ymm4, %ymm2, %ymm3 # ymm3 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
-	vpblendd	$170, %ymm4, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
 	vmovdqu	%ymm8, 96(%rdi,%rcx)
-	vmovdqu	%ymm3, (%rdi,%rcx)
-	vmovdqu	%ymm1, 32(%rdi,%rcx)
-	vpblendd	$170, %ymm4, %ymm7, %ymm1 # ymm1 = ymm7[0],ymm4[1],ymm7[2],ymm4[3],ymm7[4],ymm4[5],ymm7[6],ymm4[7]
-	vmovdqu	%ymm1, 64(%rdi,%rcx)
-	vpsrlq	$31, %ymm12, %ymm12
-	vpsrlq	$31, %ymm5, %ymm14
-	vpsrlq	$31, %ymm13, %ymm13
-	vpsrlq	$31, %ymm11, %ymm11
-	vpsrlq	$32, %ymm2, %ymm7
-	vpsrlq	$32, %ymm0, %ymm15
-	vmovdqu	(%rsi), %ymm2
-	vmovdqu	32(%rsi), %ymm3
-	vmovdqu	64(%rsi), %ymm0
-	vmovdqu	96(%rsi), %ymm1
-	vpmuludq	%ymm0, %ymm0, %ymm6
-	vmovdqa	%ymm6, (%rsp)           # 32-byte Spill
-	vpmuludq	%ymm1, %ymm1, %ymm0
-	vpmuludq	%ymm2, %ymm2, %ymm1
-	vmovdqa	%ymm1, 32(%rsp)         # 32-byte Spill
+	vmovdqu	%ymm7, 32(%rdi,%rcx)
+	vmovdqu	%ymm6, (%rdi,%rcx)
+	vpblendd	$170, %ymm4, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
+	vmovdqu	%ymm6, 64(%rdi,%rcx)
+	vpsllq	$1, %ymm10, %ymm6
+	vpsllq	$1, %ymm11, %ymm7
+	vpsllq	$1, %ymm12, %ymm8
+	vpsllq	$1, %ymm13, %ymm9
+	vpaddd	%ymm6, %ymm1, %ymm6
+	vpaddd	%ymm7, %ymm3, %ymm7
+	vpaddd	%ymm8, %ymm2, %ymm8
+	vpaddd	%ymm9, %ymm0, %ymm9
+	vpsrlq	$32, %ymm6, %ymm10
+	vpsrlq	$32, %ymm7, %ymm11
+#	vpsrlq	$32, %ymm8, %ymm12
+#	vpsrlq	$32, %ymm9, %ymm13
+	vpsrldq	$4, %ymm8, %ymm12
+	vpsrldq	$4, %ymm9, %ymm13
+	vpblendd	$170, %ymm4, %ymm12, %ymm12
+	vpblendd	$170, %ymm4, %ymm13, %ymm13
+#	vpblendd	$85, 96(%rsi), %ymm4, %ymm6 # ymm6 = mem[0],ymm4[1],mem[2],ymm4[3],mem[4],ymm4[5],mem[6],ymm4[7]
+#	vpblendd	$85, 64(%rsi), %ymm4, %ymm2 # ymm2 = mem[0],ymm4[1],mem[2],ymm4[3],mem[4],ymm4[5],mem[6],ymm4[7]
+#	vpblendd	$85, 32(%rsi), %ymm4, %ymm3 # ymm3 = mem[0],ymm4[1],mem[2],ymm4[3],mem[4],ymm4[5],mem[6],ymm4[7]
+#	vpblendd	$85, (%rsi), %ymm4, %ymm0 # ymm0 = mem[0],ymm4[1],mem[2],ymm4[3],mem[4],ymm4[5],mem[6],ymm4[7]
+    vmovdqa  (%rsi), %ymm0
+    vmovdqa  32(%rsi), %ymm3
+    vmovdqa  64(%rsi), %ymm2
+    vmovdqa  96(%rsi), %ymm6
+	vpmuludq	%ymm0, %ymm0, %ymm1
 	vpmuludq	%ymm3, %ymm3, %ymm3
-	vmovdqa	128(%rsp,%rcx), %ymm9
-	vmovdqa	160(%rsp,%rcx), %ymm8
-	vpblendd	$170, %ymm4, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
-	vpaddq	%ymm5, %ymm12, %ymm5
-	vpblendd	$170, %ymm4, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
+	vpmuludq	%ymm2, %ymm2, %ymm2
+	vpmuludq	%ymm6, %ymm6, %ymm0
+	vmovdqa	128(%rsp,%rcx), %ymm6
+	vmovdqa	160(%rsp,%rcx), %ymm7
+	vmovdqa	192(%rsp,%rcx), %ymm8
+	vmovdqa	224(%rsp,%rcx), %ymm9
+	vpaddd	%ymm6, %ymm6, %ymm14
+	vpaddq	%ymm14, %ymm10, %ymm10
+	vpblendd	$170, %ymm4, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
+	vpaddq	%ymm10, %ymm14, %ymm10
+	vpaddd	%ymm7, %ymm7, %ymm14
+	vpaddq	%ymm14, %ymm11, %ymm11
+	vpblendd	$170, %ymm4, %ymm3, %ymm14 # ymm14 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+	vpaddq	%ymm11, %ymm14, %ymm11
+	vpaddd	%ymm8, %ymm8, %ymm14
 	vpaddq	%ymm14, %ymm12, %ymm12
+	vpaddd	%ymm9, %ymm9, %ymm14
+	vpaddq	%ymm14, %ymm13, %ymm13
 	vpblendd	$170, %ymm4, %ymm0, %ymm14 # ymm14 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
-	vpaddq	%ymm13, %ymm14, %ymm14
-	vpblendd	$170, %ymm4, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm4[1],ymm6[2],ymm4[3],ymm6[4],ymm4[5],ymm6[6],ymm4[7]
-	vpaddq	%ymm11, %ymm13, %ymm6
-	vpermd	%ymm8, %ymm10, %ymm11
-	vpaddd	%xmm11, %xmm11, %xmm1
-	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
-	vpaddq	%ymm1, %ymm5, %ymm1
-	vmovdqa	192(%rsp,%rcx), %ymm11
-	vpaddq	%ymm1, %ymm15, %ymm13
-	vpermd	%ymm9, %ymm10, %ymm1
-	vpaddd	%xmm1, %xmm1, %xmm1
-	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
-	vpaddq	%ymm1, %ymm12, %ymm1
-	vmovdqa	224(%rsp,%rcx), %ymm12
-	vpaddq	%ymm1, %ymm7, %ymm1
-	vpermd	%ymm12, %ymm10, %ymm5
-	vpaddd	%xmm5, %xmm5, %xmm5
-	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpaddq	%ymm5, %ymm14, %ymm5
-	vmovdqa	%ymm0, %ymm14
-	vpermd	%ymm11, %ymm10, %ymm10
-	vpaddd	%xmm10, %xmm10, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpaddq	%ymm2, %ymm6, %ymm0
-	vmovdqa	96(%rsp), %ymm2         # 32-byte Reload
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	%ymm0, %ymm2, %ymm0
+	vpaddq	%ymm13, %ymm14, %ymm13
 	addq	$2, %rax
 	movl	%eax, %ecx
 	shlq	$7, %rcx
-	vpblendd	$170, %ymm4, %ymm0, %ymm2 # ymm2 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
-	vmovdqu	%ymm2, 64(%rdi,%rcx)
-	vmovdqa	64(%rsp), %ymm2         # 32-byte Reload
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	%ymm5, %ymm2, %ymm2
-	vpblendd	$170, %ymm4, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
-	vmovdqu	%ymm5, 96(%rdi,%rcx)
-	vpblendd	$170, %ymm4, %ymm1, %ymm5 # ymm5 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
-	vmovdqu	%ymm5, (%rdi,%rcx)
-	vpblendd	$170, %ymm4, %ymm13, %ymm5 # ymm5 = ymm13[0],ymm4[1],ymm13[2],ymm4[3],ymm13[4],ymm4[5],ymm13[6],ymm4[7]
-	vmovdqu	%ymm5, 32(%rdi,%rcx)
-	vpsrlq	$31, %ymm9, %ymm5
-	vpsrlq	$32, %ymm1, %ymm1
-	vpaddq	%ymm5, %ymm1, %ymm15
-	vpsrlq	$31, %ymm8, %ymm1
-	vpsrlq	$32, %ymm13, %ymm5
-	vpaddq	%ymm1, %ymm5, %ymm7
-	vpsrlq	$31, %ymm11, %ymm1
-	vpsrlq	$32, %ymm0, %ymm0
-	vpaddq	%ymm1, %ymm0, %ymm8
-	vpsrlq	$31, %ymm12, %ymm0
-	vpsrlq	$32, %ymm2, %ymm1
-	vmovdqa	32(%rsp), %ymm2         # 32-byte Reload
-	vpaddq	%ymm0, %ymm1, %ymm9
-	vmovdqa	(%rsp), %ymm0           # 32-byte Reload
+	vpblendd	$170, %ymm4, %ymm13, %ymm14 # ymm14 = ymm13[0],ymm4[1],ymm13[2],ymm4[3],ymm13[4],ymm4[5],ymm13[6],ymm4[7]
+	vmovdqu	%ymm14, 96(%rdi,%rcx)
+	vpblendd	$170, %ymm4, %ymm2, %ymm14 # ymm14 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
+	vpaddq	%ymm12, %ymm14, %ymm12
+	vpblendd	$170, %ymm4, %ymm12, %ymm14 # ymm14 = ymm12[0],ymm4[1],ymm12[2],ymm4[3],ymm12[4],ymm4[5],ymm12[6],ymm4[7]
+	vmovdqu	%ymm14, 64(%rdi,%rcx)
+	vpblendd	$170, %ymm4, %ymm11, %ymm14 # ymm14 = ymm11[0],ymm4[1],ymm11[2],ymm4[3],ymm11[4],ymm4[5],ymm11[6],ymm4[7]
+	vmovdqu	%ymm14, 32(%rdi,%rcx)
+	vpblendd	$170, %ymm4, %ymm10, %ymm14 # ymm14 = ymm10[0],ymm4[1],ymm10[2],ymm4[3],ymm10[4],ymm4[5],ymm10[6],ymm4[7]
+	vmovdqu	%ymm14, (%rdi,%rcx)
+	vpsllq	$1, %ymm6, %ymm6
+	vpsllq	$1, %ymm7, %ymm7
+	vpsllq	$1, %ymm8, %ymm8
+	vpsllq	$1, %ymm9, %ymm9
+	vpaddd	%ymm6, %ymm10, %ymm6
+	vpaddd	%ymm7, %ymm11, %ymm7
+	vpaddd	%ymm8, %ymm12, %ymm8
+	vpaddd	%ymm9, %ymm13, %ymm9
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+#	vpsrlq	$32, %ymm8, %ymm8
+#	vpsrlq	$32, %ymm9, %ymm9
+	vpsrldq	$4, %ymm8, %ymm8
+	vpsrldq	$4, %ymm9, %ymm9
+	vpblendd	$170, %ymm4, %ymm8, %ymm8
+	vpblendd	$170, %ymm4, %ymm9, %ymm9
 	subq	$-128, %rsi
 	cmpq	%rax, %r9
 	jne	.LBB0_21
@@ -518,20 +520,20 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	vpxor	%xmm9, %xmm9, %xmm9
 .LBB0_22:                               # %for_exit90
 	leal	(%rdx,%rdx), %eax
-	decl	%eax
+	addl	$-1, %eax
 	shlq	$7, %rax
-	vpsrlq	$32, %ymm0, %ymm0
-	vpaddq	%ymm0, %ymm8, %ymm0
-	vpsrlq	$32, %ymm3, %ymm1
-	vpaddq	%ymm7, %ymm1, %ymm1
 	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	%ymm2, %ymm15, %ymm2
-	vpsrlq	$32, %ymm14, %ymm3
-	vpaddq	%ymm3, %ymm9, %ymm3
-	vmovdqu	%ymm0, 64(%rdi,%rax)
-	vmovdqu	%ymm1, 32(%rdi,%rax)
-	vmovdqu	%ymm2, (%rdi,%rax)
-	vmovdqu	%ymm3, 96(%rdi,%rax)
+	vpaddq	%ymm8, %ymm2, %ymm2
+	vpsrlq	$32, %ymm3, %ymm3
+	vpaddq	%ymm7, %ymm3, %ymm3
+	vpsrlq	$32, %ymm1, %ymm1
+	vpaddq	%ymm6, %ymm1, %ymm1
+	vpsrlq	$32, %ymm0, %ymm0
+	vpaddq	%ymm9, %ymm0, %ymm0
+	vmovdqu	%ymm2, 64(%rdi,%rax)
+	vmovdqu	%ymm3, 32(%rdi,%rax)
+	vmovdqu	%ymm1, (%rdi,%rax)
+	vmovdqu	%ymm0, 96(%rdi,%rax)
 	leaq	-40(%rbp), %rsp
 	popq	%rbx
 	popq	%r12
@@ -548,47 +550,9 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	.p2align	3               # -- Begin function toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
 .LCPI1_0:
 	.quad	-9223372036854775808    # 0x8000000000000000
-	.section	.rodata.cst16,"aM",@progbits,16
-	.p2align	4
-.LCPI1_1:
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI1_2:
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI1_3:
-	.zero	16,128
 	.section	.rodata.cst32,"aM",@progbits,32
 	.p2align	5
-.LCPI1_4:
+.LCPI1_1:
 	.long	0                       # 0x0
 	.long	0                       # 0x0
 	.long	1                       # 0x1
@@ -597,7 +561,7 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	.long	2                       # 0x2
 	.long	3                       # 0x3
 	.long	3                       # 0x3
-.LCPI1_5:
+.LCPI1_2:
 	.long	4                       # 0x4
 	.long	4                       # 0x4
 	.long	5                       # 0x5
@@ -606,6 +570,8 @@ squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @squareSimple___UM_un_3C_vyU
 	.long	6                       # 0x6
 	.long	7                       # 0x7
 	.long	7                       # 0x7
+.LCPI1_3:
+	.zero	32
 	.text
 	.p2align	4, 0x90
 	.type	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu,@function
@@ -623,164 +589,144 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
                                         # kill: def $edx killed $edx def $rdx
 	movq	%rsi, %r13
 	movq	%rdi, %rbx
-	movl	%edx, %r14d
-	shrl	%r14d
+	movl	%edx, %r9d
+	shrl	%r9d
 	movq	%rdx, %rax
-	movq	%rdx, 160(%rsp)         # 8-byte Spill
-                                        # kill: def $edx killed $edx killed $rdx def $rdx
-	subl	%r14d, %edx
-	movq	%rdx, %r15
-	shlq	$7, %r15
-	leaq	(%rsi,%r15), %r12
-	cmpl	%edx, %r14d
-	jne	.LBB1_19
+	movq	%rdx, 56(%rsp)          # 8-byte Spill
+	subl	%r9d, %eax
+	movq	%rax, %rcx
+	shlq	$7, %rcx
+	movq	%rcx, 48(%rsp)          # 8-byte Spill
+	leaq	(%rsi,%rcx), %r10
+	movq	%rax, %r12
+	cmpl	%eax, %r9d
+	jne	.LBB1_20
 # %bb.1:                                # %for_test.i.preheader
-	leal	-1(%r14), %eax
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
-	vpbroadcastq	.LCPI1_0(%rip), %ymm0 # ymm0 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
-	vmovdqa	%ymm0, 96(%rsp)         # 32-byte Spill
-                                        # implicit-def: $xmm1
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm10, %xmm10, %xmm10
+	leal	-1(%r9), %eax
+	vbroadcastsd	.LCPI1_0(%rip), %ymm0 # ymm0 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
+	vmovaps	%ymm0, 160(%rsp)        # 32-byte Spill
+                                        # implicit-def: $ymm0
+                                        # kill: killed $ymm0
+                                        # implicit-def: $ymm14
+	vxorps	%xmm7, %xmm7, %xmm7
+	vxorps	%xmm8, %xmm8, %xmm8
 	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm0, 64(%rsp)         # 32-byte Spill
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	jmp	.LBB1_2
 	.p2align	4, 0x90
+.LBB1_19:                               # %no_return43.i
+                                        #   in Loop: Header=BB1_2 Depth=1
+	vmovaps	%ymm1, %ymm14
+	vmovaps	%ymm15, 128(%rsp)       # 32-byte Spill
+	vmovaps	64(%rsp), %ymm0         # 32-byte Reload
+	vandnps	%ymm0, %ymm7, %ymm0
+	vmovaps	%ymm0, 64(%rsp)         # 32-byte Spill
+	vmovaps	96(%rsp), %ymm1         # 32-byte Reload
+	vandnps	%ymm1, %ymm8, %ymm1
+	addl	$-1, %eax
 .LBB1_2:                                # %for_test.i
                                         # =>This Inner Loop Header: Depth=1
 	movl	%eax, %ecx
 	shlq	$7, %rcx
-	vmovdqa	96(%rsp), %ymm0         # 32-byte Reload
-	vpxor	96(%r13,%rcx), %ymm0, %ymm11
-	vpxor	96(%r12,%rcx), %ymm0, %ymm12
-	vpcmpgtq	%ymm11, %ymm12, %ymm2
-	vextracti128	$1, %ymm2, %xmm4
-	vpxor	64(%r13,%rcx), %ymm0, %ymm13
-	vpackssdw	%xmm4, %xmm2, %xmm2
-	vpxor	64(%r12,%rcx), %ymm0, %ymm14
-	vpcmpgtq	%ymm13, %ymm14, %ymm4
-	vextracti128	$1, %ymm4, %xmm6
-	vpackssdw	%xmm6, %xmm4, %xmm4
-	vpxor	32(%r13,%rcx), %ymm0, %ymm15
-	vinserti128	$1, %xmm2, %ymm4, %ymm5
-	vpxor	32(%r12,%rcx), %ymm0, %ymm2
-	vpcmpgtq	%ymm15, %ymm2, %ymm4
-	vextracti128	$1, %ymm4, %xmm6
-	vpackssdw	%xmm6, %xmm4, %xmm7
-	vpxor	(%r13,%rcx), %ymm0, %ymm6
-	vpxor	(%r12,%rcx), %ymm0, %ymm4
-	vpcmpgtq	%ymm6, %ymm4, %ymm0
-	vextracti128	$1, %ymm0, %xmm8
-	vpackssdw	%xmm8, %xmm0, %xmm0
-	vinserti128	$1, %xmm7, %ymm0, %ymm0
-	vmovdqa	%ymm3, 64(%rsp)         # 32-byte Spill
-	vpand	%ymm3, %ymm0, %ymm0
-	vpand	128(%rsp), %ymm5, %ymm5 # 32-byte Folded Reload
-	vextracti128	$1, %ymm5, %xmm7
-	vmovdqa	.LCPI1_1(%rip), %xmm3   # xmm3 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm3, %xmm7, %xmm7
-	vpshufb	%xmm3, %xmm5, %xmm3
-	vpunpckldq	%xmm7, %xmm3, %xmm8 # xmm8 = xmm3[0],xmm7[0],xmm3[1],xmm7[1]
-	vextracti128	$1, %ymm0, %xmm7
-	vmovdqa	.LCPI1_2(%rip), %xmm3   # xmm3 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm3, %xmm7, %xmm7
-	vpshufb	%xmm3, %xmm0, %xmm3
-	vpunpckldq	%xmm7, %xmm3, %xmm3 # xmm3 = xmm3[0],xmm7[0],xmm3[1],xmm7[1]
-	vpblendd	$12, %xmm8, %xmm3, %xmm3 # xmm3 = xmm3[0,1],xmm8[2,3]
-	vpsllw	$7, %xmm3, %xmm3
-	vpand	.LCPI1_3(%rip), %xmm3, %xmm3
-	vpxor	%xmm7, %xmm7, %xmm7
-	vpcmpgtb	%xmm3, %xmm7, %xmm3
-	vpor	%xmm1, %xmm3, %xmm1
-	vpor	%ymm5, %ymm10, %ymm10
-	vpor	%ymm0, %ymm9, %ymm9
-	vmovmskps	%ymm9, %ecx
-	vmovmskps	%ymm10, %esi
-	shll	$8, %esi
-	orl	%ecx, %esi
-	cmpl	$65535, %esi            # imm = 0xFFFF
-	je	.LBB1_5
-# %bb.3:                                # %no_return.i
-                                        #   in Loop: Header=BB1_2 Depth=1
-	vpcmpgtq	%ymm2, %ymm15, %ymm0
-	vextracti128	$1, %ymm0, %xmm2
-	vpackssdw	%xmm2, %xmm0, %xmm0
-	vpcmpgtq	%ymm4, %ymm6, %ymm2
+	vmovdqa	160(%rsp), %ymm0        # 32-byte Reload
+	vpxor	32(%r13,%rcx), %ymm0, %ymm9
+	vpxor	32(%r10,%rcx), %ymm0, %ymm10
+	vpcmpgtq	%ymm9, %ymm10, %ymm2
 	vextracti128	$1, %ymm2, %xmm3
 	vpackssdw	%xmm3, %xmm2, %xmm2
-	vandnps	64(%rsp), %ymm9, %ymm3  # 32-byte Folded Reload
-	vpcmpgtq	%ymm12, %ymm11, %ymm4
-	vextracti128	$1, %ymm4, %xmm5
-	vpackssdw	%xmm5, %xmm4, %xmm4
-	vandnps	128(%rsp), %ymm10, %ymm5 # 32-byte Folded Reload
-	vpcmpgtq	%ymm14, %ymm13, %ymm6
-	vpxor	%xmm11, %xmm11, %xmm11
-	vinserti128	$1, %xmm0, %ymm2, %ymm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	vblendvps	%ymm7, %ymm3, %ymm8, %ymm7
-	vblendvps	%xmm2, %xmm3, %xmm11, %xmm2
-	vextractf128	$1, %ymm3, %xmm3
-	vblendvps	%xmm0, %xmm3, %xmm11, %xmm0
-	vextracti128	$1, %ymm6, %xmm3
-	vpackssdw	%xmm3, %xmm6, %xmm3
-	vinserti128	$1, %xmm4, %ymm3, %ymm6
-	vblendvps	%ymm6, %ymm5, %ymm8, %ymm6
-	vblendvps	%xmm3, %xmm5, %xmm11, %xmm3
-	vextractf128	$1, %ymm5, %xmm5
-	vblendvps	%xmm4, %xmm5, %xmm11, %xmm4
-	vmovdqa	.LCPI1_2(%rip), %xmm5   # xmm5 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm5, %xmm2, %xmm2
-	vpshufb	%xmm5, %xmm0, %xmm0
-	vpunpckldq	%xmm0, %xmm2, %xmm0 # xmm0 = xmm2[0],xmm0[0],xmm2[1],xmm0[1]
-	vmovdqa	.LCPI1_1(%rip), %xmm5   # xmm5 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm5, %xmm3, %xmm2
-	vpshufb	%xmm5, %xmm4, %xmm3
-	vpunpckldq	%xmm3, %xmm2, %xmm2 # xmm2 = xmm2[0],xmm3[0],xmm2[1],xmm3[1]
-	vpblendd	$12, %xmm2, %xmm0, %xmm0 # xmm0 = xmm0[0,1],xmm2[2,3]
-	vpsllw	$7, %xmm0, %xmm0
-	vpand	.LCPI1_3(%rip), %xmm0, %xmm0
-	vpcmpgtb	%xmm0, %xmm11, %xmm0
-	vpandn	%xmm1, %xmm0, %xmm1
-	vorps	%ymm7, %ymm9, %ymm9
-	vorps	%ymm6, %ymm10, %ymm10
-	vmovmskps	%ymm9, %ecx
-	vmovmskps	%ymm10, %esi
-	shll	$8, %esi
-	orl	%ecx, %esi
-	cmpl	$65535, %esi            # imm = 0xFFFF
-	je	.LBB1_5
-# %bb.4:                                # %no_return43.i
+	vpxor	(%r13,%rcx), %ymm0, %ymm11
+	vpxor	(%r10,%rcx), %ymm0, %ymm12
+	vpcmpgtq	%ymm11, %ymm12, %ymm3
+	vextracti128	$1, %ymm3, %xmm5
+	vpackssdw	%xmm5, %xmm3, %xmm3
+	vinserti128	$1, %xmm2, %ymm3, %ymm3
+	vpxor	96(%r13,%rcx), %ymm0, %ymm13
+	vpxor	96(%r10,%rcx), %ymm0, %ymm4
+	vpcmpgtq	%ymm13, %ymm4, %ymm2
+	vextracti128	$1, %ymm2, %xmm5
+	vpxor	64(%r13,%rcx), %ymm0, %ymm15
+	vpackssdw	%xmm5, %xmm2, %xmm5
+	vpxor	64(%r10,%rcx), %ymm0, %ymm2
+	vpcmpgtq	%ymm15, %ymm2, %ymm6
+	vextracti128	$1, %ymm6, %xmm0
+	vpackssdw	%xmm0, %xmm6, %xmm0
+	vinserti128	$1, %xmm5, %ymm0, %ymm0
+	vmovdqa	%ymm1, 96(%rsp)         # 32-byte Spill
+	vpand	%ymm1, %ymm0, %ymm0
+	vmovaps	%ymm14, %ymm1
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vblendvps	%ymm0, %ymm5, %ymm14, %ymm1
+	vorps	%ymm8, %ymm0, %ymm8
+	vpand	64(%rsp), %ymm3, %ymm0  # 32-byte Folded Reload
+	vmovaps	128(%rsp), %ymm14       # 32-byte Reload
+	vblendvps	%ymm0, %ymm5, %ymm14, %ymm14
+	vorps	%ymm7, %ymm0, %ymm7
+	vmovmskps	%ymm7, %ecx
+	vmovmskps	%ymm8, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	cmpl	$65535, %edx            # imm = 0xFFFF
+	je	.LBB1_3
+# %bb.18:                               # %no_return.i
                                         #   in Loop: Header=BB1_2 Depth=1
-	vmovaps	64(%rsp), %ymm3         # 32-byte Reload
-	vandnps	%ymm3, %ymm9, %ymm3
-	vmovaps	128(%rsp), %ymm0        # 32-byte Reload
-	vandnps	%ymm0, %ymm10, %ymm0
-	vmovaps	%ymm0, 128(%rsp)        # 32-byte Spill
-	decl	%eax
-	jmp	.LBB1_2
-.LBB1_19:                               # %if_else
-	movl	%r14d, %r9d
-	shlq	$7, %r9
-	vmovdqu	(%r13,%r9), %ymm14
-	vmovdqu	32(%r13,%r9), %ymm15
-	vmovdqu	64(%r13,%r9), %ymm2
-	vmovdqu	96(%r13,%r9), %ymm0
+	vpcmpgtq	%ymm10, %ymm9, %ymm0
+	vextracti128	$1, %ymm0, %xmm3
+	vpackssdw	%xmm3, %xmm0, %xmm0
+	vpcmpgtq	%ymm12, %ymm11, %ymm3
+	vextracti128	$1, %ymm3, %xmm5
+	vpackssdw	%xmm5, %xmm3, %xmm3
+	vpcmpgtq	%ymm4, %ymm13, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpgtq	%ymm2, %ymm15, %ymm2
+	vextracti128	$1, %ymm2, %xmm6
+	vpackssdw	%xmm6, %xmm2, %xmm2
+	vinserti128	$1, %xmm5, %ymm2, %ymm2
+	vandnps	96(%rsp), %ymm8, %ymm5  # 32-byte Folded Reload
 	vpxor	%xmm4, %xmm4, %xmm4
-	vmovdqa	%ymm0, 288(%rsp)        # 32-byte Spill
-	vpcmpeqq	%ymm4, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm5, %ymm4, %ymm2
+	vinserti128	$1, %xmm0, %ymm3, %ymm0
+	vandnps	64(%rsp), %ymm7, %ymm3  # 32-byte Folded Reload
+	vblendvps	%ymm0, %ymm3, %ymm4, %ymm0
+	vblendvps	%ymm0, %ymm4, %ymm14, %ymm14
+	vorps	%ymm7, %ymm0, %ymm7
+	vblendvps	%ymm2, %ymm4, %ymm1, %ymm1
+	vorps	%ymm8, %ymm2, %ymm8
+	vmovmskps	%ymm7, %ecx
+	vmovmskps	%ymm8, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	cmpl	$65535, %edx            # imm = 0xFFFF
+	vmovaps	%ymm14, %ymm15
+	jne	.LBB1_19
+	jmp	.LBB1_4
+.LBB1_20:                               # %if_else
+	movl	%r9d, %eax
+	shlq	$7, %rax
+	vmovdqu	(%r13,%rax), %ymm4
+	vmovdqu	32(%r13,%rax), %ymm5
+	vmovdqu	64(%r13,%rax), %ymm2
+	vmovdqu	96(%r13,%rax), %ymm0
+	vpxor	%xmm6, %xmm6, %xmm6
+	vmovdqa	%ymm0, 192(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm6, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm1
-	vmovdqa	%ymm2, 192(%rsp)        # 32-byte Spill
-	vpcmpeqq	%ymm4, %ymm2, %ymm2
+	vmovdqa	%ymm2, 224(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm6, %ymm2, %ymm2
 	vextracti128	$1, %ymm2, %xmm3
 	vpackssdw	%xmm3, %xmm2, %xmm3
-	vinserti128	$1, %xmm1, %ymm3, %ymm7
-	vpcmpeqq	%ymm4, %ymm15, %ymm1
+	vinserti128	$1, %xmm1, %ymm3, %ymm12
+	vmovdqa	%ymm5, 256(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm6, %ymm5, %ymm1
 	vextracti128	$1, %ymm1, %xmm3
 	vpackssdw	%xmm3, %xmm1, %xmm3
-	vpcmpeqq	%ymm4, %ymm14, %ymm4
+	vmovdqa	%ymm4, 288(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm6, %ymm4, %ymm4
 	vextracti128	$1, %ymm4, %xmm5
 	vpackssdw	%xmm5, %xmm4, %xmm5
-	vinserti128	$1, %xmm3, %ymm5, %ymm6
+	vinserti128	$1, %xmm3, %ymm5, %ymm11
 	vpcmpeqd	%ymm5, %ymm5, %ymm5
 	vpxor	%ymm5, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm3
@@ -796,355 +742,353 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	vextracti128	$1, %ymm2, %xmm3
 	vpackssdw	%xmm3, %xmm2, %xmm2
 	vinserti128	$1, %xmm1, %ymm2, %ymm1
-	vmovmskps	%ymm1, %eax
-	vmovmskps	%ymm0, %ecx
+	vmovmskps	%ymm1, %ecx
+	vmovmskps	%ymm0, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	cmpl	$65535, %edx            # imm = 0xFFFF
+	je	.LBB1_25
+# %bb.21:                               # %for_test.i528.preheader
+	vmovdqa	%ymm11, 160(%rsp)       # 32-byte Spill
+	vmovmskps	%ymm11, %edx
+	vmovdqa	%ymm12, 352(%rsp)       # 32-byte Spill
+	vmovmskps	%ymm12, %ecx
 	shll	$8, %ecx
-	orl	%eax, %ecx
-	cmpl	$65535, %ecx            # imm = 0xFFFF
-	je	.LBB1_23
-# %bb.20:                               # %for_test.i377.preheader
-	vmovdqa	%ymm15, 256(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm14, 224(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm6, 320(%rsp)        # 32-byte Spill
-	vmovmskps	%ymm6, %eax
-	vmovdqa	%ymm7, 96(%rsp)         # 32-byte Spill
-	vmovmskps	%ymm7, %ecx
-	shlq	$8, %rcx
-	orq	%rax, %rcx
-	leal	-1(%r14), %edi
+	orl	%edx, %ecx
+	leal	-1(%r9), %edx
 	vpbroadcastq	.LCPI1_0(%rip), %ymm0 # ymm0 = [9223372036854775808,9223372036854775808,9223372036854775808,9223372036854775808]
-	vmovdqa	%ymm0, 352(%rsp)        # 32-byte Spill
-                                        # implicit-def: $xmm8
-	vpxor	%xmm15, %xmm15, %xmm15
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm0, 320(%rsp)        # 32-byte Spill
+                                        # implicit-def: $ymm8
+                                        # implicit-def: $ymm9
+	vxorps	%xmm13, %xmm13, %xmm13
+	vxorps	%xmm14, %xmm14, %xmm14
+	vpcmpeqd	%ymm10, %ymm10, %ymm10
 	vpcmpeqd	%ymm0, %ymm0, %ymm0
 	vmovdqa	%ymm0, 64(%rsp)         # 32-byte Spill
+	jmp	.LBB1_22
 	.p2align	4, 0x90
-.LBB1_21:                               # %for_test.i377
+.LBB1_89:                               # %no_return43.i552
+                                        #   in Loop: Header=BB1_22 Depth=1
+	vmovaps	96(%rsp), %ymm10        # 32-byte Reload
+	vandnps	%ymm10, %ymm13, %ymm10
+	vmovaps	64(%rsp), %ymm0         # 32-byte Reload
+	vandnps	%ymm0, %ymm14, %ymm0
+	vmovaps	%ymm0, 64(%rsp)         # 32-byte Spill
+	addl	$-1, %edx
+.LBB1_22:                               # %for_test.i528
                                         # =>This Inner Loop Header: Depth=1
-	movl	%edi, %eax
-	shlq	$7, %rax
-	vmovdqa	352(%rsp), %ymm0        # 32-byte Reload
-	vpxor	96(%r13,%rax), %ymm0, %ymm11
-	vpxor	96(%r12,%rax), %ymm0, %ymm12
-	vpcmpgtq	%ymm11, %ymm12, %ymm1
-	vextracti128	$1, %ymm1, %xmm3
-	vpxor	64(%r13,%rax), %ymm0, %ymm13
-	vpxor	64(%r12,%rax), %ymm0, %ymm9
-	vpackssdw	%xmm3, %xmm1, %xmm1
-	vpcmpgtq	%ymm13, %ymm9, %ymm3
-	vextracti128	$1, %ymm3, %xmm4
-	vpackssdw	%xmm4, %xmm3, %xmm5
-	vpxor	32(%r13,%rax), %ymm0, %ymm3
-	vpxor	32(%r12,%rax), %ymm0, %ymm4
-	vinserti128	$1, %xmm1, %ymm5, %ymm2
-	vpcmpgtq	%ymm3, %ymm4, %ymm1
-	vextracti128	$1, %ymm1, %xmm5
-	vpackssdw	%xmm5, %xmm1, %xmm6
-	vpxor	(%r13,%rax), %ymm0, %ymm5
-	vpxor	(%r12,%rax), %ymm0, %ymm1
-	vpcmpgtq	%ymm5, %ymm1, %ymm7
-	vextracti128	$1, %ymm7, %xmm14
-	vpackssdw	%xmm14, %xmm7, %xmm7
-	vinserti128	$1, %xmm6, %ymm7, %ymm6
-	vpand	64(%rsp), %ymm6, %ymm6  # 32-byte Folded Reload
-	vpand	128(%rsp), %ymm2, %ymm2 # 32-byte Folded Reload
-	vextracti128	$1, %ymm2, %xmm7
-	vmovdqa	.LCPI1_1(%rip), %xmm0   # xmm0 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm0, %xmm7, %xmm7
-	vpshufb	%xmm0, %xmm2, %xmm0
-	vpunpckldq	%xmm7, %xmm0, %xmm14 # xmm14 = xmm0[0],xmm7[0],xmm0[1],xmm7[1]
-	vextracti128	$1, %ymm6, %xmm7
-	vmovdqa	.LCPI1_2(%rip), %xmm0   # xmm0 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm0, %xmm7, %xmm7
-	vpshufb	%xmm0, %xmm6, %xmm0
-	vpunpckldq	%xmm7, %xmm0, %xmm0 # xmm0 = xmm0[0],xmm7[0],xmm0[1],xmm7[1]
-	vpblendd	$12, %xmm14, %xmm0, %xmm0 # xmm0 = xmm0[0,1],xmm14[2,3]
-	vpsllw	$7, %xmm0, %xmm0
-	vmovdqa	.LCPI1_3(%rip), %xmm14  # xmm14 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-	vpand	%xmm0, %xmm14, %xmm0
-	vpxor	%xmm14, %xmm14, %xmm14
-	vpcmpgtb	%xmm0, %xmm14, %xmm0
-	vpor	%xmm0, %xmm8, %xmm8
-	vmovdqa	96(%rsp), %ymm7         # 32-byte Reload
-	vpand	%ymm7, %ymm2, %ymm0
-	vpor	%ymm0, %ymm10, %ymm10
-	vmovdqa	320(%rsp), %ymm2        # 32-byte Reload
-	vpand	%ymm2, %ymm6, %ymm0
-	vmovdqa	%ymm2, %ymm6
-	vpor	%ymm0, %ymm15, %ymm15
-	vmovmskps	%ymm15, %eax
-	vmovmskps	%ymm10, %esi
-	shlq	$8, %rsi
-	orq	%rax, %rsi
-	cmpq	%rsi, %rcx
-	je	.LBB1_22
-# %bb.27:                               # %no_return.i394
-                                        #   in Loop: Header=BB1_21 Depth=1
-	vpcmpgtq	%ymm4, %ymm3, %ymm0
-	vextracti128	$1, %ymm0, %xmm2
-	vpackssdw	%xmm2, %xmm0, %xmm0
-	vpcmpgtq	%ymm1, %ymm5, %ymm1
+	movl	%edx, %esi
+	shlq	$7, %rsi
+	vmovdqa	320(%rsp), %ymm6        # 32-byte Reload
+	vpxor	32(%r13,%rsi), %ymm6, %ymm15
+	vpxor	32(%r10,%rsi), %ymm6, %ymm0
+	vpcmpgtq	%ymm15, %ymm0, %ymm1
 	vextracti128	$1, %ymm1, %xmm2
-	vpackssdw	%xmm2, %xmm1, %xmm1
-	vpcmpgtq	%ymm12, %ymm11, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vmovaps	64(%rsp), %ymm11        # 32-byte Reload
-	vandnps	%ymm11, %ymm15, %ymm3
-	vpcmpgtq	%ymm9, %ymm13, %ymm4
+	vpackssdw	%xmm2, %xmm1, %xmm3
+	vpxor	(%r13,%rsi), %ymm6, %ymm1
+	vpxor	(%r10,%rsi), %ymm6, %ymm2
+	vpcmpgtq	%ymm1, %ymm2, %ymm4
 	vextracti128	$1, %ymm4, %xmm5
 	vpackssdw	%xmm5, %xmm4, %xmm4
-	vinserti128	$1, %xmm0, %ymm1, %ymm5
-	vpxor	%xmm9, %xmm9, %xmm9
-	vblendvps	%ymm5, %ymm3, %ymm9, %ymm5
-	vblendvps	%xmm1, %xmm3, %xmm14, %xmm1
-	vextractf128	$1, %ymm3, %xmm3
-	vblendvps	%xmm0, %xmm3, %xmm14, %xmm0
-	vandnps	128(%rsp), %ymm10, %ymm3 # 32-byte Folded Reload
-	vmovdqa	%ymm7, %ymm12
-	vmovdqa	.LCPI1_2(%rip), %xmm7   # xmm7 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm7, %xmm1, %xmm1
-	vpshufb	%xmm7, %xmm0, %xmm0
-	vpunpckldq	%xmm0, %xmm1, %xmm0 # xmm0 = xmm1[0],xmm0[0],xmm1[1],xmm0[1]
-	vinserti128	$1, %xmm2, %ymm4, %ymm1
-	vblendvps	%ymm1, %ymm3, %ymm9, %ymm1
-	vblendvps	%xmm4, %xmm3, %xmm14, %xmm4
-	vextractf128	$1, %ymm3, %xmm3
-	vblendvps	%xmm2, %xmm3, %xmm14, %xmm2
-	vmovdqa	.LCPI1_1(%rip), %xmm3   # xmm3 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vmovdqa	%ymm6, %ymm9
-	vmovdqa	%xmm3, %xmm6
-	vpshufb	%xmm3, %xmm4, %xmm3
-	vpshufb	%xmm6, %xmm2, %xmm2
-	vpunpckldq	%xmm2, %xmm3, %xmm2 # xmm2 = xmm3[0],xmm2[0],xmm3[1],xmm2[1]
-	vpblendd	$12, %xmm2, %xmm0, %xmm0 # xmm0 = xmm0[0,1],xmm2[2,3]
-	vpsllw	$7, %xmm0, %xmm0
-	vpand	.LCPI1_3(%rip), %xmm0, %xmm0
-	vpcmpgtb	%xmm0, %xmm14, %xmm0
-	vpandn	%xmm8, %xmm0, %xmm8
-	vandps	%ymm5, %ymm9, %ymm0
-	vorps	%ymm0, %ymm15, %ymm15
-	vandps	%ymm1, %ymm12, %ymm0
-	vorps	%ymm0, %ymm10, %ymm10
-	vmovmskps	%ymm15, %eax
-	vmovmskps	%ymm10, %esi
-	shlq	$8, %rsi
-	orq	%rax, %rsi
-	cmpq	%rsi, %rcx
-	je	.LBB1_28
-# %bb.29:                               # %no_return43.i400
-                                        #   in Loop: Header=BB1_21 Depth=1
-	vmovaps	%ymm11, %ymm0
-	vandnps	%ymm11, %ymm15, %ymm0
-	vmovaps	%ymm0, 64(%rsp)         # 32-byte Spill
-	vmovaps	128(%rsp), %ymm1        # 32-byte Reload
-	vandnps	%ymm1, %ymm10, %ymm1
-	vmovaps	%ymm1, 128(%rsp)        # 32-byte Spill
-	decl	%edi
-	jmp	.LBB1_21
-.LBB1_5:                                # %lessThan___un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
-	vpshufd	$78, %xmm1, %xmm0       # xmm0 = xmm1[2,3,0,1]
-	vpmovsxbd	%xmm0, %ymm0
-	vpmovsxbd	%xmm1, %ymm1
-	vmovmskps	%ymm1, %r9d
-	vmovmskps	%ymm0, %r10d
-	movl	%r10d, %eax
-	shll	$8, %eax
-	orl	%r9d, %eax
-	je	.LBB1_11
-# %bb.6:                                # %lessThan___un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
-	testl	%r14d, %r14d
-	je	.LBB1_11
-# %bb.7:                                # %for_loop.i548.lr.ph
-	vmovaps	.LCPI1_4(%rip), %ymm4   # ymm4 = [0,0,1,1,2,2,3,3]
-	vpermps	%ymm1, %ymm4, %ymm2
-	vmovaps	.LCPI1_5(%rip), %ymm5   # ymm5 = [4,4,5,5,6,6,7,7]
-	vpermps	%ymm1, %ymm5, %ymm3
-	vpermps	%ymm0, %ymm4, %ymm4
-	vpermps	%ymm0, %ymm5, %ymm5
-	movl	%r14d, %eax
-	notl	%eax
-	movl	%r14d, %r8d
-	andl	$1, %r8d
-	addl	160(%rsp), %eax         # 4-byte Folded Reload
-	jne	.LBB1_75
-# %bb.8:
-	vxorps	%xmm7, %xmm7, %xmm7
-	xorl	%ecx, %ecx
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm10, %xmm10, %xmm10
-	jmp	.LBB1_9
-.LBB1_75:                               # %for_loop.i548.lr.ph.new
-	leaq	(%r15,%r13), %rdi
-	addq	$128, %rdi
-	movl	%r14d, %esi
-	subl	%r8d, %esi
-	vxorps	%xmm6, %xmm6, %xmm6
-	xorl	%eax, %eax
-	xorl	%ecx, %ecx
-	vxorps	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm10, %xmm10, %xmm10
-	.p2align	4, 0x90
-.LBB1_76:                               # %for_loop.i548
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqu	-128(%rdi,%rax), %ymm11
-	vmovdqu	-96(%rdi,%rax), %ymm12
-	vmovdqu	-64(%rdi,%rax), %ymm13
-	vmovdqu	-32(%rdi,%rax), %ymm14
-	vpsubq	96(%r13,%rax), %ymm14, %ymm14
-	vpsubq	64(%r13,%rax), %ymm13, %ymm13
-	vpaddq	%ymm10, %ymm14, %ymm10
-	vpaddq	%ymm9, %ymm13, %ymm9
-	vpsubq	32(%r13,%rax), %ymm12, %ymm12
-	vpaddq	%ymm8, %ymm12, %ymm8
-	vpsubq	(%r13,%rax), %ymm11, %ymm11
-	vpaddq	%ymm7, %ymm11, %ymm7
-	vpblendd	$170, %ymm6, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm6[1],ymm10[2],ymm6[3],ymm10[4],ymm6[5],ymm10[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm7, %ymm14 # ymm14 = ymm7[0],ymm6[1],ymm7[2],ymm6[3],ymm7[4],ymm6[5],ymm7[6],ymm6[7]
-	vmaskmovpd	%ymm14, %ymm2, (%rbx,%rax)
-	vmaskmovpd	%ymm13, %ymm3, 32(%rbx,%rax)
-	vmaskmovpd	%ymm12, %ymm4, 64(%rbx,%rax)
-	vmaskmovpd	%ymm11, %ymm5, 96(%rbx,%rax)
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vpsrad	$31, %ymm9, %ymm11
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
-	vpsrad	$31, %ymm8, %ymm11
-	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm11[1],ymm8[2],ymm11[3],ymm8[4],ymm11[5],ymm8[6],ymm11[7]
-	vpsrad	$31, %ymm7, %ymm11
-	vpshufd	$245, %ymm7, %ymm7      # ymm7 = ymm7[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm11[1],ymm7[2],ymm11[3],ymm7[4],ymm11[5],ymm7[6],ymm11[7]
-	vmovdqu	(%rdi,%rax), %ymm11
-	vmovdqu	32(%rdi,%rax), %ymm12
-	vmovdqu	64(%rdi,%rax), %ymm13
-	vmovdqu	96(%rdi,%rax), %ymm14
-	vpsubq	224(%r13,%rax), %ymm14, %ymm14
-	vpsubq	192(%r13,%rax), %ymm13, %ymm13
-	vpaddq	%ymm10, %ymm14, %ymm10
-	vpaddq	%ymm9, %ymm13, %ymm9
-	vpsubq	160(%r13,%rax), %ymm12, %ymm12
-	vpaddq	%ymm8, %ymm12, %ymm8
-	vpsubq	128(%r13,%rax), %ymm11, %ymm11
-	vpaddq	%ymm7, %ymm11, %ymm7
-	vpblendd	$170, %ymm6, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm6[1],ymm10[2],ymm6[3],ymm10[4],ymm6[5],ymm10[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
-	vpblendd	$170, %ymm6, %ymm7, %ymm14 # ymm14 = ymm7[0],ymm6[1],ymm7[2],ymm6[3],ymm7[4],ymm6[5],ymm7[6],ymm6[7]
-	vmaskmovpd	%ymm14, %ymm2, 128(%rbx,%rax)
-	vmaskmovpd	%ymm13, %ymm3, 160(%rbx,%rax)
-	vmaskmovpd	%ymm12, %ymm4, 192(%rbx,%rax)
-	vmaskmovpd	%ymm11, %ymm5, 224(%rbx,%rax)
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vpsrad	$31, %ymm9, %ymm11
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
-	vpsrad	$31, %ymm8, %ymm11
-	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm11[1],ymm8[2],ymm11[3],ymm8[4],ymm11[5],ymm8[6],ymm11[7]
-	vpsrad	$31, %ymm7, %ymm11
-	vpshufd	$245, %ymm7, %ymm7      # ymm7 = ymm7[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm7, %ymm7 # ymm7 = ymm7[0],ymm11[1],ymm7[2],ymm11[3],ymm7[4],ymm11[5],ymm7[6],ymm11[7]
-	addq	$2, %rcx
-	addq	$256, %rax              # imm = 0x100
-	cmpl	%ecx, %esi
-	jne	.LBB1_76
-.LBB1_9:                                # %for_test.i536.safe_if_after_true.loopexit_crit_edge.unr-lcssa
-	testl	%r8d, %r8d
-	je	.LBB1_11
-# %bb.10:                               # %for_loop.i548.epil.preheader
-	shlq	$7, %rcx
-	vmovdqu	(%r12,%rcx), %ymm6
-	vmovdqu	32(%r12,%rcx), %ymm11
-	vmovdqu	96(%r12,%rcx), %ymm12
-	vpsubq	96(%r13,%rcx), %ymm12, %ymm12
-	vmovdqu	64(%r12,%rcx), %ymm13
-	vpaddq	%ymm10, %ymm12, %ymm10
-	vpsubq	64(%r13,%rcx), %ymm13, %ymm12
-	vpaddq	%ymm9, %ymm12, %ymm9
-	vpsubq	32(%r13,%rcx), %ymm11, %ymm11
-	vpaddq	%ymm8, %ymm11, %ymm8
-	vpsubq	(%r13,%rcx), %ymm6, %ymm6
-	vpaddq	%ymm7, %ymm6, %ymm6
-	vpxor	%xmm7, %xmm7, %xmm7
-	vpblendd	$170, %ymm7, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm7[1],ymm10[2],ymm7[3],ymm10[4],ymm7[5],ymm10[6],ymm7[7]
-	vpblendd	$170, %ymm7, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm7[1],ymm9[2],ymm7[3],ymm9[4],ymm7[5],ymm9[6],ymm7[7]
-	vpblendd	$170, %ymm7, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm7[1],ymm8[2],ymm7[3],ymm8[4],ymm7[5],ymm8[6],ymm7[7]
-	vpblendd	$170, %ymm7, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7]
-	vmaskmovpd	%ymm6, %ymm2, (%rbx,%rcx)
-	vmaskmovpd	%ymm8, %ymm3, 32(%rbx,%rcx)
-	vmaskmovpd	%ymm9, %ymm4, 64(%rbx,%rcx)
-	vmaskmovpd	%ymm10, %ymm5, 96(%rbx,%rcx)
-.LBB1_11:                               # %safe_if_after_true
-	xorl	$255, %r9d
-	xorl	$255, %r10d
-	shll	$8, %r10d
-	orl	%r9d, %r10d
-	je	.LBB1_17
-# %bb.12:                               # %safe_if_after_true
-	testl	%r14d, %r14d
-	je	.LBB1_17
-# %bb.13:                               # %for_loop.i525.lr.ph
-	vpcmpeqd	%ymm2, %ymm2, %ymm2
-	vpxor	%ymm2, %ymm1, %ymm1
-	vpxor	%ymm2, %ymm0, %ymm3
-	vmovdqa	.LCPI1_4(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm1, %ymm2, %ymm0
-	vmovdqa	.LCPI1_5(%rip), %ymm4   # ymm4 = [4,4,5,5,6,6,7,7]
-	vpermd	%ymm1, %ymm4, %ymm1
-	vpermd	%ymm3, %ymm2, %ymm2
-	vpermd	%ymm3, %ymm4, %ymm3
-	movl	%r14d, %eax
-	notl	%eax
-	movl	%r14d, %r8d
-	andl	$1, %r8d
-	addl	160(%rsp), %eax         # 4-byte Folded Reload
-	jne	.LBB1_77
-# %bb.14:
-	vpxor	%xmm5, %xmm5, %xmm5
-	xorl	%eax, %eax
-	vxorps	%xmm6, %xmm6, %xmm6
-	vxorps	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	jmp	.LBB1_15
-.LBB1_77:                               # %for_loop.i525.lr.ph.new
-	leaq	(%r15,%r13), %rcx
-	addq	$128, %rcx
-	movl	%r14d, %esi
-	subl	%r8d, %esi
+	vinserti128	$1, %xmm3, %ymm4, %ymm3
+	vmovdqa	%ymm3, 128(%rsp)        # 32-byte Spill
+	vpxor	96(%r13,%rsi), %ymm6, %ymm3
+	vpxor	96(%r10,%rsi), %ymm6, %ymm4
+	vpcmpgtq	%ymm3, %ymm4, %ymm11
+	vextracti128	$1, %ymm11, %xmm12
+	vpxor	64(%r13,%rsi), %ymm6, %ymm5
+	vpxor	64(%r10,%rsi), %ymm6, %ymm7
+	vpackssdw	%xmm12, %xmm11, %xmm11
+	vpcmpgtq	%ymm5, %ymm7, %ymm12
+	vextracti128	$1, %ymm12, %xmm6
+	vpackssdw	%xmm6, %xmm12, %xmm6
+	vinserti128	$1, %xmm11, %ymm6, %ymm6
+	vmovdqa	%ymm10, 96(%rsp)        # 32-byte Spill
+	vpand	128(%rsp), %ymm10, %ymm12 # 32-byte Folded Reload
+	vpcmpeqd	%ymm11, %ymm11, %ymm11
+	vblendvps	%ymm12, %ymm11, %ymm8, %ymm8
+	vpand	64(%rsp), %ymm6, %ymm6  # 32-byte Folded Reload
+	vblendvps	%ymm6, %ymm11, %ymm9, %ymm9
+	vmovaps	352(%rsp), %ymm10       # 32-byte Reload
+	vandps	%ymm10, %ymm6, %ymm6
+	vorps	%ymm14, %ymm6, %ymm14
+	vmovaps	160(%rsp), %ymm11       # 32-byte Reload
+	vandps	%ymm11, %ymm12, %ymm6
+	vorps	%ymm13, %ymm6, %ymm13
+	vmovmskps	%ymm13, %esi
+	vmovmskps	%ymm14, %edi
+	shll	$8, %edi
+	orl	%esi, %edi
+	cmpl	%edi, %ecx
+	je	.LBB1_24
+# %bb.23:                               # %no_return.i547
+                                        #   in Loop: Header=BB1_22 Depth=1
+	vpcmpgtq	%ymm0, %ymm15, %ymm0
+	vextracti128	$1, %ymm0, %xmm6
+	vpackssdw	%xmm6, %xmm0, %xmm0
+	vpcmpgtq	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm0
+	vpcmpgtq	%ymm4, %ymm3, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vpcmpgtq	%ymm7, %ymm5, %ymm2
+	vextracti128	$1, %ymm2, %xmm3
+	vpackssdw	%xmm3, %xmm2, %xmm2
+	vinserti128	$1, %xmm1, %ymm2, %ymm1
+	vandnps	64(%rsp), %ymm14, %ymm2 # 32-byte Folded Reload
+	vpxor	%xmm3, %xmm3, %xmm3
+	vblendvps	%ymm1, %ymm2, %ymm3, %ymm1
+	vandnps	96(%rsp), %ymm13, %ymm2 # 32-byte Folded Reload
+	vblendvps	%ymm0, %ymm2, %ymm3, %ymm0
+	vblendvps	%ymm0, %ymm3, %ymm8, %ymm8
+	vblendvps	%ymm1, %ymm3, %ymm9, %ymm9
+	vandps	%ymm11, %ymm0, %ymm0
+	vorps	%ymm13, %ymm0, %ymm13
+	vandps	%ymm10, %ymm1, %ymm0
+	vorps	%ymm14, %ymm0, %ymm14
+	vmovmskps	%ymm13, %esi
+	vmovmskps	%ymm14, %edi
+	shll	$8, %edi
+	orl	%esi, %edi
+	cmpl	%edi, %ecx
+	jne	.LBB1_89
+.LBB1_24:
+	vmovdqa	%ymm10, %ymm12
+	vandps	%ymm11, %ymm8, %ymm11
+	vandps	%ymm10, %ymm9, %ymm12
+.LBB1_25:                               # %logical_op_done
+	vmovmskps	%ymm11, %ecx
+	vmovmskps	%ymm12, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	je	.LBB1_73
+# %bb.26:                               # %for_test.i453.preheader
+	vmovaps	.LCPI1_1(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm11, %ymm0, %ymm6
+	vmovaps	.LCPI1_2(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm11, %ymm1, %ymm7
+	vpermps	%ymm12, %ymm0, %ymm8
+	vmovaps	%ymm12, %ymm10
+	vpermps	%ymm12, %ymm1, %ymm9
+	testl	%r9d, %r9d
+	je	.LBB1_79
+# %bb.27:                               # %for_loop.i465.lr.ph
 	vpxor	%xmm4, %xmm4, %xmm4
+	cmpl	$1, %r9d
+	jne	.LBB1_75
+# %bb.28:
+	xorl	%ecx, %ecx
+	vpxor	%xmm12, %xmm12, %xmm12
+	vxorps	%xmm13, %xmm13, %xmm13
+	vxorps	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
+	jmp	.LBB1_78
+.LBB1_3:                                # %do_return.i
+	vmovaps	%ymm14, %ymm15
+.LBB1_4:                                # %lessThan___un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
+	vmovmskps	%ymm15, %eax
+	vmovmskps	%ymm1, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB1_10
+# %bb.5:                                # %lessThan___un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
+	testl	%r9d, %r9d
+	je	.LBB1_10
+# %bb.6:                                # %for_loop.i482.lr.ph
+	vmovaps	.LCPI1_1(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm15, %ymm0, %ymm2
+	vmovaps	.LCPI1_2(%rip), %ymm5   # ymm5 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm15, %ymm5, %ymm3
+	vpermps	%ymm1, %ymm0, %ymm4
+	vpermps	%ymm1, %ymm5, %ymm5
+	movl	%r9d, %eax
+	notl	%eax
+	movl	%r9d, %ecx
+	andl	$1, %ecx
+	addl	56(%rsp), %eax          # 4-byte Folded Reload
+	jne	.LBB1_69
+# %bb.7:
+	vxorps	%xmm7, %xmm7, %xmm7
+	xorl	%eax, %eax
+	vxorps	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm10, %xmm10, %xmm10
+	testl	%ecx, %ecx
+	jne	.LBB1_9
+	jmp	.LBB1_10
+.LBB1_69:                               # %for_loop.i482.lr.ph.new
+	movq	48(%rsp), %rax          # 8-byte Reload
+	leaq	(%rax,%r13), %rdx
+	addq	$128, %rdx
+	movl	%r9d, %esi
+	subl	%ecx, %esi
+	vpxor	%xmm6, %xmm6, %xmm6
 	xorl	%edi, %edi
 	xorl	%eax, %eax
-	vpxor	%xmm5, %xmm5, %xmm5
-	vxorps	%xmm6, %xmm6, %xmm6
 	vxorps	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
+	vxorps	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm10, %xmm10, %xmm10
 	.p2align	4, 0x90
-.LBB1_78:                               # %for_loop.i525
+.LBB1_70:                               # %for_loop.i482
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqu	-128(%rdx,%rdi), %ymm0
+	vmovdqu	-96(%rdx,%rdi), %ymm11
+	vmovdqu	-64(%rdx,%rdi), %ymm12
+	vmovdqu	-32(%rdx,%rdi), %ymm13
+	vpsubq	96(%r13,%rdi), %ymm13, %ymm13
+	vpsubq	64(%r13,%rdi), %ymm12, %ymm12
+	vpaddq	%ymm10, %ymm13, %ymm10
+	vpaddq	%ymm9, %ymm12, %ymm9
+	vpsubq	32(%r13,%rdi), %ymm11, %ymm11
+	vpaddq	%ymm8, %ymm11, %ymm8
+	vpsubq	(%r13,%rdi), %ymm0, %ymm0
+	vpaddq	%ymm7, %ymm0, %ymm0
+	vpblendd	$170, %ymm6, %ymm10, %ymm7 # ymm7 = ymm10[0],ymm6[1],ymm10[2],ymm6[3],ymm10[4],ymm6[5],ymm10[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm6[1],ymm0[2],ymm6[3],ymm0[4],ymm6[5],ymm0[6],ymm6[7]
+	vmaskmovpd	%ymm13, %ymm2, (%rbx,%rdi)
+	vmaskmovpd	%ymm12, %ymm3, 32(%rbx,%rdi)
+	vmaskmovpd	%ymm11, %ymm4, 64(%rbx,%rdi)
+	vmaskmovpd	%ymm7, %ymm5, 96(%rbx,%rdi)
+	vpsrad	$31, %ymm10, %ymm7
+	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm7, %ymm10, %ymm7 # ymm7 = ymm10[0],ymm7[1],ymm10[2],ymm7[3],ymm10[4],ymm7[5],ymm10[6],ymm7[7]
+	vpsrad	$31, %ymm9, %ymm10
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vpsrad	$31, %ymm8, %ymm10
+	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm10[1],ymm8[2],ymm10[3],ymm8[4],ymm10[5],ymm8[6],ymm10[7]
+	vpsrad	$31, %ymm0, %ymm10
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vmovdqu	(%rdx,%rdi), %ymm10
+	vmovdqu	32(%rdx,%rdi), %ymm11
+	vmovdqu	64(%rdx,%rdi), %ymm12
+	vmovdqu	96(%rdx,%rdi), %ymm13
+	vpsubq	224(%r13,%rdi), %ymm13, %ymm13
+	vpsubq	192(%r13,%rdi), %ymm12, %ymm12
+	vpaddq	%ymm7, %ymm13, %ymm7
+	vpaddq	%ymm9, %ymm12, %ymm9
+	vpsubq	160(%r13,%rdi), %ymm11, %ymm11
+	vpaddq	%ymm8, %ymm11, %ymm8
+	vpsubq	128(%r13,%rdi), %ymm10, %ymm10
+	vpaddq	%ymm0, %ymm10, %ymm0
+	vpblendd	$170, %ymm6, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm6[1],ymm7[2],ymm6[3],ymm7[4],ymm6[5],ymm7[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+	vpblendd	$170, %ymm6, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm6[1],ymm0[2],ymm6[3],ymm0[4],ymm6[5],ymm0[6],ymm6[7]
+	vmaskmovpd	%ymm13, %ymm2, 128(%rbx,%rdi)
+	vmaskmovpd	%ymm12, %ymm3, 160(%rbx,%rdi)
+	vmaskmovpd	%ymm11, %ymm4, 192(%rbx,%rdi)
+	vmaskmovpd	%ymm10, %ymm5, 224(%rbx,%rdi)
+	vpsrad	$31, %ymm7, %ymm10
+	vpshufd	$245, %ymm7, %ymm7      # ymm7 = ymm7[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm10[1],ymm7[2],ymm10[3],ymm7[4],ymm10[5],ymm7[6],ymm10[7]
+	vpsrad	$31, %ymm9, %ymm7
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm7, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm7[1],ymm9[2],ymm7[3],ymm9[4],ymm7[5],ymm9[6],ymm7[7]
+	vpsrad	$31, %ymm8, %ymm7
+	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm7, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm7[1],ymm8[2],ymm7[3],ymm8[4],ymm7[5],ymm8[6],ymm7[7]
+	vpsrad	$31, %ymm0, %ymm7
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm7, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm7[1],ymm0[2],ymm7[3],ymm0[4],ymm7[5],ymm0[6],ymm7[7]
+	addq	$2, %rax
+	addq	$256, %rdi              # imm = 0x100
+	cmpl	%eax, %esi
+	jne	.LBB1_70
+# %bb.8:                                # %for_test.i470.safe_if_after_true.loopexit_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB1_10
+.LBB1_9:                                # %for_loop.i482.epil.preheader
+	shlq	$7, %rax
+	vmovdqu	(%r10,%rax), %ymm0
+	vmovdqu	32(%r10,%rax), %ymm6
+	vmovdqu	96(%r10,%rax), %ymm11
+	vpsubq	96(%r13,%rax), %ymm11, %ymm11
+	vmovdqu	64(%r10,%rax), %ymm12
+	vpaddq	%ymm10, %ymm11, %ymm10
+	vpsubq	64(%r13,%rax), %ymm12, %ymm11
+	vpaddq	%ymm9, %ymm11, %ymm9
+	vpsubq	32(%r13,%rax), %ymm6, %ymm6
+	vpaddq	%ymm8, %ymm6, %ymm6
+	vpsubq	(%r13,%rax), %ymm0, %ymm0
+	vpaddq	%ymm7, %ymm0, %ymm0
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpblendd	$170, %ymm7, %ymm10, %ymm8 # ymm8 = ymm10[0],ymm7[1],ymm10[2],ymm7[3],ymm10[4],ymm7[5],ymm10[6],ymm7[7]
+	vpblendd	$170, %ymm7, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm7[1],ymm9[2],ymm7[3],ymm9[4],ymm7[5],ymm9[6],ymm7[7]
+	vpblendd	$170, %ymm7, %ymm6, %ymm6 # ymm6 = ymm6[0],ymm7[1],ymm6[2],ymm7[3],ymm6[4],ymm7[5],ymm6[6],ymm7[7]
+	vpblendd	$170, %ymm7, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm7[1],ymm0[2],ymm7[3],ymm0[4],ymm7[5],ymm0[6],ymm7[7]
+	vmaskmovpd	%ymm0, %ymm2, (%rbx,%rax)
+	vmaskmovpd	%ymm6, %ymm3, 32(%rbx,%rax)
+	vmaskmovpd	%ymm9, %ymm4, 64(%rbx,%rax)
+	vmaskmovpd	%ymm8, %ymm5, 96(%rbx,%rax)
+.LBB1_10:                               # %safe_if_after_true
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vxorps	%ymm0, %ymm15, %ymm2
+	vxorps	%ymm0, %ymm1, %ymm3
+	vmovmskps	%ymm2, %eax
+	vmovmskps	%ymm3, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB1_16
+# %bb.11:                               # %safe_if_after_true
+	testl	%r9d, %r9d
+	je	.LBB1_16
+# %bb.12:                               # %for_loop.i499.lr.ph
+	vmovaps	.LCPI1_1(%rip), %ymm4   # ymm4 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm2, %ymm4, %ymm0
+	vmovaps	.LCPI1_2(%rip), %ymm5   # ymm5 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm2, %ymm5, %ymm1
+	vpermps	%ymm3, %ymm4, %ymm2
+	vpermps	%ymm3, %ymm5, %ymm3
+	movl	%r9d, %eax
+	notl	%eax
+	movl	%r9d, %ecx
+	andl	$1, %ecx
+	addl	56(%rsp), %eax          # 4-byte Folded Reload
+	jne	.LBB1_71
+# %bb.13:
+	vxorps	%xmm5, %xmm5, %xmm5
+	xorl	%eax, %eax
+	vpxor	%xmm6, %xmm6, %xmm6
+	vxorps	%xmm7, %xmm7, %xmm7
+	vxorps	%xmm8, %xmm8, %xmm8
+	testl	%ecx, %ecx
+	jne	.LBB1_15
+	jmp	.LBB1_16
+.LBB1_71:                               # %for_loop.i499.lr.ph.new
+	movq	48(%rsp), %rax          # 8-byte Reload
+	leaq	(%rax,%r13), %rdx
+	addq	$128, %rdx
+	movl	%r9d, %esi
+	subl	%ecx, %esi
+	vxorps	%xmm4, %xmm4, %xmm4
+	xorl	%edi, %edi
+	xorl	%eax, %eax
+	vxorps	%xmm5, %xmm5, %xmm5
+	vpxor	%xmm6, %xmm6, %xmm6
+	vxorps	%xmm7, %xmm7, %xmm7
+	vxorps	%xmm8, %xmm8, %xmm8
+	.p2align	4, 0x90
+.LBB1_72:                               # %for_loop.i499
                                         # =>This Inner Loop Header: Depth=1
 	vmovdqu	(%r13,%rdi), %ymm9
 	vmovdqu	32(%r13,%rdi), %ymm10
 	vmovdqu	64(%r13,%rdi), %ymm11
 	vmovdqu	96(%r13,%rdi), %ymm12
-	vpsubq	-32(%rcx,%rdi), %ymm12, %ymm12
-	vpsubq	-64(%rcx,%rdi), %ymm11, %ymm11
+	vpsubq	-32(%rdx,%rdi), %ymm12, %ymm12
+	vpsubq	-64(%rdx,%rdi), %ymm11, %ymm11
 	vpaddq	%ymm8, %ymm12, %ymm8
 	vpaddq	%ymm7, %ymm11, %ymm7
-	vpsubq	-96(%rcx,%rdi), %ymm10, %ymm10
+	vpsubq	-96(%rdx,%rdi), %ymm10, %ymm10
 	vpaddq	%ymm6, %ymm10, %ymm6
-	vpsubq	-128(%rcx,%rdi), %ymm9, %ymm9
+	vpsubq	-128(%rdx,%rdi), %ymm9, %ymm9
 	vpaddq	%ymm5, %ymm9, %ymm5
 	vpblendd	$170, %ymm4, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm4[1],ymm8[2],ymm4[3],ymm8[4],ymm4[5],ymm8[6],ymm4[7]
 	vpblendd	$170, %ymm4, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm4[1],ymm7[2],ymm4[3],ymm7[4],ymm4[5],ymm7[6],ymm4[7]
@@ -1170,13 +1114,13 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	vmovdqu	160(%r13,%rdi), %ymm10
 	vmovdqu	192(%r13,%rdi), %ymm11
 	vmovdqu	224(%r13,%rdi), %ymm12
-	vpsubq	96(%rcx,%rdi), %ymm12, %ymm12
-	vpsubq	64(%rcx,%rdi), %ymm11, %ymm11
+	vpsubq	96(%rdx,%rdi), %ymm12, %ymm12
+	vpsubq	64(%rdx,%rdi), %ymm11, %ymm11
 	vpaddq	%ymm8, %ymm12, %ymm8
 	vpaddq	%ymm7, %ymm11, %ymm7
-	vpsubq	32(%rcx,%rdi), %ymm10, %ymm10
+	vpsubq	32(%rdx,%rdi), %ymm10, %ymm10
 	vpaddq	%ymm6, %ymm10, %ymm6
-	vpsubq	(%rcx,%rdi), %ymm9, %ymm9
+	vpsubq	(%rdx,%rdi), %ymm9, %ymm9
 	vpaddq	%ymm5, %ymm9, %ymm5
 	vpblendd	$170, %ymm4, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm4[1],ymm8[2],ymm4[3],ymm8[4],ymm4[5],ymm8[6],ymm4[7]
 	vpblendd	$170, %ymm4, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm4[1],ymm7[2],ymm4[3],ymm7[4],ymm4[5],ymm7[6],ymm4[7]
@@ -1201,23 +1145,23 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	addq	$2, %rax
 	addq	$256, %rdi              # imm = 0x100
 	cmpl	%eax, %esi
-	jne	.LBB1_78
-.LBB1_15:                               # %for_test.i513.if_exit.loopexit_crit_edge.unr-lcssa
-	testl	%r8d, %r8d
-	je	.LBB1_17
-# %bb.16:                               # %for_loop.i525.epil.preheader
+	jne	.LBB1_72
+# %bb.14:                               # %for_test.i487.if_exit.loopexit_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB1_16
+.LBB1_15:                               # %for_loop.i499.epil.preheader
 	shlq	$7, %rax
 	vmovdqu	(%r13,%rax), %ymm4
 	vmovdqu	32(%r13,%rax), %ymm9
 	vmovdqu	96(%r13,%rax), %ymm10
-	vpsubq	96(%r12,%rax), %ymm10, %ymm10
+	vpsubq	96(%r10,%rax), %ymm10, %ymm10
 	vmovdqu	64(%r13,%rax), %ymm11
 	vpaddq	%ymm8, %ymm10, %ymm8
-	vpsubq	64(%r12,%rax), %ymm11, %ymm10
+	vpsubq	64(%r10,%rax), %ymm11, %ymm10
 	vpaddq	%ymm7, %ymm10, %ymm7
-	vpsubq	32(%r12,%rax), %ymm9, %ymm9
+	vpsubq	32(%r10,%rax), %ymm9, %ymm9
 	vpaddq	%ymm6, %ymm9, %ymm6
-	vpsubq	(%r12,%rax), %ymm4, %ymm4
+	vpsubq	(%r10,%rax), %ymm4, %ymm4
 	vpaddq	%ymm5, %ymm4, %ymm4
 	vpxor	%xmm5, %xmm5, %xmm5
 	vpblendd	$170, %ymm5, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
@@ -1228,864 +1172,1141 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	vmaskmovpd	%ymm6, %ymm1, 32(%rbx,%rax)
 	vmaskmovpd	%ymm7, %ymm2, 64(%rbx,%rax)
 	vmaskmovpd	%ymm8, %ymm3, 96(%rbx,%rax)
-	jmp	.LBB1_17
-.LBB1_28:
-	vmovaps	%ymm12, %ymm7
-	vmovaps	%ymm9, %ymm6
-.LBB1_22:
-	vmovdqa	224(%rsp), %ymm14       # 32-byte Reload
-	vmovdqa	256(%rsp), %ymm15       # 32-byte Reload
-	vpshufd	$78, %xmm8, %xmm0       # xmm0 = xmm8[2,3,0,1]
-	vpmovsxbd	%xmm0, %ymm0
-	vpmovsxbd	%xmm8, %ymm1
-	vpand	%ymm6, %ymm1, %ymm6
-	vpand	%ymm7, %ymm0, %ymm7
-.LBB1_23:                               # %logical_op_done
-	vmovmskps	%ymm6, %r10d
-	vmovmskps	%ymm7, %r11d
-	movl	%r11d, %eax
-	shll	$8, %eax
-	orl	%r10d, %eax
-	je	.LBB1_79
-# %bb.24:                               # %for_test.i484.preheader
-	vmovdqa	.LCPI1_4(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
-	vmovdqa	%ymm6, %ymm3
-	vpermd	%ymm6, %ymm0, %ymm6
-	vmovdqa	.LCPI1_5(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
-	vmovdqa	%ymm7, %ymm2
-	vmovdqa	%ymm3, 320(%rsp)        # 32-byte Spill
-	vpermd	%ymm3, %ymm1, %ymm7
-	vpermd	%ymm2, %ymm0, %ymm8
-	vmovdqa	%ymm2, 96(%rsp)         # 32-byte Spill
-	vpermd	%ymm2, %ymm1, %ymm9
-	testl	%r14d, %r14d
-	je	.LBB1_85
-# %bb.25:                               # %for_loop.i496.lr.ph
-	vpxor	%xmm0, %xmm0, %xmm0
-	cmpl	$1, %r14d
-	jne	.LBB1_81
-# %bb.26:
-	xorl	%esi, %esi
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm10, %xmm10, %xmm10
-	vxorps	%xmm11, %xmm11, %xmm11
-	jmp	.LBB1_84
-.LBB1_81:                               # %for_loop.i496.lr.ph.new
-	movl	%r14d, %r8d
+	jmp	.LBB1_16
+.LBB1_75:                               # %for_loop.i465.lr.ph.new
+	vmovaps	%ymm11, 160(%rsp)       # 32-byte Spill
+	movl	%r9d, %r8d
 	andl	$1, %r8d
-	leaq	(%r15,%r13), %rdi
-	addq	$128, %rdi
-	movl	%r14d, %eax
-	subl	%r8d, %eax
-	vpxor	%xmm1, %xmm1, %xmm1
+	movq	48(%rsp), %rcx          # 8-byte Reload
+	leaq	(%rcx,%r13), %rsi
+	addq	$128, %rsi
+	movl	%r9d, %edi
+	subl	%r8d, %edi
+	vpxor	%xmm11, %xmm11, %xmm11
+	xorl	%edx, %edx
 	xorl	%ecx, %ecx
-	xorl	%esi, %esi
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm10, %xmm10, %xmm10
-	vxorps	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm12, %xmm12, %xmm12
+	vxorps	%xmm13, %xmm13, %xmm13
+	vxorps	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
 	.p2align	4, 0x90
-.LBB1_82:                               # %for_loop.i496
+.LBB1_76:                               # %for_loop.i465
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqu	-128(%rdi,%rcx), %ymm4
-	vmovdqu	-96(%rdi,%rcx), %ymm5
-	vmovdqu	-64(%rdi,%rcx), %ymm12
-	vmovdqu	-32(%rdi,%rcx), %ymm13
-	vpsubq	96(%r13,%rcx), %ymm13, %ymm13
-	vpsubq	64(%r13,%rcx), %ymm12, %ymm12
-	vpaddq	%ymm11, %ymm13, %ymm11
-	vpaddq	%ymm10, %ymm12, %ymm10
-	vpsubq	32(%r13,%rcx), %ymm5, %ymm5
-	vpaddq	%ymm3, %ymm5, %ymm3
-	vpsubq	(%r13,%rcx), %ymm4, %ymm4
-	vpaddq	%ymm2, %ymm4, %ymm2
-	vpblendd	$170, %ymm1, %ymm11, %ymm4 # ymm4 = ymm11[0],ymm1[1],ymm11[2],ymm1[3],ymm11[4],ymm1[5],ymm11[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm10, %ymm5 # ymm5 = ymm10[0],ymm1[1],ymm10[2],ymm1[3],ymm10[4],ymm1[5],ymm10[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vmaskmovpd	%ymm13, %ymm6, (%rbx,%rcx)
-	vmaskmovpd	%ymm12, %ymm7, 32(%rbx,%rcx)
-	vmaskmovpd	%ymm5, %ymm8, 64(%rbx,%rcx)
-	vmaskmovpd	%ymm4, %ymm9, 96(%rbx,%rcx)
-	vpsrad	$31, %ymm11, %ymm4
-	vpshufd	$245, %ymm11, %ymm5     # ymm5 = ymm11[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm4, %ymm5, %ymm4 # ymm4 = ymm5[0],ymm4[1],ymm5[2],ymm4[3],ymm5[4],ymm4[5],ymm5[6],ymm4[7]
-	vpsrad	$31, %ymm10, %ymm5
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm5, %ymm10, %ymm5 # ymm5 = ymm10[0],ymm5[1],ymm10[2],ymm5[3],ymm10[4],ymm5[5],ymm10[6],ymm5[7]
-	vpsrad	$31, %ymm3, %ymm10
-	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
-	vpsrad	$31, %ymm2, %ymm10
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm10[1],ymm2[2],ymm10[3],ymm2[4],ymm10[5],ymm2[6],ymm10[7]
-	vmovdqu	(%rdi,%rcx), %ymm10
-	vmovdqu	32(%rdi,%rcx), %ymm11
-	vmovdqu	64(%rdi,%rcx), %ymm12
-	vmovdqu	96(%rdi,%rcx), %ymm13
-	vpsubq	224(%r13,%rcx), %ymm13, %ymm13
-	vpsubq	192(%r13,%rcx), %ymm12, %ymm12
-	vpaddq	%ymm4, %ymm13, %ymm4
-	vpaddq	%ymm5, %ymm12, %ymm5
-	vpsubq	160(%r13,%rcx), %ymm11, %ymm11
-	vpaddq	%ymm3, %ymm11, %ymm3
-	vpsubq	128(%r13,%rcx), %ymm10, %ymm10
-	vpaddq	%ymm2, %ymm10, %ymm2
-	vpblendd	$170, %ymm1, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vmaskmovpd	%ymm13, %ymm6, 128(%rbx,%rcx)
-	vmaskmovpd	%ymm12, %ymm7, 160(%rbx,%rcx)
-	vmaskmovpd	%ymm11, %ymm8, 192(%rbx,%rcx)
-	vmaskmovpd	%ymm10, %ymm9, 224(%rbx,%rcx)
-	vpsrad	$31, %ymm4, %ymm10
-	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm10[1],ymm4[2],ymm10[3],ymm4[4],ymm10[5],ymm4[6],ymm10[7]
-	vpsrad	$31, %ymm5, %ymm4
-	vpshufd	$245, %ymm5, %ymm5      # ymm5 = ymm5[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm4, %ymm5, %ymm10 # ymm10 = ymm5[0],ymm4[1],ymm5[2],ymm4[3],ymm5[4],ymm4[5],ymm5[6],ymm4[7]
+	vmovdqu	-128(%rsi,%rdx), %ymm0
+	vmovdqu	-96(%rsi,%rdx), %ymm1
+	vmovdqu	-64(%rsi,%rdx), %ymm2
+	vmovdqu	-32(%rsi,%rdx), %ymm3
+	vpsubq	96(%r13,%rdx), %ymm3, %ymm3
+	vpsubq	64(%r13,%rdx), %ymm2, %ymm2
+	vpaddq	%ymm15, %ymm3, %ymm3
+	vpaddq	%ymm14, %ymm2, %ymm2
+	vpsubq	32(%r13,%rdx), %ymm1, %ymm1
+	vpaddq	%ymm13, %ymm1, %ymm1
+	vpsubq	(%r13,%rdx), %ymm0, %ymm0
+	vpaddq	%ymm12, %ymm0, %ymm0
+	vpblendd	$170, %ymm11, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm11[1],ymm3[2],ymm11[3],ymm3[4],ymm11[5],ymm3[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm11[1],ymm0[2],ymm11[3],ymm0[4],ymm11[5],ymm0[6],ymm11[7]
+	vmaskmovpd	%ymm13, %ymm6, (%rbx,%rdx)
+	vmaskmovpd	%ymm12, %ymm7, 32(%rbx,%rdx)
+	vmaskmovpd	%ymm5, %ymm8, 64(%rbx,%rdx)
+	vmaskmovpd	%ymm4, %ymm9, 96(%rbx,%rdx)
 	vpsrad	$31, %ymm3, %ymm4
 	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm4, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
 	vpsrad	$31, %ymm2, %ymm4
 	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm4, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
-	addq	$2, %rsi
-	addq	$256, %rcx              # imm = 0x100
-	cmpl	%esi, %eax
-	jne	.LBB1_82
-# %bb.83:                               # %for_test.i484.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit497_crit_edge.unr-lcssa
-	testl	%r8d, %r8d
-	je	.LBB1_85
-.LBB1_84:                               # %for_loop.i496.epil.preheader
-	shlq	$7, %rsi
-	vmovdqu	(%r12,%rsi), %ymm1
-	vmovdqu	32(%r12,%rsi), %ymm4
-	vmovdqu	64(%r12,%rsi), %ymm5
-	vmovdqu	96(%r12,%rsi), %ymm12
-	vpsubq	96(%r13,%rsi), %ymm12, %ymm12
-	vpsubq	64(%r13,%rsi), %ymm5, %ymm5
-	vpaddq	%ymm11, %ymm12, %ymm11
-	vpaddq	%ymm5, %ymm10, %ymm5
-	vpsubq	32(%r13,%rsi), %ymm4, %ymm4
-	vpaddq	%ymm3, %ymm4, %ymm3
-	vpsubq	(%r13,%rsi), %ymm1, %ymm1
-	vpaddq	%ymm2, %ymm1, %ymm1
-	vpblendd	$170, %ymm0, %ymm11, %ymm2 # ymm2 = ymm11[0],ymm0[1],ymm11[2],ymm0[3],ymm11[4],ymm0[5],ymm11[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm5, %ymm4 # ymm4 = ymm5[0],ymm0[1],ymm5[2],ymm0[3],ymm5[4],ymm0[5],ymm5[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm0 # ymm0 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmaskmovpd	%ymm0, %ymm6, (%rbx,%rsi)
-	vmaskmovpd	%ymm3, %ymm7, 32(%rbx,%rsi)
-	vmaskmovpd	%ymm4, %ymm8, 64(%rbx,%rsi)
-	vmaskmovpd	%ymm2, %ymm9, 96(%rbx,%rsi)
-.LBB1_85:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit497
-	vxorpd	%xmm0, %xmm0, %xmm0
-	vmaskmovpd	%ymm0, %ymm6, (%rbx,%r9)
-	vmaskmovpd	%ymm0, %ymm7, 32(%rbx,%r9)
-	vmaskmovpd	%ymm0, %ymm8, 64(%rbx,%r9)
-	vmaskmovpd	%ymm0, %ymm9, 96(%rbx,%r9)
-	vmovaps	96(%rsp), %ymm7         # 32-byte Reload
-	vmovaps	320(%rsp), %ymm6        # 32-byte Reload
-.LBB1_79:                               # %safe_if_after_true57
-	xorl	$255, %r10d
-	xorl	$255, %r11d
-	shll	$8, %r11d
-	orl	%r10d, %r11d
-	je	.LBB1_80
-# %bb.86:                               # %safe_if_run_false75
-	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	vpxor	%ymm0, %ymm6, %ymm1
-	vpxor	%ymm0, %ymm7, %ymm0
-	addq	%rbx, %r9
-	vmovdqa	.LCPI1_4(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm1, %ymm2, %ymm4
-	vmovdqa	.LCPI1_5(%rip), %ymm3   # ymm3 = [4,4,5,5,6,6,7,7]
-	vpermd	%ymm1, %ymm3, %ymm5
-	vpermd	%ymm0, %ymm2, %ymm6
-	vpermd	%ymm0, %ymm3, %ymm7
-	testl	%r14d, %r14d
-	je	.LBB1_87
-# %bb.88:                               # %for_loop.i.lr.ph
-	vpxor	%xmm0, %xmm0, %xmm0
-	cmpl	$1, %r14d
-	jne	.LBB1_90
-# %bb.89:
-	xorl	%ecx, %ecx
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm8, %xmm8, %xmm8
-	jmp	.LBB1_93
-.LBB1_87:
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm8, %xmm8, %xmm8
-	jmp	.LBB1_94
-.LBB1_90:                               # %for_loop.i.lr.ph.new
-	movl	%r14d, %r8d
-	andl	$1, %r8d
-	leaq	(%r15,%r13), %rax
-	addq	$128, %rax
-	movl	%r14d, %esi
-	subl	%r8d, %esi
-	vpxor	%xmm1, %xmm1, %xmm1
-	xorl	%edi, %edi
-	xorl	%ecx, %ecx
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm8, %xmm8, %xmm8
-	.p2align	4, 0x90
-.LBB1_91:                               # %for_loop.i
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqu	(%r13,%rdi), %ymm10
-	vmovdqu	32(%r13,%rdi), %ymm11
-	vmovdqu	64(%r13,%rdi), %ymm12
-	vmovdqu	96(%r13,%rdi), %ymm13
-	vpsubq	-32(%rax,%rdi), %ymm13, %ymm13
-	vpsubq	-64(%rax,%rdi), %ymm12, %ymm12
-	vpaddq	%ymm8, %ymm13, %ymm8
-	vpaddq	%ymm9, %ymm12, %ymm9
-	vpsubq	-96(%rax,%rdi), %ymm11, %ymm11
-	vpaddq	%ymm3, %ymm11, %ymm3
-	vpsubq	-128(%rax,%rdi), %ymm10, %ymm10
-	vpaddq	%ymm2, %ymm10, %ymm2
-	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vmaskmovpd	%ymm13, %ymm4, (%rbx,%rdi)
-	vmaskmovpd	%ymm12, %ymm5, 32(%rbx,%rdi)
-	vmaskmovpd	%ymm11, %ymm6, 64(%rbx,%rdi)
-	vmaskmovpd	%ymm10, %ymm7, 96(%rbx,%rdi)
-	vpsrad	$31, %ymm8, %ymm10
-	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm10[1],ymm8[2],ymm10[3],ymm8[4],ymm10[5],ymm8[6],ymm10[7]
-	vpsrad	$31, %ymm9, %ymm10
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
-	vpsrad	$31, %ymm3, %ymm10
+	vpsrad	$31, %ymm1, %ymm4
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm4, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
+	vpsrad	$31, %ymm0, %ymm4
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm4, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
+	vmovdqu	(%rsi,%rdx), %ymm4
+	vmovdqu	32(%rsi,%rdx), %ymm5
+	vmovdqu	64(%rsi,%rdx), %ymm12
+	vmovdqu	96(%rsi,%rdx), %ymm13
+	vpsubq	224(%r13,%rdx), %ymm13, %ymm13
+	vpsubq	192(%r13,%rdx), %ymm12, %ymm12
+	vpaddq	%ymm3, %ymm13, %ymm3
+	vpaddq	%ymm2, %ymm12, %ymm2
+	vpsubq	160(%r13,%rdx), %ymm5, %ymm5
+	vpaddq	%ymm1, %ymm5, %ymm1
+	vpsubq	128(%r13,%rdx), %ymm4, %ymm4
+	vpaddq	%ymm0, %ymm4, %ymm0
+	vpblendd	$170, %ymm11, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm11[1],ymm3[2],ymm11[3],ymm3[4],ymm11[5],ymm3[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm11[1],ymm0[2],ymm11[3],ymm0[4],ymm11[5],ymm0[6],ymm11[7]
+	vmaskmovpd	%ymm13, %ymm6, 128(%rbx,%rdx)
+	vmaskmovpd	%ymm12, %ymm7, 160(%rbx,%rdx)
+	vmaskmovpd	%ymm5, %ymm8, 192(%rbx,%rdx)
+	vmaskmovpd	%ymm4, %ymm9, 224(%rbx,%rdx)
+	vpsrad	$31, %ymm3, %ymm4
 	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
-	vpsrad	$31, %ymm2, %ymm10
+	vpblendd	$170, %ymm4, %ymm3, %ymm15 # ymm15 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+	vpsrad	$31, %ymm2, %ymm3
 	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm10[1],ymm2[2],ymm10[3],ymm2[4],ymm10[5],ymm2[6],ymm10[7]
-	vmovdqu	128(%r13,%rdi), %ymm10
-	vmovdqu	160(%r13,%rdi), %ymm11
-	vmovdqu	192(%r13,%rdi), %ymm12
-	vmovdqu	224(%r13,%rdi), %ymm13
-	vpsubq	96(%rax,%rdi), %ymm13, %ymm13
-	vpsubq	64(%rax,%rdi), %ymm12, %ymm12
-	vpaddq	%ymm8, %ymm13, %ymm8
-	vpaddq	%ymm9, %ymm12, %ymm9
-	vpsubq	32(%rax,%rdi), %ymm11, %ymm11
-	vpaddq	%ymm3, %ymm11, %ymm3
-	vpsubq	(%rax,%rdi), %ymm10, %ymm10
-	vpaddq	%ymm2, %ymm10, %ymm2
-	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vmaskmovpd	%ymm13, %ymm4, 128(%rbx,%rdi)
-	vmaskmovpd	%ymm12, %ymm5, 160(%rbx,%rdi)
-	vmaskmovpd	%ymm11, %ymm6, 192(%rbx,%rdi)
-	vmaskmovpd	%ymm10, %ymm7, 224(%rbx,%rdi)
-	vpsrad	$31, %ymm8, %ymm10
-	vpshufd	$245, %ymm8, %ymm8      # ymm8 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm8, %ymm8 # ymm8 = ymm8[0],ymm10[1],ymm8[2],ymm10[3],ymm8[4],ymm10[5],ymm8[6],ymm10[7]
-	vpsrad	$31, %ymm9, %ymm10
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
-	vpsrad	$31, %ymm3, %ymm10
-	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
-	vpsrad	$31, %ymm2, %ymm10
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm10[1],ymm2[2],ymm10[3],ymm2[4],ymm10[5],ymm2[6],ymm10[7]
+	vpblendd	$170, %ymm3, %ymm2, %ymm14 # ymm14 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vpsrad	$31, %ymm1, %ymm2
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vpsrad	$31, %ymm0, %ymm1
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm1, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm1[1],ymm0[2],ymm1[3],ymm0[4],ymm1[5],ymm0[6],ymm1[7]
 	addq	$2, %rcx
-	addq	$256, %rdi              # imm = 0x100
-	cmpl	%ecx, %esi
-	jne	.LBB1_91
-# %bb.92:                               # %for_test.i353.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit_crit_edge.unr-lcssa
+	addq	$256, %rdx              # imm = 0x100
+	cmpl	%ecx, %edi
+	jne	.LBB1_76
+# %bb.77:                               # %for_test.i453.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit466_crit_edge.unr-lcssa
 	testl	%r8d, %r8d
-	je	.LBB1_94
-.LBB1_93:                               # %for_loop.i.epil.preheader
+	vmovaps	160(%rsp), %ymm11       # 32-byte Reload
+	vpxor	%xmm4, %xmm4, %xmm4
+	je	.LBB1_79
+.LBB1_78:                               # %for_loop.i465.epil.preheader
 	shlq	$7, %rcx
-	vmovdqu	(%r13,%rcx), %ymm1
-	vmovdqu	32(%r13,%rcx), %ymm10
-	vmovdqu	64(%r13,%rcx), %ymm11
-	vmovdqu	96(%r13,%rcx), %ymm12
-	vpsubq	96(%r12,%rcx), %ymm12, %ymm12
-	vpsubq	64(%r12,%rcx), %ymm11, %ymm11
-	vpaddq	%ymm8, %ymm12, %ymm8
-	vpaddq	%ymm9, %ymm11, %ymm9
-	vpsubq	32(%r12,%rcx), %ymm10, %ymm10
-	vpaddq	%ymm3, %ymm10, %ymm3
-	vpsubq	(%r12,%rcx), %ymm1, %ymm1
-	vpaddq	%ymm2, %ymm1, %ymm1
-	vpblendd	$170, %ymm0, %ymm8, %ymm2 # ymm2 = ymm8[0],ymm0[1],ymm8[2],ymm0[3],ymm8[4],ymm0[5],ymm8[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm0[1],ymm9[2],ymm0[3],ymm9[4],ymm0[5],ymm9[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm11 # ymm11 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm0 # ymm0 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmaskmovpd	%ymm0, %ymm4, (%rbx,%rcx)
+	vmovdqu	(%r10,%rcx), %ymm0
+	vmovdqu	32(%r10,%rcx), %ymm1
+	vmovdqu	64(%r10,%rcx), %ymm2
+	vmovdqu	96(%r10,%rcx), %ymm3
+	vpsubq	96(%r13,%rcx), %ymm3, %ymm3
+	vpsubq	64(%r13,%rcx), %ymm2, %ymm2
+	vpaddq	%ymm15, %ymm3, %ymm3
+	vpaddq	%ymm14, %ymm2, %ymm2
+	vpsubq	32(%r13,%rcx), %ymm1, %ymm1
+	vpaddq	%ymm13, %ymm1, %ymm1
+	vpsubq	(%r13,%rcx), %ymm0, %ymm0
+	vpaddq	%ymm12, %ymm0, %ymm0
+	vpblendd	$170, %ymm4, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm4[1],ymm3[2],ymm4[3],ymm3[4],ymm4[5],ymm3[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm4[1],ymm2[2],ymm4[3],ymm2[4],ymm4[5],ymm2[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm4[1],ymm1[2],ymm4[3],ymm1[4],ymm4[5],ymm1[6],ymm4[7]
+	vpblendd	$170, %ymm4, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm4[1],ymm0[2],ymm4[3],ymm0[4],ymm4[5],ymm0[6],ymm4[7]
+	vmaskmovpd	%ymm0, %ymm6, (%rbx,%rcx)
+	vmaskmovpd	%ymm1, %ymm7, 32(%rbx,%rcx)
+	vmaskmovpd	%ymm2, %ymm8, 64(%rbx,%rcx)
+	vmaskmovpd	%ymm3, %ymm9, 96(%rbx,%rcx)
+.LBB1_79:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit466
+	vxorpd	%xmm0, %xmm0, %xmm0
+	vmaskmovpd	%ymm0, %ymm6, (%rbx,%rax)
+	vmaskmovpd	%ymm0, %ymm7, 32(%rbx,%rax)
+	vmaskmovpd	%ymm0, %ymm8, 64(%rbx,%rax)
+	vmaskmovpd	%ymm0, %ymm9, 96(%rbx,%rax)
+	vmovaps	%ymm10, %ymm12
+.LBB1_73:                               # %safe_if_after_true57
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vpxor	%ymm0, %ymm11, %ymm1
+	vpxor	%ymm0, %ymm12, %ymm0
+	vmovmskps	%ymm1, %ecx
+	vmovmskps	%ymm0, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	je	.LBB1_74
+# %bb.80:                               # %safe_if_run_false75
+	addq	%rbx, %rax
+	vmovaps	.LCPI1_1(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm1, %ymm2, %ymm4
+	vmovaps	.LCPI1_2(%rip), %ymm3   # ymm3 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm1, %ymm3, %ymm5
+	vpermps	%ymm0, %ymm2, %ymm6
+	vpermps	%ymm0, %ymm3, %ymm7
+	testl	%r9d, %r9d
+	je	.LBB1_81
+# %bb.82:                               # %for_loop.i.lr.ph
+	vxorps	%xmm8, %xmm8, %xmm8
+	cmpl	$1, %r9d
+	jne	.LBB1_84
+# %bb.83:
+	xorl	%ecx, %ecx
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm11, %xmm11, %xmm11
+	vxorps	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm12, %xmm12, %xmm12
+	jmp	.LBB1_87
+.LBB1_81:
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm11, %xmm11, %xmm11
+	vxorps	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm12, %xmm12, %xmm12
+	jmp	.LBB1_88
+.LBB1_84:                               # %for_loop.i.lr.ph.new
+	movl	%r9d, %r8d
+	andl	$1, %r8d
+	movq	48(%rsp), %rcx          # 8-byte Reload
+	leaq	(%rcx,%r13), %rsi
+	addq	$128, %rsi
+	movl	%r9d, %edi
+	subl	%r8d, %edi
+	vxorps	%xmm9, %xmm9, %xmm9
+	xorl	%edx, %edx
+	xorl	%ecx, %ecx
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm11, %xmm11, %xmm11
+	vxorps	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm12, %xmm12, %xmm12
+	.p2align	4, 0x90
+.LBB1_85:                               # %for_loop.i
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqu	(%r13,%rdx), %ymm0
+	vmovdqu	32(%r13,%rdx), %ymm1
+	vmovdqu	64(%r13,%rdx), %ymm2
+	vmovdqu	96(%r13,%rdx), %ymm3
+	vpsubq	-32(%rsi,%rdx), %ymm3, %ymm3
+	vpsubq	-64(%rsi,%rdx), %ymm2, %ymm2
+	vpaddq	%ymm12, %ymm3, %ymm3
+	vpaddq	%ymm13, %ymm2, %ymm2
+	vpsubq	-96(%rsi,%rdx), %ymm1, %ymm1
+	vpaddq	%ymm11, %ymm1, %ymm1
+	vpsubq	-128(%rsi,%rdx), %ymm0, %ymm0
+	vpaddq	%ymm10, %ymm0, %ymm0
+	vpblendd	$170, %ymm9, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm9[1],ymm3[2],ymm9[3],ymm3[4],ymm9[5],ymm3[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm2, %ymm11 # ymm11 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm9[1],ymm0[2],ymm9[3],ymm0[4],ymm9[5],ymm0[6],ymm9[7]
+	vmaskmovpd	%ymm13, %ymm4, (%rbx,%rdx)
+	vmaskmovpd	%ymm12, %ymm5, 32(%rbx,%rdx)
+	vmaskmovpd	%ymm11, %ymm6, 64(%rbx,%rdx)
+	vmaskmovpd	%ymm10, %ymm7, 96(%rbx,%rdx)
+	vpsrad	$31, %ymm3, %ymm10
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
+	vpsrad	$31, %ymm2, %ymm10
+	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm10[1],ymm2[2],ymm10[3],ymm2[4],ymm10[5],ymm2[6],ymm10[7]
+	vpsrad	$31, %ymm1, %ymm10
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpsrad	$31, %ymm0, %ymm10
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vmovdqu	128(%r13,%rdx), %ymm10
+	vmovdqu	160(%r13,%rdx), %ymm11
+	vmovdqu	192(%r13,%rdx), %ymm12
+	vmovdqu	224(%r13,%rdx), %ymm13
+	vpsubq	96(%rsi,%rdx), %ymm13, %ymm13
+	vpsubq	64(%rsi,%rdx), %ymm12, %ymm12
+	vpaddq	%ymm3, %ymm13, %ymm3
+	vpaddq	%ymm2, %ymm12, %ymm2
+	vpsubq	32(%rsi,%rdx), %ymm11, %ymm11
+	vpaddq	%ymm1, %ymm11, %ymm1
+	vpsubq	(%rsi,%rdx), %ymm10, %ymm10
+	vpaddq	%ymm0, %ymm10, %ymm0
+	vpblendd	$170, %ymm9, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm9[1],ymm3[2],ymm9[3],ymm3[4],ymm9[5],ymm3[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm2, %ymm11 # ymm11 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm0, %ymm13 # ymm13 = ymm0[0],ymm9[1],ymm0[2],ymm9[3],ymm0[4],ymm9[5],ymm0[6],ymm9[7]
+	vmaskmovpd	%ymm13, %ymm4, 128(%rbx,%rdx)
+	vmaskmovpd	%ymm12, %ymm5, 160(%rbx,%rdx)
+	vmaskmovpd	%ymm11, %ymm6, 192(%rbx,%rdx)
+	vmaskmovpd	%ymm10, %ymm7, 224(%rbx,%rdx)
+	vpsrad	$31, %ymm3, %ymm10
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm10, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm10[1],ymm3[2],ymm10[3],ymm3[4],ymm10[5],ymm3[6],ymm10[7]
+	vpsrad	$31, %ymm2, %ymm3
+	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm3, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vpsrad	$31, %ymm1, %ymm2
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vpsrad	$31, %ymm0, %ymm1
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm1, %ymm0, %ymm10 # ymm10 = ymm0[0],ymm1[1],ymm0[2],ymm1[3],ymm0[4],ymm1[5],ymm0[6],ymm1[7]
+	addq	$2, %rcx
+	addq	$256, %rdx              # imm = 0x100
+	cmpl	%ecx, %edi
+	jne	.LBB1_85
+# %bb.86:                               # %for_test.i371.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit_crit_edge.unr-lcssa
+	testl	%r8d, %r8d
+	je	.LBB1_88
+.LBB1_87:                               # %for_loop.i.epil.preheader
+	shlq	$7, %rcx
+	vmovdqu	(%r13,%rcx), %ymm0
+	vmovdqu	32(%r13,%rcx), %ymm1
+	vmovdqu	64(%r13,%rcx), %ymm2
+	vmovdqu	96(%r13,%rcx), %ymm3
+	vpsubq	96(%r10,%rcx), %ymm3, %ymm3
+	vpsubq	64(%r10,%rcx), %ymm2, %ymm2
+	vpaddq	%ymm12, %ymm3, %ymm3
+	vpaddq	%ymm13, %ymm2, %ymm2
+	vpsubq	32(%r10,%rcx), %ymm1, %ymm1
+	vpaddq	%ymm11, %ymm1, %ymm1
+	vpsubq	(%r10,%rcx), %ymm0, %ymm0
+	vpaddq	%ymm10, %ymm0, %ymm0
+	vpblendd	$170, %ymm8, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
+	vpblendd	$170, %ymm8, %ymm2, %ymm10 # ymm10 = ymm2[0],ymm8[1],ymm2[2],ymm8[3],ymm2[4],ymm8[5],ymm2[6],ymm8[7]
+	vpblendd	$170, %ymm8, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm8[1],ymm1[2],ymm8[3],ymm1[4],ymm8[5],ymm1[6],ymm8[7]
+	vpblendd	$170, %ymm8, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm8[1],ymm0[2],ymm8[3],ymm0[4],ymm8[5],ymm0[6],ymm8[7]
+	vmaskmovpd	%ymm8, %ymm4, (%rbx,%rcx)
 	vmaskmovpd	%ymm11, %ymm5, 32(%rbx,%rcx)
 	vmaskmovpd	%ymm10, %ymm6, 64(%rbx,%rcx)
-	vmaskmovpd	%ymm2, %ymm7, 96(%rbx,%rcx)
-	vpsrad	$31, %ymm8, %ymm0
-	vpshufd	$245, %ymm8, %ymm2      # ymm2 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpsrad	$31, %ymm9, %ymm0
-	vpshufd	$245, %ymm9, %ymm2      # ymm2 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm9 # ymm9 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpsrad	$31, %ymm3, %ymm0
-	vpshufd	$245, %ymm3, %ymm2      # ymm2 = ymm3[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm3 # ymm3 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpsrad	$31, %ymm1, %ymm0
+	vmaskmovpd	%ymm9, %ymm7, 96(%rbx,%rcx)
+	vpsrad	$31, %ymm3, %ymm8
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm8, %ymm3, %ymm12 # ymm12 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
+	vpsrad	$31, %ymm2, %ymm3
+	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm3, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vpsrad	$31, %ymm1, %ymm2
 	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm2 # ymm2 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-.LBB1_94:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
-	vpaddq	288(%rsp), %ymm8, %ymm0 # 32-byte Folded Reload
-	vpaddq	192(%rsp), %ymm9, %ymm1 # 32-byte Folded Reload
-	vpaddq	%ymm3, %ymm15, %ymm3
-	vpaddq	%ymm2, %ymm14, %ymm2
-	vmaskmovpd	%ymm2, %ymm4, (%r9)
-	vmaskmovpd	%ymm3, %ymm5, 32(%r9)
-	vmaskmovpd	%ymm1, %ymm6, 64(%r9)
-	vmaskmovpd	%ymm0, %ymm7, 96(%r9)
-.LBB1_80:                               # %if_done56
-	leal	-2(,%rdx,4), %eax
+	vpblendd	$170, %ymm2, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vpsrad	$31, %ymm0, %ymm1
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm1, %ymm0, %ymm10 # ymm10 = ymm0[0],ymm1[1],ymm0[2],ymm1[3],ymm0[4],ymm1[5],ymm0[6],ymm1[7]
+.LBB1_88:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit
+	vpaddq	192(%rsp), %ymm12, %ymm0 # 32-byte Folded Reload
+	vpaddq	224(%rsp), %ymm13, %ymm1 # 32-byte Folded Reload
+	vpaddq	256(%rsp), %ymm11, %ymm2 # 32-byte Folded Reload
+	vpaddq	288(%rsp), %ymm10, %ymm3 # 32-byte Folded Reload
+	vmaskmovpd	%ymm3, %ymm4, (%rax)
+	vmaskmovpd	%ymm2, %ymm5, 32(%rax)
+	vmaskmovpd	%ymm1, %ymm6, 64(%rax)
+	vmaskmovpd	%ymm0, %ymm7, 96(%rax)
+.LBB1_74:                               # %if_done56
+	movq	%r12, %rcx
+	leal	-2(,%r12,4), %eax
 	shlq	$7, %rax
 	vxorps	%xmm0, %xmm0, %xmm0
 	vmovups	%ymm0, 96(%rbx,%rax)
 	vmovups	%ymm0, 64(%rbx,%rax)
 	vmovups	%ymm0, 32(%rbx,%rax)
 	vmovups	%ymm0, (%rbx,%rax)
-	leal	-1(,%rdx,4), %eax
+	leal	-1(,%r12,4), %eax
 	shlq	$7, %rax
-	vmovups	%ymm0, 64(%rbx,%rax)
 	vmovups	%ymm0, 96(%rbx,%rax)
-	vmovups	%ymm0, (%rbx,%rax)
+	vmovups	%ymm0, 64(%rbx,%rax)
 	vmovups	%ymm0, 32(%rbx,%rax)
-.LBB1_17:                               # %if_exit
-	leal	(%rdx,%rdx), %eax
-	movq	%r12, 64(%rsp)          # 8-byte Spill
-	movq	%rax, 256(%rsp)         # 8-byte Spill
-	movq	%rax, %r12
-	shlq	$7, %r12
-	leaq	(%rbx,%r12), %rax
-	movq	%rax, 96(%rsp)          # 8-byte Spill
+	vmovups	%ymm0, (%rbx,%rax)
+.LBB1_16:                               # %if_exit
+	leal	(%r12,%r12), %r15d
+	movq	%r15, %rax
+	shlq	$7, %rax
+	movq	%r9, 64(%rsp)           # 8-byte Spill
+	movq	%rax, 128(%rsp)         # 8-byte Spill
+	leaq	(%rbx,%rax), %r14
 	leaq	384(%rsp), %rdi
 	movq	%rbx, %rsi
-	movq	%rdx, 128(%rsp)         # 8-byte Spill
+	movl	%r12d, %edx
+	movq	%r10, 96(%rsp)          # 8-byte Spill
 	vzeroupper
 	callq	squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	movq	96(%rsp), %rdi          # 8-byte Reload
-	movq	64(%rsp), %rsi          # 8-byte Reload
-	movq	%r14, 192(%rsp)         # 8-byte Spill
-	movl	%r14d, %edx
+	movq	%r14, %rdi
+	movq	96(%rsp), %rsi          # 8-byte Reload
+	movq	64(%rsp), %rdx          # 8-byte Reload
+                                        # kill: def $edx killed $edx killed $rdx
 	callq	squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
 	movq	%rbx, %rdi
 	movq	%r13, %rsi
-	movq	128(%rsp), %rdx         # 8-byte Reload
-                                        # kill: def $edx killed $edx killed $rdx
+	movq	%r12, %r13
+	movl	%r13d, %edx
 	callq	squareSimple___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	movq	128(%rsp), %r14         # 8-byte Reload
-	vxorps	%xmm0, %xmm0, %xmm0
-	testl	%r14d, %r14d
-	je	.LBB1_18
-# %bb.30:                               # %for_loop.i423.lr.ph
-	movq	192(%rsp), %rax         # 8-byte Reload
-	movq	%rax, %r8
-                                        # kill: def $eax killed $eax killed $rax
-	notl	%eax
-	addl	160(%rsp), %eax         # 4-byte Folded Reload
-	movl	%r14d, %ecx
-	andl	$3, %ecx
-	cmpl	$3, %eax
-	jae	.LBB1_39
-# %bb.31:
-	vpxor	%xmm1, %xmm1, %xmm1
-	xorl	%edx, %edx
+	vxorps	%xmm14, %xmm14, %xmm14
+	testl	%r13d, %r13d
+	je	.LBB1_17
+# %bb.29:                               # %for_loop.i390.lr.ph
+	movq	48(%rsp), %rax          # 8-byte Reload
+	leaq	(%rbx,%rax), %rax
+	movabsq	$8589934592, %r10       # imm = 0x200000000
+	movabsq	$4294967296, %r11       # imm = 0x100000000
+	movq	64(%rsp), %rcx          # 8-byte Reload
+	movl	%ecx, %r8d
+	notl	%r8d
+	movl	%r13d, %r9d
+	andl	$1, %r9d
+	movl	%r8d, %ecx
+	addl	56(%rsp), %ecx          # 4-byte Folded Reload
+	jne	.LBB1_38
+# %bb.30:
+	vpxor	%xmm6, %xmm6, %xmm6
+	xorl	%edi, %edi
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpxor	%xmm4, %xmm4, %xmm4
-	jmp	.LBB1_32
-.LBB1_18:
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 320(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 352(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 64(%rsp)         # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 96(%rsp)         # 32-byte Spill
-	vpxor	%xmm5, %xmm5, %xmm5
+	testl	%r9d, %r9d
+	jne	.LBB1_32
+	jmp	.LBB1_33
+.LBB1_17:
 	vpxor	%xmm6, %xmm6, %xmm6
+	vpxor	%xmm2, %xmm2, %xmm2
+	vpxor	%xmm3, %xmm3, %xmm3
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm15, %xmm15, %xmm15
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	jmp	.LBB1_48
-.LBB1_39:                               # %for_loop.i423.lr.ph.new
-	movl	%r14d, %esi
-	subl	%ecx, %esi
-	leaq	384(%rbx), %rdi
-	vpxor	%xmm5, %xmm5, %xmm5
-	xorl	%edx, %edx
+	vxorps	%xmm8, %xmm8, %xmm8
 	vpxor	%xmm1, %xmm1, %xmm1
+	vxorps	%xmm9, %xmm9, %xmm9
+	jmp	.LBB1_35
+.LBB1_38:                               # %for_loop.i390.lr.ph.new
+	movl	%r13d, %r12d
+	subl	%r9d, %r12d
+	movq	128(%rsp), %rcx         # 8-byte Reload
+	addq	%rbx, %rcx
+	addq	$128, %rcx
+	vpxor	%xmm5, %xmm5, %xmm5
+	xorl	%esi, %esi
+	xorl	%edi, %edi
+	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB1_40:                               # %for_loop.i423
+.LBB1_39:                               # %for_loop.i390
                                         # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rdi,%r15), %ymm4, %ymm4
-	vpaddq	-320(%rdi,%r15), %ymm3, %ymm3
-	vpaddq	-384(%rdi,%r15), %ymm1, %ymm1
-	vpaddq	-352(%rdi,%r15), %ymm2, %ymm2
-	vpaddq	-352(%rdi,%r12), %ymm2, %ymm2
-	vpaddq	-384(%rdi,%r12), %ymm1, %ymm1
-	vpaddq	-320(%rdi,%r12), %ymm3, %ymm3
-	vpaddq	-288(%rdi,%r12), %ymm4, %ymm4
+	movq	%rsi, %rdx
+	sarq	$25, %rdx
+	vpaddq	96(%rax,%rdx), %ymm4, %ymm4
+	vpaddq	64(%rax,%rdx), %ymm3, %ymm3
+	vpaddq	(%rax,%rdx), %ymm6, %ymm1
+	vpaddq	32(%rax,%rdx), %ymm2, %ymm2
+	vpaddq	32(%r14,%rdx), %ymm2, %ymm2
+	vpaddq	(%r14,%rdx), %ymm1, %ymm1
+	vpaddq	64(%r14,%rdx), %ymm3, %ymm3
+	vpaddq	96(%r14,%rdx), %ymm4, %ymm4
 	vpblendd	$170, %ymm5, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm2, %ymm9 # ymm9 = ymm2[0],ymm5[1],ymm2[2],ymm5[3],ymm2[4],ymm5[5],ymm2[6],ymm5[7]
-	vmovdqu	%ymm9, -352(%rdi,%r12)
-	vmovdqu	%ymm8, -384(%rdi,%r12)
-	vmovdqu	%ymm7, -320(%rdi,%r12)
-	vmovdqu	%ymm6, -288(%rdi,%r12)
+	vmovdqu	%ymm9, -96(%rcx)
+	vmovdqu	%ymm8, -128(%rcx)
+	vmovdqu	%ymm7, -64(%rcx)
+	vmovdqu	%ymm6, -32(%rcx)
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm3, %ymm3
 	vpsrlq	$32, %ymm2, %ymm2
 	vpsrlq	$32, %ymm1, %ymm1
-	vpaddq	-256(%rdi,%r15), %ymm1, %ymm1
-	vpaddq	-224(%rdi,%r15), %ymm2, %ymm2
-	vpaddq	-192(%rdi,%r15), %ymm3, %ymm3
-	vpaddq	-160(%rdi,%r15), %ymm4, %ymm4
-	vpaddq	-160(%rdi,%r12), %ymm4, %ymm4
-	vpaddq	-192(%rdi,%r12), %ymm3, %ymm3
-	vpaddq	-224(%rdi,%r12), %ymm2, %ymm2
-	vpaddq	-256(%rdi,%r12), %ymm1, %ymm1
+	leaq	(%rsi,%r11), %rdx
+	sarq	$25, %rdx
+	vpaddq	(%rax,%rdx), %ymm1, %ymm1
+	vpaddq	32(%rax,%rdx), %ymm2, %ymm2
+	vpaddq	64(%rax,%rdx), %ymm3, %ymm3
+	vpaddq	96(%rax,%rdx), %ymm4, %ymm4
+	vpaddq	96(%r14,%rdx), %ymm4, %ymm4
+	vpaddq	64(%r14,%rdx), %ymm3, %ymm3
+	vpaddq	32(%r14,%rdx), %ymm2, %ymm2
+	vpaddq	(%r14,%rdx), %ymm1, %ymm1
 	vpblendd	$170, %ymm5, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm5[1],ymm2[2],ymm5[3],ymm2[4],ymm5[5],ymm2[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vmovdqu	%ymm9, -160(%rdi,%r12)
-	vmovdqu	%ymm8, -192(%rdi,%r12)
-	vmovdqu	%ymm7, -224(%rdi,%r12)
-	vmovdqu	%ymm6, -256(%rdi,%r12)
+	vmovdqu	%ymm9, 96(%rcx)
+	vmovdqu	%ymm8, 64(%rcx)
+	vmovdqu	%ymm7, 32(%rcx)
+	vmovdqu	%ymm6, (%rcx)
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm3, %ymm3
 	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm1, %ymm1
-	vpaddq	-128(%rdi,%r15), %ymm1, %ymm1
-	vpaddq	-96(%rdi,%r15), %ymm2, %ymm2
-	vpaddq	-64(%rdi,%r15), %ymm3, %ymm3
-	vpaddq	-32(%rdi,%r15), %ymm4, %ymm4
-	vpaddq	-32(%rdi,%r12), %ymm4, %ymm4
-	vpaddq	-64(%rdi,%r12), %ymm3, %ymm3
-	vpaddq	-96(%rdi,%r12), %ymm2, %ymm2
-	vpaddq	-128(%rdi,%r12), %ymm1, %ymm1
+	vpsrlq	$32, %ymm1, %ymm6
+	addq	$2, %rdi
+	addq	$256, %rcx              # imm = 0x100
+	addq	%r10, %rsi
+	cmpl	%edi, %r12d
+	jne	.LBB1_39
+# %bb.31:                               # %for_test.i379.for_test.i394.preheader_crit_edge.unr-lcssa
+	testl	%r9d, %r9d
+	je	.LBB1_33
+.LBB1_32:                               # %for_loop.i390.epil.preheader
+	movslq	%edi, %rcx
+	shlq	$7, %rcx
+	vpaddq	(%rax,%rcx), %ymm6, %ymm1
+	vpaddq	32(%rax,%rcx), %ymm2, %ymm2
+	vpaddq	64(%rax,%rcx), %ymm3, %ymm3
+	vpaddq	96(%rax,%rcx), %ymm4, %ymm4
+	vpaddq	96(%r14,%rcx), %ymm4, %ymm4
+	vpaddq	64(%r14,%rcx), %ymm3, %ymm3
+	vpaddq	32(%r14,%rcx), %ymm2, %ymm2
+	vpaddq	(%r14,%rcx), %ymm1, %ymm1
+	shlq	$7, %rdi
+	vpxor	%xmm5, %xmm5, %xmm5
 	vpblendd	$170, %ymm5, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm5[1],ymm2[2],ymm5[3],ymm2[4],ymm5[5],ymm2[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vmovdqu	%ymm9, -32(%rdi,%r12)
-	vmovdqu	%ymm8, -64(%rdi,%r12)
-	vmovdqu	%ymm7, -96(%rdi,%r12)
-	vmovdqu	%ymm6, -128(%rdi,%r12)
-	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	32(%rdi,%r15), %ymm2, %ymm2
-	vpaddq	(%rdi,%r15), %ymm1, %ymm1
-	vpaddq	96(%rdi,%r15), %ymm4, %ymm4
-	vpaddq	64(%rdi,%r15), %ymm3, %ymm3
-	vpaddq	64(%rdi,%r12), %ymm3, %ymm3
-	vpaddq	96(%rdi,%r12), %ymm4, %ymm4
-	vpaddq	(%rdi,%r12), %ymm1, %ymm1
-	vpaddq	32(%rdi,%r12), %ymm2, %ymm2
-	vpblendd	$170, %ymm5, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm5[1],ymm2[2],ymm5[3],ymm2[4],ymm5[5],ymm2[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
-	vmovdqu	%ymm9, 64(%rdi,%r12)
-	vmovdqu	%ymm8, 96(%rdi,%r12)
-	vmovdqu	%ymm7, (%rdi,%r12)
-	vmovdqu	%ymm6, 32(%rdi,%r12)
+	vpblendd	$170, %ymm5, %ymm4, %ymm5 # ymm5 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
+	vmovdqu	%ymm5, 96(%r14,%rdi)
+	vmovdqu	%ymm8, 64(%r14,%rdi)
+	vmovdqu	%ymm7, 32(%r14,%rdi)
+	vmovdqu	%ymm6, (%r14,%rdi)
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm3, %ymm3
 	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm1, %ymm1
-	addq	$4, %rdx
-	addq	$512, %rdi              # imm = 0x200
-	cmpl	%edx, %esi
+	vpsrlq	$32, %ymm1, %ymm6
+.LBB1_33:                               # %for_test.i394.preheader
+	testl	%r13d, %r13d
+	je	.LBB1_34
+# %bb.36:                               # %for_loop.i406.lr.ph
+	vmovdqa	%ymm6, %ymm0
+	movl	%r13d, %r9d
+	andl	$1, %r9d
+	movl	%r8d, %ecx
+	addl	56(%rsp), %ecx          # 4-byte Folded Reload
 	jne	.LBB1_40
-.LBB1_32:                               # %for_test.i412.for_test.i427.preheader_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	je	.LBB1_35
-# %bb.33:                               # %for_loop.i423.epil.preheader
-	shlq	$7, %rdx
-	addq	%rbx, %rdx
-	vpxor	%xmm5, %xmm5, %xmm5
-	.p2align	4, 0x90
-.LBB1_34:                               # %for_loop.i423.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rdx,%r15), %ymm4, %ymm4
-	vpaddq	64(%rdx,%r15), %ymm3, %ymm3
-	vpaddq	32(%rdx,%r15), %ymm2, %ymm2
-	vpaddq	(%rdx,%r15), %ymm1, %ymm1
-	vpaddq	(%rdx,%r12), %ymm1, %ymm1
-	vpaddq	32(%rdx,%r12), %ymm2, %ymm2
-	vpaddq	64(%rdx,%r12), %ymm3, %ymm3
-	vpaddq	96(%rdx,%r12), %ymm4, %ymm4
-	vpblendd	$170, %ymm5, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm5[1],ymm4[2],ymm5[3],ymm4[4],ymm5[5],ymm4[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm3, %ymm7 # ymm7 = ymm3[0],ymm5[1],ymm3[2],ymm5[3],ymm3[4],ymm5[5],ymm3[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm5[1],ymm2[2],ymm5[3],ymm2[4],ymm5[5],ymm2[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm1, %ymm9 # ymm9 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
-	vmovdqu	%ymm9, (%rdx,%r12)
-	vmovdqu	%ymm8, 32(%rdx,%r12)
-	vmovdqu	%ymm7, 64(%rdx,%r12)
-	vmovdqu	%ymm6, 96(%rdx,%r12)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm4, %ymm4
-	subq	$-128, %rdx
-	decl	%ecx
-	jne	.LBB1_34
-.LBB1_35:                               # %for_test.i427.preheader
-	testl	%r14d, %r14d
-	vmovdqa	%ymm3, 64(%rsp)         # 32-byte Spill
-	vmovdqa	%ymm4, 96(%rsp)         # 32-byte Spill
-	je	.LBB1_36
-# %bb.37:                               # %for_loop.i439.lr.ph
-	movl	%r14d, %ecx
-	andl	$3, %ecx
-	cmpl	$3, %eax
-	jae	.LBB1_41
-# %bb.38:
+# %bb.37:
 	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%edx, %edx
+	xorl	%edi, %edi
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm9, %xmm9, %xmm9
-	jmp	.LBB1_43
-.LBB1_36:
+	vxorps	%xmm9, %xmm9, %xmm9
+	vxorps	%xmm8, %xmm8, %xmm8
+	testl	%r9d, %r9d
+	jne	.LBB1_43
+	jmp	.LBB1_44
+.LBB1_34:
+	vxorps	%xmm9, %xmm9, %xmm9
+	vmovdqa	%ymm6, %ymm15
+	vmovdqa	%ymm2, %ymm7
+	vmovdqa	%ymm3, %ymm8
+	vmovdqa	%ymm4, %ymm1
+.LBB1_35:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit441
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vxorps	%xmm13, %xmm13, %xmm13
+	jmp	.LBB1_62
+.LBB1_40:                               # %for_loop.i406.lr.ph.new
+	movl	%r13d, %r12d
+	subl	%r9d, %r12d
+	movq	48(%rsp), %rcx          # 8-byte Reload
+	addq	%rbx, %rcx
+	addq	$128, %rcx
 	vpxor	%xmm5, %xmm5, %xmm5
-	vmovdqa	%ymm5, 160(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm1, 320(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm1, %ymm5
-	vmovdqa	%ymm2, 352(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm2, %ymm6
-	vmovdqa	%ymm3, %ymm7
-	vmovdqa	%ymm4, %ymm8
-	jmp	.LBB1_49
-.LBB1_41:                               # %for_loop.i439.lr.ph.new
-	movl	%r14d, %esi
-	subl	%ecx, %esi
-	leaq	384(%rbx), %rdi
-	vpxor	%xmm5, %xmm5, %xmm5
-	xorl	%edx, %edx
+	xorl	%esi, %esi
+	xorl	%edi, %edi
 	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm9, %xmm9, %xmm9
+	vxorps	%xmm9, %xmm9, %xmm9
+	vxorps	%xmm8, %xmm8, %xmm8
 	.p2align	4, 0x90
-.LBB1_42:                               # %for_loop.i439
+.LBB1_41:                               # %for_loop.i406
                                         # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rdi,%r12), %ymm9, %ymm9
-	vpaddq	-320(%rdi,%r12), %ymm8, %ymm8
-	vpaddq	-352(%rdi,%r12), %ymm7, %ymm7
-	vpaddq	-384(%rdi,%r12), %ymm6, %ymm6
-	vpaddq	-384(%rdi), %ymm6, %ymm6
-	vpaddq	-352(%rdi), %ymm7, %ymm7
-	vpaddq	-320(%rdi), %ymm8, %ymm8
-	vpaddq	-288(%rdi), %ymm9, %ymm9
-	vpblendd	$170, %ymm5, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vmovdqu	%ymm13, -384(%rdi,%r15)
-	vmovdqu	%ymm12, -352(%rdi,%r15)
-	vmovdqu	%ymm11, -320(%rdi,%r15)
-	vmovdqu	%ymm10, -288(%rdi,%r15)
-	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm8, %ymm8
-	vpaddq	-192(%rdi,%r12), %ymm8, %ymm8
-	vpaddq	-224(%rdi,%r12), %ymm7, %ymm7
-	vpaddq	-256(%rdi,%r12), %ymm6, %ymm6
-	vpaddq	-160(%rdi,%r12), %ymm9, %ymm9
-	vpaddq	-160(%rdi), %ymm9, %ymm9
-	vpaddq	-256(%rdi), %ymm6, %ymm6
-	vpaddq	-224(%rdi), %ymm7, %ymm7
-	vpaddq	-192(%rdi), %ymm8, %ymm8
+	movq	%rsi, %rdx
+	sarq	$25, %rdx
+	vpaddq	96(%r14,%rdx), %ymm8, %ymm8
+	vpaddq	64(%r14,%rdx), %ymm9, %ymm9
+	vpaddq	(%r14,%rdx), %ymm6, %ymm6
+	vpaddq	32(%r14,%rdx), %ymm7, %ymm7
+	vpaddq	32(%rbx,%rdx), %ymm7, %ymm7
+	vpaddq	(%rbx,%rdx), %ymm6, %ymm6
+	vpaddq	64(%rbx,%rdx), %ymm9, %ymm9
+	vpaddq	96(%rbx,%rdx), %ymm8, %ymm8
 	vpblendd	$170, %ymm5, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm9, %ymm13 # ymm13 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
-	vmovdqu	%ymm13, -160(%rdi,%r15)
-	vmovdqu	%ymm12, -256(%rdi,%r15)
-	vmovdqu	%ymm11, -224(%rdi,%r15)
-	vmovdqu	%ymm10, -192(%rdi,%r15)
-	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm8, %ymm8
-	vpaddq	-64(%rdi,%r12), %ymm8, %ymm8
-	vpaddq	-96(%rdi,%r12), %ymm7, %ymm7
-	vpaddq	-128(%rdi,%r12), %ymm6, %ymm6
-	vpaddq	-32(%rdi,%r12), %ymm9, %ymm9
-	vpaddq	-32(%rdi), %ymm9, %ymm9
-	vpaddq	-128(%rdi), %ymm6, %ymm6
-	vpaddq	-96(%rdi), %ymm7, %ymm7
-	vpaddq	-64(%rdi), %ymm8, %ymm8
-	vpblendd	$170, %ymm5, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm9, %ymm13 # ymm13 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
-	vmovdqu	%ymm13, -32(%rdi,%r15)
-	vmovdqu	%ymm12, -128(%rdi,%r15)
-	vmovdqu	%ymm11, -96(%rdi,%r15)
-	vmovdqu	%ymm10, -64(%rdi,%r15)
+	vpblendd	$170, %ymm5, %ymm7, %ymm13 # ymm13 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
+	vmovdqu	%ymm13, -96(%rcx)
+	vmovdqu	%ymm12, -128(%rcx)
+	vmovdqu	%ymm11, -64(%rcx)
+	vmovdqu	%ymm10, -32(%rcx)
 	vpsrlq	$32, %ymm8, %ymm8
 	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm7, %ymm7
-	vpaddq	32(%rdi,%r12), %ymm7, %ymm7
-	vpaddq	(%rdi,%r12), %ymm6, %ymm6
-	vpaddq	96(%rdi,%r12), %ymm9, %ymm9
-	vpaddq	64(%rdi,%r12), %ymm8, %ymm8
-	vpaddq	64(%rdi), %ymm8, %ymm8
-	vpaddq	96(%rdi), %ymm9, %ymm9
-	vpaddq	(%rdi), %ymm6, %ymm6
-	vpaddq	32(%rdi), %ymm7, %ymm7
-	vpblendd	$170, %ymm5, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vpsrlq	$32, %ymm6, %ymm6
+	leaq	(%rsi,%r11), %rdx
+	sarq	$25, %rdx
+	vpaddq	(%r14,%rdx), %ymm6, %ymm6
+	vpaddq	32(%r14,%rdx), %ymm7, %ymm7
+	vpaddq	64(%r14,%rdx), %ymm9, %ymm9
+	vpaddq	96(%r14,%rdx), %ymm8, %ymm8
+	vpaddq	96(%rbx,%rdx), %ymm8, %ymm8
+	vpaddq	64(%rbx,%rdx), %ymm9, %ymm9
+	vpaddq	32(%rbx,%rdx), %ymm7, %ymm7
+	vpaddq	(%rbx,%rdx), %ymm6, %ymm6
+	vpblendd	$170, %ymm5, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
+	vpblendd	$170, %ymm5, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
 	vpblendd	$170, %ymm5, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vmovdqu	%ymm13, 64(%rdi,%r15)
-	vmovdqu	%ymm12, 96(%rdi,%r15)
-	vmovdqu	%ymm11, (%rdi,%r15)
-	vmovdqu	%ymm10, 32(%rdi,%r15)
-	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm6, %ymm6
-	addq	$4, %rdx
-	addq	$512, %rdi              # imm = 0x200
-	cmpl	%edx, %esi
-	jne	.LBB1_42
-.LBB1_43:                               # %for_test.i427.bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit440_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	je	.LBB1_46
-# %bb.44:                               # %for_loop.i439.epil.preheader
-	shlq	$7, %rdx
-	addq	%rbx, %rdx
-	vpxor	%xmm5, %xmm5, %xmm5
-	.p2align	4, 0x90
-.LBB1_45:                               # %for_loop.i439.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rdx,%r12), %ymm9, %ymm9
-	vpaddq	32(%rdx,%r12), %ymm7, %ymm7
-	vpaddq	(%rdx,%r12), %ymm6, %ymm6
-	vpaddq	64(%rdx,%r12), %ymm8, %ymm8
-	vpaddq	64(%rdx), %ymm8, %ymm8
-	vpaddq	(%rdx), %ymm6, %ymm6
-	vpaddq	32(%rdx), %ymm7, %ymm7
-	vpaddq	96(%rdx), %ymm9, %ymm9
-	vpblendd	$170, %ymm5, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm5[1],ymm9[2],ymm5[3],ymm9[4],ymm5[5],ymm9[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm6, %ymm12 # ymm12 = ymm6[0],ymm5[1],ymm6[2],ymm5[3],ymm6[4],ymm5[5],ymm6[6],ymm5[7]
-	vpblendd	$170, %ymm5, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm5[1],ymm8[2],ymm5[3],ymm8[4],ymm5[5],ymm8[6],ymm5[7]
-	vmovdqu	%ymm13, 64(%rdx,%r15)
-	vmovdqu	%ymm12, (%rdx,%r15)
-	vmovdqu	%ymm11, 32(%rdx,%r15)
-	vmovdqu	%ymm10, 96(%rdx,%r15)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm7, %ymm7
+	vmovdqu	%ymm13, 96(%rcx)
+	vmovdqu	%ymm12, 64(%rcx)
+	vmovdqu	%ymm11, 32(%rcx)
+	vmovdqu	%ymm10, (%rcx)
 	vpsrlq	$32, %ymm8, %ymm8
 	vpsrlq	$32, %ymm9, %ymm9
-	subq	$-128, %rdx
-	decl	%ecx
-	jne	.LBB1_45
-.LBB1_46:                               # %bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit440
-	vpaddq	%ymm1, %ymm6, %ymm5
-	vpaddq	%ymm2, %ymm7, %ymm6
-	vpaddq	%ymm3, %ymm8, %ymm7
-	vpaddq	%ymm4, %ymm9, %ymm8
-	testl	%r14d, %r14d
-	je	.LBB1_47
-# %bb.50:                               # %for_loop.i456.lr.ph
-	movl	%r14d, %ecx
-	andl	$3, %ecx
-	vmovdqa	%ymm2, %ymm4
-	vmovdqa	%ymm1, %ymm3
-	cmpl	$3, %eax
-	jae	.LBB1_52
-# %bb.51:
-	vpxor	%xmm10, %xmm10, %xmm10
-	xorl	%eax, %eax
-	vpxor	%xmm12, %xmm12, %xmm12
-	vxorps	%xmm11, %xmm11, %xmm11
-	vpxor	%xmm13, %xmm13, %xmm13
-	movq	256(%rsp), %rdi         # 8-byte Reload
-	jmp	.LBB1_54
-.LBB1_47:
-	vmovdqa	%ymm2, 352(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm1, 320(%rsp)        # 32-byte Spill
-.LBB1_48:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit474
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
-.LBB1_49:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit474
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 288(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 192(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 224(%rsp)        # 32-byte Spill
-	movq	256(%rsp), %rdi         # 8-byte Reload
-.LBB1_68:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit474
-	vpcmpeqd	%ymm15, %ymm15, %ymm15
-	vmovaps	.LCPI1_4(%rip), %ymm13  # ymm13 = [0,0,1,1,2,2,3,3]
-	vmovaps	.LCPI1_5(%rip), %ymm14  # ymm14 = [4,4,5,5,6,6,7,7]
-	vpcmpeqd	%ymm9, %ymm9, %ymm9
-	.p2align	4, 0x90
-.LBB1_69:                               # %for_test
-                                        # =>This Inner Loop Header: Depth=1
-	vpcmpeqq	%ymm0, %ymm6, %ymm1
-	vextracti128	$1, %ymm1, %xmm2
-	vpackssdw	%xmm2, %xmm1, %xmm1
-	vpcmpeqq	%ymm0, %ymm5, %ymm2
-	vextracti128	$1, %ymm2, %xmm10
-	vpackssdw	%xmm10, %xmm2, %xmm2
-	vinserti128	$1, %xmm1, %ymm2, %ymm1
-	vpandn	%ymm15, %ymm1, %ymm15
-	vpcmpeqq	%ymm0, %ymm8, %ymm1
-	vextracti128	$1, %ymm1, %xmm2
-	vpackssdw	%xmm2, %xmm1, %xmm1
-	vpcmpeqq	%ymm0, %ymm7, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vinserti128	$1, %xmm1, %ymm2, %ymm1
-	vpandn	%ymm9, %ymm1, %ymm9
-	vmovmskps	%ymm15, %eax
-	vmovmskps	%ymm9, %ecx
-	shll	$8, %ecx
-	orl	%eax, %ecx
-	je	.LBB1_71
-# %bb.70:                               # %for_loop
-                                        #   in Loop: Header=BB1_69 Depth=1
-	movl	%edi, %eax
-	shlq	$7, %rax
-	vpaddq	(%rbx,%rax), %ymm5, %ymm1
-	vpaddq	32(%rbx,%rax), %ymm6, %ymm2
-	vpaddq	64(%rbx,%rax), %ymm7, %ymm3
-	vpaddq	96(%rbx,%rax), %ymm8, %ymm10
-	vpblendd	$170, %ymm0, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpermps	%ymm15, %ymm13, %ymm12
-	vmaskmovpd	%ymm11, %ymm12, (%rbx,%rax)
-	vpblendd	$170, %ymm0, %ymm2, %ymm11 # ymm11 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpermps	%ymm15, %ymm14, %ymm4
-	vmaskmovpd	%ymm11, %ymm4, 32(%rbx,%rax)
-	vpsrlq	$32, %ymm1, %ymm1
-	vblendvpd	%ymm12, %ymm1, %ymm5, %ymm5
-	vpblendd	$170, %ymm0, %ymm3, %ymm1 # ymm1 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpermps	%ymm9, %ymm13, %ymm11
-	vmaskmovpd	%ymm1, %ymm11, 64(%rbx,%rax)
-	vpsrlq	$32, %ymm2, %ymm1
-	vblendvpd	%ymm4, %ymm1, %ymm6, %ymm6
-	vpsrlq	$32, %ymm3, %ymm1
-	vblendvpd	%ymm11, %ymm1, %ymm7, %ymm7
-	vpblendd	$170, %ymm0, %ymm10, %ymm1 # ymm1 = ymm10[0],ymm0[1],ymm10[2],ymm0[3],ymm10[4],ymm0[5],ymm10[6],ymm0[7]
-	vpermps	%ymm9, %ymm14, %ymm2
-	vmaskmovpd	%ymm1, %ymm2, 96(%rbx,%rax)
-	vpsrlq	$32, %ymm10, %ymm1
-	vblendvpd	%ymm2, %ymm1, %ymm8, %ymm8
-	incl	%edi
-	jmp	.LBB1_69
-.LBB1_71:                               # %for_exit
-	vmovdqa	160(%rsp), %ymm0        # 32-byte Reload
-	vpaddq	320(%rsp), %ymm0, %ymm8 # 32-byte Folded Reload
-	vmovdqa	288(%rsp), %ymm0        # 32-byte Reload
-	vpaddq	352(%rsp), %ymm0, %ymm9 # 32-byte Folded Reload
-	vmovdqa	192(%rsp), %ymm0        # 32-byte Reload
-	vpaddq	64(%rsp), %ymm0, %ymm2  # 32-byte Folded Reload
-	vmovdqa	224(%rsp), %ymm0        # 32-byte Reload
-	vpaddq	96(%rsp), %ymm0, %ymm3  # 32-byte Folded Reload
-	leal	(%r14,%r14,2), %eax
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpcmpeqd	%ymm6, %ymm6, %ymm6
-	.p2align	4, 0x90
-.LBB1_72:                               # %for_test200
-                                        # =>This Inner Loop Header: Depth=1
-	vpcmpeqq	%ymm5, %ymm9, %ymm7
-	vextracti128	$1, %ymm7, %xmm0
-	vpackssdw	%xmm0, %xmm7, %xmm0
-	vpcmpeqq	%ymm5, %ymm8, %ymm7
-	vextracti128	$1, %ymm7, %xmm1
-	vpackssdw	%xmm1, %xmm7, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm4, %ymm0, %ymm4
-	vpcmpeqq	%ymm5, %ymm3, %ymm0
-	vextracti128	$1, %ymm0, %xmm1
-	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm5, %ymm2, %ymm1
-	vextracti128	$1, %ymm1, %xmm7
-	vpackssdw	%xmm7, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm6, %ymm0, %ymm6
-	vmovmskps	%ymm4, %ecx
-	vmovmskps	%ymm6, %edx
-	shll	$8, %edx
-	orl	%ecx, %edx
-	je	.LBB1_74
-# %bb.73:                               # %for_loop201
-                                        #   in Loop: Header=BB1_72 Depth=1
-	movl	%eax, %ecx
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm6, %ymm6
+	addq	$2, %rdi
+	addq	$256, %rcx              # imm = 0x100
+	addq	%r10, %rsi
+	cmpl	%edi, %r12d
+	jne	.LBB1_41
+# %bb.42:                               # %for_test.i394.bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit407_crit_edge.unr-lcssa
+	testl	%r9d, %r9d
+	je	.LBB1_44
+.LBB1_43:                               # %for_loop.i406.epil.preheader
+	movslq	%edi, %rcx
 	shlq	$7, %rcx
-	vpaddq	(%rbx,%rcx), %ymm8, %ymm0
-	vpaddq	32(%rbx,%rcx), %ymm9, %ymm1
-	vpaddq	64(%rbx,%rcx), %ymm2, %ymm7
-	vpaddq	96(%rbx,%rcx), %ymm3, %ymm10
-	vpblendd	$170, %ymm5, %ymm0, %ymm11 # ymm11 = ymm0[0],ymm5[1],ymm0[2],ymm5[3],ymm0[4],ymm5[5],ymm0[6],ymm5[7]
-	vpermps	%ymm4, %ymm13, %ymm12
-	vmaskmovpd	%ymm11, %ymm12, (%rbx,%rcx)
-	vpblendd	$170, %ymm5, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm5[1],ymm1[2],ymm5[3],ymm1[4],ymm5[5],ymm1[6],ymm5[7]
-	vpermps	%ymm4, %ymm14, %ymm15
-	vmaskmovpd	%ymm11, %ymm15, 32(%rbx,%rcx)
+	vpaddq	(%r14,%rcx), %ymm6, %ymm5
+	vpaddq	32(%r14,%rcx), %ymm7, %ymm6
+	vpaddq	64(%r14,%rcx), %ymm9, %ymm7
+	vpaddq	96(%r14,%rcx), %ymm8, %ymm8
+	vpaddq	96(%rbx,%rcx), %ymm8, %ymm8
+	vpaddq	64(%rbx,%rcx), %ymm7, %ymm7
+	vpaddq	32(%rbx,%rcx), %ymm6, %ymm6
+	vpaddq	(%rbx,%rcx), %ymm5, %ymm5
+	shlq	$7, %rdi
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpblendd	$170, %ymm9, %ymm5, %ymm10 # ymm10 = ymm5[0],ymm9[1],ymm5[2],ymm9[3],ymm5[4],ymm9[5],ymm5[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm9[1],ymm6[2],ymm9[3],ymm6[4],ymm9[5],ymm6[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm9[1],ymm7[2],ymm9[3],ymm7[4],ymm9[5],ymm7[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm8, %ymm9 # ymm9 = ymm8[0],ymm9[1],ymm8[2],ymm9[3],ymm8[4],ymm9[5],ymm8[6],ymm9[7]
+	vmovdqu	%ymm9, 96(%rax,%rdi)
+	vmovdqu	%ymm12, 64(%rax,%rdi)
+	vmovdqu	%ymm11, 32(%rax,%rdi)
+	vmovdqu	%ymm10, (%rax,%rdi)
+	vpsrlq	$32, %ymm8, %ymm8
+	vpsrlq	$32, %ymm7, %ymm9
+	vpsrlq	$32, %ymm6, %ymm7
+	vpsrlq	$32, %ymm5, %ymm6
+.LBB1_44:                               # %bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit407
+	vpaddq	%ymm0, %ymm6, %ymm15
+	vmovdqa	%ymm0, %ymm6
+	vpaddq	%ymm2, %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm9, %ymm0
+	vpaddq	%ymm4, %ymm8, %ymm1
+	testl	%r13d, %r13d
+	movq	48(%rsp), %rsi          # 8-byte Reload
+	je	.LBB1_45
+# %bb.46:                               # %for_loop.i423.lr.ph
+	addq	%r14, %rsi
+	movl	%r13d, %r9d
+	andl	$1, %r9d
+	addl	56(%rsp), %r8d          # 4-byte Folded Reload
+	vmovdqa	%ymm1, 96(%rsp)         # 32-byte Spill
+	vmovdqa	%ymm15, %ymm5
+	jne	.LBB1_48
+# %bb.47:
+	vpxor	%xmm10, %xmm10, %xmm10
+	xorl	%r12d, %r12d
+	vpxor	%xmm12, %xmm12, %xmm12
+	vxorps	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm11, %xmm11, %xmm11
+	vmovdqa	%ymm0, %ymm8
+	testl	%r9d, %r9d
+	jne	.LBB1_51
+	jmp	.LBB1_52
+.LBB1_45:
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vxorps	%xmm13, %xmm13, %xmm13
+	vmovdqa	%ymm0, %ymm8
+	jmp	.LBB1_62
+.LBB1_48:                               # %for_loop.i423.lr.ph.new
+	movl	%r13d, %r8d
+	subl	%r9d, %r8d
+	movq	128(%rsp), %rcx         # 8-byte Reload
+	addq	%rbx, %rcx
+	addq	$128, %rcx
+	vpxor	%xmm9, %xmm9, %xmm9
+	xorl	%edi, %edi
+	xorl	%r12d, %r12d
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm12, %xmm12, %xmm12
+	vxorps	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm11, %xmm11, %xmm11
+	vmovdqa	%ymm0, %ymm8
+	.p2align	4, 0x90
+.LBB1_49:                               # %for_loop.i423
+                                        # =>This Inner Loop Header: Depth=1
+	movq	%rdi, %rdx
+	sarq	$25, %rdx
+	vpaddq	96(%r14,%rdx), %ymm11, %ymm11
+	vpaddq	64(%r14,%rdx), %ymm13, %ymm13
+	vpaddq	(%r14,%rdx), %ymm10, %ymm10
+	vpaddq	32(%r14,%rdx), %ymm12, %ymm12
+	vpaddq	32(%rsi,%rdx), %ymm12, %ymm12
+	vpaddq	(%rsi,%rdx), %ymm10, %ymm10
+	vpaddq	64(%rsi,%rdx), %ymm13, %ymm13
+	vpaddq	96(%rsi,%rdx), %ymm11, %ymm11
+	vpblendd	$170, %ymm9, %ymm11, %ymm14 # ymm14 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm13, %ymm15 # ymm15 = ymm13[0],ymm9[1],ymm13[2],ymm9[3],ymm13[4],ymm9[5],ymm13[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm10, %ymm0 # ymm0 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm12, %ymm1 # ymm1 = ymm12[0],ymm9[1],ymm12[2],ymm9[3],ymm12[4],ymm9[5],ymm12[6],ymm9[7]
+	vmovdqu	%ymm1, -96(%rcx)
+	vmovdqu	%ymm0, -128(%rcx)
+	vmovdqu	%ymm15, -64(%rcx)
+	vmovdqu	%ymm14, -32(%rcx)
+	vpsrlq	$32, %ymm11, %ymm0
+	vpsrlq	$32, %ymm13, %ymm1
+	vpsrlq	$32, %ymm12, %ymm11
+	vpsrlq	$32, %ymm10, %ymm10
+	leaq	(%rdi,%r11), %rdx
+	sarq	$25, %rdx
+	vpaddq	(%r14,%rdx), %ymm10, %ymm10
+	vpaddq	32(%r14,%rdx), %ymm11, %ymm11
+	vpaddq	64(%r14,%rdx), %ymm1, %ymm1
+	vpaddq	96(%r14,%rdx), %ymm0, %ymm0
+	vpaddq	96(%rsi,%rdx), %ymm0, %ymm0
+	vpaddq	64(%rsi,%rdx), %ymm1, %ymm1
+	vpaddq	32(%rsi,%rdx), %ymm11, %ymm12
+	vpaddq	(%rsi,%rdx), %ymm10, %ymm10
+	vpblendd	$170, %ymm9, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm12, %ymm13 # ymm13 = ymm12[0],ymm9[1],ymm12[2],ymm9[3],ymm12[4],ymm9[5],ymm12[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vpblendd	$170, %ymm9, %ymm0, %ymm15 # ymm15 = ymm0[0],ymm9[1],ymm0[2],ymm9[3],ymm0[4],ymm9[5],ymm0[6],ymm9[7]
+	vmovdqu	%ymm15, 96(%rcx)
+	vmovdqu	%ymm14, 64(%rcx)
+	vmovdqu	%ymm13, 32(%rcx)
+	vmovdqu	%ymm11, (%rcx)
+	vpsrlq	$32, %ymm0, %ymm11
+	vpsrlq	$32, %ymm1, %ymm13
+	vpsrlq	$32, %ymm12, %ymm12
+	vpsrlq	$32, %ymm10, %ymm10
+	addq	$2, %r12
+	addq	$256, %rcx              # imm = 0x100
+	addq	%r10, %rdi
+	cmpl	%r12d, %r8d
+	jne	.LBB1_49
+# %bb.50:                               # %for_test.i411.bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit424_crit_edge.unr-lcssa
+	testl	%r9d, %r9d
+	je	.LBB1_52
+.LBB1_51:                               # %for_loop.i423.epil.preheader
+	movslq	%r12d, %rcx
+	shlq	$7, %rcx
+	vpaddq	(%r14,%rcx), %ymm10, %ymm0
+	vpaddq	32(%r14,%rcx), %ymm12, %ymm1
+	vpaddq	64(%r14,%rcx), %ymm13, %ymm9
+	vpaddq	96(%r14,%rcx), %ymm11, %ymm10
+	vpaddq	96(%rsi,%rcx), %ymm10, %ymm10
+	vpaddq	64(%rsi,%rcx), %ymm9, %ymm9
+	vpaddq	32(%rsi,%rcx), %ymm1, %ymm1
+	vpaddq	(%rsi,%rcx), %ymm0, %ymm0
+	shlq	$7, %r12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpblendd	$170, %ymm11, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm11[1],ymm0[2],ymm11[3],ymm0[4],ymm11[5],ymm0[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+	vpblendd	$170, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
+	vmovdqu	%ymm11, 96(%r14,%r12)
+	vmovdqu	%ymm14, 64(%r14,%r12)
+	vmovdqu	%ymm13, 32(%r14,%r12)
+	vmovdqu	%ymm12, (%r14,%r12)
+	vpsrlq	$32, %ymm10, %ymm11
+	vpsrlq	$32, %ymm9, %ymm13
+	vpsrlq	$32, %ymm1, %ymm12
+	vpsrlq	$32, %ymm0, %ymm10
+.LBB1_52:                               # %bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit424
+	vpaddq	%ymm6, %ymm10, %ymm6
+	vpaddq	%ymm2, %ymm12, %ymm2
+	vpaddq	%ymm3, %ymm13, %ymm3
+	vpaddq	%ymm4, %ymm11, %ymm4
+	testl	%r15d, %r15d
+	je	.LBB1_53
+# %bb.54:                               # %for_loop.i440.lr.ph
+	movq	56(%rsp), %rcx          # 8-byte Reload
+	leal	(%rcx,%rcx), %esi
+	orl	$1, %ecx
+	movl	%esi, %edx
+	subl	%ecx, %edx
+	movl	%r15d, %ecx
+	andl	$2, %ecx
+	cmpl	$3, %edx
+	jae	.LBB1_56
+# %bb.55:
+	vpxor	%xmm9, %xmm9, %xmm9
+	xorl	%edx, %edx
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm13, %xmm13, %xmm13
+	testl	%ecx, %ecx
+	jne	.LBB1_59
+	jmp	.LBB1_61
+.LBB1_53:
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm13, %xmm13, %xmm13
+	jmp	.LBB1_61
+.LBB1_56:                               # %for_loop.i440.lr.ph.new
+	movq	64(%rsp), %rdx          # 8-byte Reload
+	leal	(%rcx,%rdx,2), %edx
+	subl	%edx, %esi
+	vpxor	%xmm10, %xmm10, %xmm10
+	movl	$384, %edi              # imm = 0x180
+	xorl	%edx, %edx
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm13, %xmm13, %xmm13
+	.p2align	4, 0x90
+.LBB1_57:                               # %for_loop.i440
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqu	-384(%rax,%rdi), %ymm0
+	vmovdqu	-352(%rax,%rdi), %ymm1
+	vmovdqu	-320(%rax,%rdi), %ymm14
+	vmovdqu	-288(%rax,%rdi), %ymm15
+	vpsubq	96(%rsp,%rdi), %ymm15, %ymm15
+	vpsubq	(%rsp,%rdi), %ymm0, %ymm0
+	vpaddq	%ymm13, %ymm15, %ymm13
+	vpaddq	%ymm9, %ymm0, %ymm0
+	vpsubq	32(%rsp,%rdi), %ymm1, %ymm1
+	vpaddq	%ymm12, %ymm1, %ymm1
+	vpsubq	64(%rsp,%rdi), %ymm14, %ymm9
+	vpaddq	%ymm11, %ymm9, %ymm9
+	vpblendd	$170, %ymm10, %ymm13, %ymm11 # ymm11 = ymm13[0],ymm10[1],ymm13[2],ymm10[3],ymm13[4],ymm10[5],ymm13[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm15 # ymm15 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vmovdqu	%ymm15, -320(%rax,%rdi)
+	vmovdqu	%ymm14, -352(%rax,%rdi)
+	vmovdqu	%ymm12, -384(%rax,%rdi)
+	vmovdqu	%ymm11, -288(%rax,%rdi)
 	vpsrad	$31, %ymm0, %ymm11
 	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm11, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm11[1],ymm0[2],ymm11[3],ymm0[4],ymm11[5],ymm0[6],ymm11[7]
-	vblendvpd	%ymm12, %ymm0, %ymm8, %ymm8
-	vpblendd	$170, %ymm5, %ymm7, %ymm0 # ymm0 = ymm7[0],ymm5[1],ymm7[2],ymm5[3],ymm7[4],ymm5[5],ymm7[6],ymm5[7]
-	vpermps	%ymm6, %ymm13, %ymm11
-	vmaskmovpd	%ymm0, %ymm11, 64(%rbx,%rcx)
-	vpsrad	$31, %ymm1, %ymm0
+	vpsrad	$31, %ymm1, %ymm11
 	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm0 # ymm0 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vblendvpd	%ymm15, %ymm0, %ymm9, %ymm9
-	vpblendd	$170, %ymm5, %ymm10, %ymm0 # ymm0 = ymm10[0],ymm5[1],ymm10[2],ymm5[3],ymm10[4],ymm5[5],ymm10[6],ymm5[7]
-	vpermps	%ymm6, %ymm14, %ymm1
-	vmaskmovpd	%ymm0, %ymm1, 96(%rbx,%rcx)
-	vpsrad	$31, %ymm7, %ymm0
-	vpshufd	$245, %ymm7, %ymm7      # ymm7 = ymm7[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm7, %ymm0 # ymm0 = ymm7[0],ymm0[1],ymm7[2],ymm0[3],ymm7[4],ymm0[5],ymm7[6],ymm0[7]
-	vblendvpd	%ymm11, %ymm0, %ymm2, %ymm2
-	vpsrad	$31, %ymm10, %ymm0
-	vpshufd	$245, %ymm10, %ymm7     # ymm7 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm7, %ymm0 # ymm0 = ymm7[0],ymm0[1],ymm7[2],ymm0[3],ymm7[4],ymm0[5],ymm7[6],ymm0[7]
-	vblendvpd	%ymm1, %ymm0, %ymm3, %ymm3
-	incl	%eax
-	jmp	.LBB1_72
-.LBB1_74:                               # %for_exit203
+	vpblendd	$170, %ymm11, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
+	vpsrad	$31, %ymm9, %ymm11
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm11, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+	vpsrad	$31, %ymm13, %ymm11
+	vpshufd	$245, %ymm13, %ymm12    # ymm12 = ymm13[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm11, %ymm12, %ymm11 # ymm11 = ymm12[0],ymm11[1],ymm12[2],ymm11[3],ymm12[4],ymm11[5],ymm12[6],ymm11[7]
+	vmovdqu	-160(%rax,%rdi), %ymm12
+	vmovdqu	-192(%rax,%rdi), %ymm13
+	vmovdqu	-224(%rax,%rdi), %ymm14
+	vmovdqu	-256(%rax,%rdi), %ymm15
+	vpsubq	128(%rsp,%rdi), %ymm15, %ymm15
+	vpsubq	160(%rsp,%rdi), %ymm14, %ymm14
+	vpaddq	%ymm0, %ymm15, %ymm0
+	vpaddq	%ymm1, %ymm14, %ymm1
+	vpsubq	192(%rsp,%rdi), %ymm13, %ymm13
+	vpaddq	%ymm9, %ymm13, %ymm9
+	vpsubq	224(%rsp,%rdi), %ymm12, %ymm12
+	vpaddq	%ymm11, %ymm12, %ymm11
+	vpblendd	$170, %ymm10, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm11, %ymm15 # ymm15 = ymm11[0],ymm10[1],ymm11[2],ymm10[3],ymm11[4],ymm10[5],ymm11[6],ymm10[7]
+	vmovdqu	%ymm15, -160(%rax,%rdi)
+	vmovdqu	%ymm14, -192(%rax,%rdi)
+	vmovdqu	%ymm13, -224(%rax,%rdi)
+	vmovdqu	%ymm12, -256(%rax,%rdi)
+	vpsrad	$31, %ymm0, %ymm12
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vpsrad	$31, %ymm1, %ymm12
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vpsrad	$31, %ymm9, %ymm12
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+	vpsrad	$31, %ymm11, %ymm12
+	vpshufd	$245, %ymm11, %ymm11    # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+	vmovdqu	-32(%rax,%rdi), %ymm12
+	vmovdqu	-64(%rax,%rdi), %ymm13
+	vmovdqu	-96(%rax,%rdi), %ymm14
+	vmovdqu	-128(%rax,%rdi), %ymm15
+	vpsubq	256(%rsp,%rdi), %ymm15, %ymm15
+	vpsubq	288(%rsp,%rdi), %ymm14, %ymm14
+	vpaddq	%ymm0, %ymm15, %ymm0
+	vpaddq	%ymm1, %ymm14, %ymm1
+	vpsubq	320(%rsp,%rdi), %ymm13, %ymm13
+	vpaddq	%ymm9, %ymm13, %ymm9
+	vpsubq	352(%rsp,%rdi), %ymm12, %ymm12
+	vpaddq	%ymm11, %ymm12, %ymm11
+	vpblendd	$170, %ymm10, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm11, %ymm15 # ymm15 = ymm11[0],ymm10[1],ymm11[2],ymm10[3],ymm11[4],ymm10[5],ymm11[6],ymm10[7]
+	vmovdqu	%ymm15, -32(%rax,%rdi)
+	vmovdqu	%ymm14, -64(%rax,%rdi)
+	vmovdqu	%ymm13, -96(%rax,%rdi)
+	vmovdqu	%ymm12, -128(%rax,%rdi)
+	vpsrad	$31, %ymm0, %ymm12
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm0, %ymm0 # ymm0 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vpsrad	$31, %ymm1, %ymm12
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vpsrad	$31, %ymm9, %ymm12
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm12[1],ymm9[2],ymm12[3],ymm9[4],ymm12[5],ymm9[6],ymm12[7]
+	vpsrad	$31, %ymm11, %ymm12
+	vpshufd	$245, %ymm11, %ymm11    # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm11, %ymm11 # ymm11 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+	vmovdqu	96(%rax,%rdi), %ymm12
+	vmovdqu	64(%rax,%rdi), %ymm13
+	vmovdqu	32(%rax,%rdi), %ymm14
+	vmovdqu	(%rax,%rdi), %ymm15
+	vpsubq	384(%rsp,%rdi), %ymm15, %ymm15
+	vpsubq	416(%rsp,%rdi), %ymm14, %ymm14
+	vpaddq	%ymm0, %ymm15, %ymm0
+	vpaddq	%ymm1, %ymm14, %ymm1
+	vpsubq	448(%rsp,%rdi), %ymm13, %ymm13
+	vpaddq	%ymm9, %ymm13, %ymm9
+	vpsubq	480(%rsp,%rdi), %ymm12, %ymm12
+	vpaddq	%ymm11, %ymm12, %ymm11
+	vpblendd	$170, %ymm10, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm11, %ymm15 # ymm15 = ymm11[0],ymm10[1],ymm11[2],ymm10[3],ymm11[4],ymm10[5],ymm11[6],ymm10[7]
+	vmovdqu	%ymm15, 96(%rax,%rdi)
+	vmovdqu	%ymm14, 64(%rax,%rdi)
+	vmovdqu	%ymm13, 32(%rax,%rdi)
+	vmovdqu	%ymm12, (%rax,%rdi)
+	vpsrad	$31, %ymm11, %ymm12
+	vpshufd	$245, %ymm11, %ymm11    # ymm11 = ymm11[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm12, %ymm11, %ymm13 # ymm13 = ymm11[0],ymm12[1],ymm11[2],ymm12[3],ymm11[4],ymm12[5],ymm11[6],ymm12[7]
+	vpsrad	$31, %ymm9, %ymm11
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm11, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+	vpsrad	$31, %ymm1, %ymm9
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm9, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vpsrad	$31, %ymm0, %ymm1
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm1, %ymm0, %ymm9 # ymm9 = ymm0[0],ymm1[1],ymm0[2],ymm1[3],ymm0[4],ymm1[5],ymm0[6],ymm1[7]
+	addq	$4, %rdx
+	addq	$512, %rdi              # imm = 0x200
+	cmpl	%edx, %esi
+	jne	.LBB1_57
+# %bb.58:                               # %for_test.i428.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit441_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB1_61
+.LBB1_59:                               # %for_loop.i440.epil.preheader
+	shlq	$7, %rdx
+	negl	%ecx
+	vpxor	%xmm10, %xmm10, %xmm10
+	.p2align	4, 0x90
+.LBB1_60:                               # %for_loop.i440.epil
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqu	(%rax,%rdx), %ymm0
+	vmovdqu	32(%rax,%rdx), %ymm1
+	vmovdqu	64(%rax,%rdx), %ymm14
+	vmovdqu	96(%rax,%rdx), %ymm15
+	vpsubq	480(%rsp,%rdx), %ymm15, %ymm15
+	vpaddq	%ymm13, %ymm15, %ymm13
+	vpsubq	384(%rsp,%rdx), %ymm0, %ymm0
+	vpaddq	%ymm9, %ymm0, %ymm0
+	vpsubq	416(%rsp,%rdx), %ymm1, %ymm1
+	vpsubq	448(%rsp,%rdx), %ymm14, %ymm9
+	vpaddq	%ymm12, %ymm1, %ymm1
+	vpaddq	%ymm11, %ymm9, %ymm9
+	vpblendd	$170, %ymm10, %ymm13, %ymm11 # ymm11 = ymm13[0],ymm10[1],ymm13[2],ymm10[3],ymm13[4],ymm10[5],ymm13[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm0, %ymm12 # ymm12 = ymm0[0],ymm10[1],ymm0[2],ymm10[3],ymm0[4],ymm10[5],ymm0[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm9, %ymm15 # ymm15 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
+	vmovdqu	%ymm15, 64(%rax,%rdx)
+	vmovdqu	%ymm14, 32(%rax,%rdx)
+	vmovdqu	%ymm12, (%rax,%rdx)
+	vmovdqu	%ymm11, 96(%rax,%rdx)
+	vpsrad	$31, %ymm9, %ymm11
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm11, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
+	vpsrad	$31, %ymm1, %ymm9
+	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm9, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vpsrad	$31, %ymm0, %ymm1
+	vpshufd	$245, %ymm0, %ymm0      # ymm0 = ymm0[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm1, %ymm0, %ymm9 # ymm9 = ymm0[0],ymm1[1],ymm0[2],ymm1[3],ymm0[4],ymm1[5],ymm0[6],ymm1[7]
+	vpsrad	$31, %ymm13, %ymm0
+	vpshufd	$245, %ymm13, %ymm1     # ymm1 = ymm13[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	subq	$-128, %rdx
+	addl	$1, %ecx
+	jne	.LBB1_60
+.LBB1_61:
+	vxorps	%xmm14, %xmm14, %xmm14
+	vmovdqa	%ymm5, %ymm15
+	vmovdqa	96(%rsp), %ymm1         # 32-byte Reload
+.LBB1_62:                               # %bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit441
+	vpaddq	%ymm13, %ymm4, %ymm0
+	vmovdqa	%ymm0, 64(%rsp)         # 32-byte Spill
+	vpaddq	%ymm11, %ymm3, %ymm0
+	vmovdqa	%ymm0, 96(%rsp)         # 32-byte Spill
+	vpaddq	%ymm12, %ymm2, %ymm0
+	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vpaddq	%ymm9, %ymm6, %ymm0
+	vmovdqa	%ymm0, 160(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm14, %ymm1, %ymm0
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vmovdqa	%ymm1, %ymm9
+	vpxor	%ymm2, %ymm0, %ymm10
+	vextracti128	$1, %ymm10, %xmm0
+	vpackssdw	%xmm0, %xmm10, %xmm11
+	vpcmpeqq	%ymm14, %ymm8, %ymm10
+	vpxor	%ymm2, %ymm10, %ymm10
+	vextracti128	$1, %ymm10, %xmm0
+	vpackssdw	%xmm0, %xmm10, %xmm0
+	vinserti128	$1, %xmm11, %ymm0, %ymm1
+	vpcmpeqq	%ymm14, %ymm7, %ymm0
+	vpxor	%ymm2, %ymm0, %ymm11
+	vextracti128	$1, %ymm11, %xmm0
+	vpackssdw	%xmm0, %xmm11, %xmm12
+	vpcmpeqq	%ymm14, %ymm15, %ymm11
+	vpxor	%ymm2, %ymm11, %ymm11
+	vextracti128	$1, %ymm11, %xmm0
+	vpackssdw	%xmm0, %xmm11, %xmm0
+	vinserti128	$1, %xmm12, %ymm0, %ymm0
+	vmovmskps	%ymm0, %eax
+	vmovmskps	%ymm1, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB1_65
+# %bb.63:
+	vmovdqa	%ymm7, %ymm2
+	vpxor	%xmm10, %xmm10, %xmm10
+	.p2align	4, 0x90
+.LBB1_64:                               # %for_loop
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%r15d, %eax
+	movslq	%r15d, %r15
+	movq	%r15, %rcx
+	shlq	$7, %rcx
+	vpaddq	(%rbx,%rcx), %ymm15, %ymm14
+	vmovdqa	%ymm15, %ymm4
+	vpaddq	32(%rbx,%rcx), %ymm2, %ymm15
+	vpaddq	64(%rbx,%rcx), %ymm8, %ymm11
+	vpaddq	96(%rbx,%rcx), %ymm9, %ymm12
+	shlq	$7, %rax
+	vpblendd	$170, %ymm10, %ymm14, %ymm13 # ymm13 = ymm14[0],ymm10[1],ymm14[2],ymm10[3],ymm14[4],ymm10[5],ymm14[6],ymm10[7]
+	vmovaps	.LCPI1_1(%rip), %ymm3   # ymm3 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm0, %ymm3, %ymm5
+	vmaskmovpd	%ymm13, %ymm5, (%rbx,%rax)
+	vpblendd	$170, %ymm10, %ymm11, %ymm13 # ymm13 = ymm11[0],ymm10[1],ymm11[2],ymm10[3],ymm11[4],ymm10[5],ymm11[6],ymm10[7]
+	vpblendd	$170, %ymm10, %ymm15, %ymm6 # ymm6 = ymm15[0],ymm10[1],ymm15[2],ymm10[3],ymm15[4],ymm10[5],ymm15[6],ymm10[7]
+	vmovaps	.LCPI1_2(%rip), %ymm3   # ymm3 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm0, %ymm3, %ymm7
+	vmovdqa	%ymm8, %ymm3
+	vmovaps	.LCPI1_1(%rip), %ymm8   # ymm8 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm1, %ymm8, %ymm8
+	vmaskmovpd	%ymm6, %ymm7, 32(%rbx,%rax)
+	vmaskmovpd	%ymm13, %ymm8, 64(%rbx,%rax)
+	vpblendd	$170, %ymm10, %ymm12, %ymm6 # ymm6 = ymm12[0],ymm10[1],ymm12[2],ymm10[3],ymm12[4],ymm10[5],ymm12[6],ymm10[7]
+	vmovaps	.LCPI1_2(%rip), %ymm13  # ymm13 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm1, %ymm13, %ymm13
+	vmaskmovpd	%ymm6, %ymm13, 96(%rbx,%rax)
+	vpsrlq	$32, %ymm14, %ymm6
+	vblendvpd	%ymm5, %ymm6, %ymm4, %ymm4
+	vpsrlq	$32, %ymm15, %ymm5
+	vmovapd	%ymm4, %ymm15
+	vblendvpd	%ymm7, %ymm5, %ymm2, %ymm2
+	vpsrlq	$32, %ymm12, %ymm5
+	vpsrlq	$32, %ymm11, %ymm6
+	vblendvpd	%ymm8, %ymm6, %ymm3, %ymm3
+	vmovapd	%ymm3, %ymm8
+	vblendvpd	%ymm13, %ymm5, %ymm9, %ymm9
+	vpcmpeqq	%ymm10, %ymm2, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	%ymm10, %ymm4, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	%ymm10, %ymm9, %ymm7
+	vextracti128	$1, %ymm7, %xmm4
+	vpackssdw	%xmm4, %xmm7, %xmm4
+	vpcmpeqq	%ymm10, %ymm3, %ymm7
+	vextracti128	$1, %ymm7, %xmm3
+	vpackssdw	%xmm3, %xmm7, %xmm3
+	vinserti128	$1, %xmm4, %ymm3, %ymm3
+	vblendvps	%ymm3, %ymm10, %ymm1, %ymm1
+	vinserti128	$1, %xmm5, %ymm6, %ymm3
+	vblendvps	%ymm3, %ymm10, %ymm0, %ymm0
+	addl	$1, %r15d
+	vmovmskps	%ymm0, %eax
+	vmovmskps	%ymm1, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	jne	.LBB1_64
+.LBB1_65:                               # %for_exit
+	vpxor	%xmm0, %xmm0, %xmm0
+	vmovdqa	64(%rsp), %ymm1         # 32-byte Reload
+	vpcmpeqq	%ymm0, %ymm1, %ymm3
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	%ymm2, %ymm3, %ymm3
+	vextracti128	$1, %ymm3, %xmm4
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vmovdqa	96(%rsp), %ymm10        # 32-byte Reload
+	vpcmpeqq	%ymm0, %ymm10, %ymm4
+	vpxor	%ymm2, %ymm4, %ymm4
+	vextracti128	$1, %ymm4, %xmm5
+	vpackssdw	%xmm5, %xmm4, %xmm4
+	vinserti128	$1, %xmm3, %ymm4, %ymm5
+	vmovdqa	128(%rsp), %ymm7        # 32-byte Reload
+	vpcmpeqq	%ymm0, %ymm7, %ymm3
+	vpxor	%ymm2, %ymm3, %ymm3
+	vextracti128	$1, %ymm3, %xmm4
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vmovdqa	160(%rsp), %ymm12       # 32-byte Reload
+	vpcmpeqq	%ymm0, %ymm12, %ymm4
+	vpxor	%ymm2, %ymm4, %ymm4
+	vextracti128	$1, %ymm4, %xmm6
+	vpackssdw	%xmm6, %xmm4, %xmm4
+	vinserti128	$1, %xmm3, %ymm4, %ymm6
+	vmovmskps	%ymm6, %eax
+	vmovmskps	%ymm5, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB1_68
+# %bb.66:                               # %for_loop202.lr.ph
+	leal	(%r13,%r13,2), %eax
+	vmovaps	.LCPI1_1(%rip), %ymm8   # ymm8 = [0,0,1,1,2,2,3,3]
+	.p2align	4, 0x90
+.LBB1_67:                               # %for_loop202
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	shlq	$7, %rcx
+	vpaddq	(%rbx,%rcx), %ymm12, %ymm3
+	vpaddq	32(%rbx,%rcx), %ymm7, %ymm4
+	vpaddq	64(%rbx,%rcx), %ymm10, %ymm9
+	vmovdqa	%ymm10, %ymm2
+	vpaddq	96(%rbx,%rcx), %ymm1, %ymm10
+	vpblendd	$170, %ymm0, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm3, %ymm15 # ymm15 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vpermps	%ymm6, %ymm8, %ymm13
+	vmovaps	.LCPI1_2(%rip), %ymm0   # ymm0 = [4,4,5,5,6,6,7,7]
+	vpermps	%ymm6, %ymm0, %ymm14
+	vmaskmovpd	%ymm15, %ymm13, (%rbx,%rcx)
+	vmaskmovpd	%ymm11, %ymm14, 32(%rbx,%rcx)
+	vpblendd	$170, .LCPI1_3, %ymm9, %ymm11 # ymm11 = ymm9[0],mem[1],ymm9[2],mem[3],ymm9[4],mem[5],ymm9[6],mem[7]
+	vpermps	%ymm5, %ymm8, %ymm15
+	vmaskmovpd	%ymm11, %ymm15, 64(%rbx,%rcx)
+	vpsrad	$31, %ymm3, %ymm11
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm11, %ymm3, %ymm3 # ymm3 = ymm3[0],ymm11[1],ymm3[2],ymm11[3],ymm3[4],ymm11[5],ymm3[6],ymm11[7]
+	vblendvpd	%ymm13, %ymm3, %ymm12, %ymm12
+	vpblendd	$170, .LCPI1_3, %ymm10, %ymm3 # ymm3 = ymm10[0],mem[1],ymm10[2],mem[3],ymm10[4],mem[5],ymm10[6],mem[7]
+	vpermps	%ymm5, %ymm0, %ymm11
+	vxorps	%xmm0, %xmm0, %xmm0
+	vmaskmovpd	%ymm3, %ymm11, 96(%rbx,%rcx)
+	vpsrad	$31, %ymm4, %ymm3
+	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm3, %ymm4, %ymm3 # ymm3 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
+	vblendvpd	%ymm14, %ymm3, %ymm7, %ymm7
+	vpsrad	$31, %ymm10, %ymm3
+	vpshufd	$245, %ymm10, %ymm4     # ymm4 = ymm10[1,1,3,3,5,5,7,7]
+	vmovdqa	%ymm2, %ymm10
+	vpblendd	$170, %ymm3, %ymm4, %ymm3 # ymm3 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
+	vpsrad	$31, %ymm9, %ymm4
+	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm4, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm4[1],ymm9[2],ymm4[3],ymm9[4],ymm4[5],ymm9[6],ymm4[7]
+	vblendvpd	%ymm15, %ymm4, %ymm2, %ymm10
+	vblendvpd	%ymm11, %ymm3, %ymm1, %ymm1
+	vpcmpeqq	%ymm0, %ymm7, %ymm3
+	vextracti128	$1, %ymm3, %xmm4
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vpcmpeqq	%ymm0, %ymm12, %ymm4
+	vmovapd	%ymm7, %ymm11
+	vextracti128	$1, %ymm4, %xmm7
+	vpackssdw	%xmm7, %xmm4, %xmm4
+	vpcmpeqq	%ymm0, %ymm1, %ymm7
+	vextracti128	$1, %ymm7, %xmm2
+	vpackssdw	%xmm2, %xmm7, %xmm2
+	vpcmpeqq	%ymm0, %ymm10, %ymm7
+	vmovapd	%ymm1, %ymm9
+	vextracti128	$1, %ymm7, %xmm1
+	vpackssdw	%xmm1, %xmm7, %xmm1
+	vmovapd	%ymm11, %ymm7
+	vinserti128	$1, %xmm2, %ymm1, %ymm1
+	vblendvps	%ymm1, %ymm0, %ymm5, %ymm5
+	vinserti128	$1, %xmm3, %ymm4, %ymm1
+	vblendvps	%ymm1, %ymm0, %ymm6, %ymm6
+	vmovapd	%ymm9, %ymm1
+	addl	$1, %eax
+	vmovmskps	%ymm6, %ecx
+	vmovmskps	%ymm5, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	jne	.LBB1_67
+.LBB1_68:                               # %for_exit203
 	leaq	-40(%rbp), %rsp
 	popq	%rbx
 	popq	%r12
@@ -2095,379 +2316,6 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	popq	%rbp
 	vzeroupper
 	retq
-.LBB1_52:                               # %for_loop.i456.lr.ph.new
-	movl	%r14d, %edx
-	subl	%ecx, %edx
-	leaq	(%r12,%rbx), %rsi
-	addq	$384, %rsi              # imm = 0x180
-	vpxor	%xmm9, %xmm9, %xmm9
-	xorl	%eax, %eax
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpxor	%xmm12, %xmm12, %xmm12
-	vxorps	%xmm11, %xmm11, %xmm11
-	vpxor	%xmm13, %xmm13, %xmm13
-	movq	256(%rsp), %rdi         # 8-byte Reload
-	.p2align	4, 0x90
-.LBB1_53:                               # %for_loop.i456
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rsi), %ymm13, %ymm13
-	vpaddq	-384(%rsi), %ymm10, %ymm10
-	vpaddq	-352(%rsi), %ymm12, %ymm12
-	vpaddq	-320(%rsi), %ymm11, %ymm11
-	vpaddq	-320(%rsi,%r15), %ymm11, %ymm11
-	vpaddq	-352(%rsi,%r15), %ymm12, %ymm12
-	vpaddq	-384(%rsi,%r15), %ymm10, %ymm10
-	vpaddq	-288(%rsi,%r15), %ymm13, %ymm13
-	vpblendd	$170, %ymm9, %ymm13, %ymm14 # ymm14 = ymm13[0],ymm9[1],ymm13[2],ymm9[3],ymm13[4],ymm9[5],ymm13[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm10, %ymm15 # ymm15 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm12, %ymm1 # ymm1 = ymm12[0],ymm9[1],ymm12[2],ymm9[3],ymm12[4],ymm9[5],ymm12[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm11, %ymm2 # ymm2 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
-	vmovdqu	%ymm2, -320(%rsi)
-	vmovdqu	%ymm1, -352(%rsi)
-	vmovdqu	%ymm15, -384(%rsi)
-	vmovdqu	%ymm14, -288(%rsi)
-	vpsrlq	$32, %ymm13, %ymm1
-	vpsrlq	$32, %ymm11, %ymm2
-	vpsrlq	$32, %ymm12, %ymm11
-	vpsrlq	$32, %ymm10, %ymm10
-	vpaddq	-256(%rsi), %ymm10, %ymm10
-	vpaddq	-224(%rsi), %ymm11, %ymm11
-	vpaddq	-192(%rsi), %ymm2, %ymm2
-	vpaddq	-160(%rsi), %ymm1, %ymm1
-	vpaddq	-160(%rsi,%r15), %ymm1, %ymm1
-	vpaddq	-192(%rsi,%r15), %ymm2, %ymm2
-	vpaddq	-224(%rsi,%r15), %ymm11, %ymm11
-	vpaddq	-256(%rsi,%r15), %ymm10, %ymm10
-	vpblendd	$170, %ymm9, %ymm10, %ymm12 # ymm12 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm11, %ymm13 # ymm13 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm14 # ymm14 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm1, %ymm15 # ymm15 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
-	vmovdqu	%ymm15, -160(%rsi)
-	vmovdqu	%ymm14, -192(%rsi)
-	vmovdqu	%ymm13, -224(%rsi)
-	vmovdqu	%ymm12, -256(%rsi)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm11, %ymm11
-	vpsrlq	$32, %ymm10, %ymm10
-	vpaddq	-128(%rsi), %ymm10, %ymm10
-	vpaddq	-96(%rsi), %ymm11, %ymm11
-	vpaddq	-64(%rsi), %ymm2, %ymm2
-	vpaddq	-32(%rsi), %ymm1, %ymm1
-	vpaddq	-32(%rsi,%r15), %ymm1, %ymm1
-	vpaddq	-64(%rsi,%r15), %ymm2, %ymm2
-	vpaddq	-96(%rsi,%r15), %ymm11, %ymm11
-	vpaddq	-128(%rsi,%r15), %ymm10, %ymm10
-	vpblendd	$170, %ymm9, %ymm10, %ymm12 # ymm12 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm11, %ymm13 # ymm13 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm14 # ymm14 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm1, %ymm15 # ymm15 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
-	vmovdqu	%ymm15, -32(%rsi)
-	vmovdqu	%ymm14, -64(%rsi)
-	vmovdqu	%ymm13, -96(%rsi)
-	vmovdqu	%ymm12, -128(%rsi)
-	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm10, %ymm10
-	vpsrlq	$32, %ymm11, %ymm11
-	vpaddq	32(%rsi), %ymm11, %ymm11
-	vpaddq	(%rsi), %ymm10, %ymm10
-	vpaddq	96(%rsi), %ymm1, %ymm1
-	vpaddq	64(%rsi), %ymm2, %ymm2
-	vpaddq	64(%rsi,%r15), %ymm2, %ymm2
-	vpaddq	96(%rsi,%r15), %ymm1, %ymm1
-	vpaddq	(%rsi,%r15), %ymm10, %ymm10
-	vpaddq	32(%rsi,%r15), %ymm11, %ymm12
-	vpblendd	$170, %ymm9, %ymm12, %ymm11 # ymm11 = ymm12[0],ymm9[1],ymm12[2],ymm9[3],ymm12[4],ymm9[5],ymm12[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm10, %ymm13 # ymm13 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm15 # ymm15 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vmovdqu	%ymm15, 64(%rsi)
-	vmovdqu	%ymm14, 96(%rsi)
-	vmovdqu	%ymm13, (%rsi)
-	vmovdqu	%ymm11, 32(%rsi)
-	vpsrlq	$32, %ymm1, %ymm13
-	vpsrlq	$32, %ymm2, %ymm11
-	vpsrlq	$32, %ymm12, %ymm12
-	vpsrlq	$32, %ymm10, %ymm10
-	addq	$4, %rax
-	addq	$512, %rsi              # imm = 0x200
-	cmpl	%eax, %edx
-	jne	.LBB1_53
-.LBB1_54:                               # %for_test.i444.bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit457_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	je	.LBB1_57
-# %bb.55:                               # %for_loop.i456.epil.preheader
-	addq	%rdi, %rax
-	shlq	$7, %rax
-	addq	%rbx, %rax
-	vpxor	%xmm9, %xmm9, %xmm9
-	.p2align	4, 0x90
-.LBB1_56:                               # %for_loop.i456.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rax), %ymm13, %ymm1
-	vpaddq	32(%rax), %ymm12, %ymm2
-	vpaddq	(%rax), %ymm10, %ymm10
-	vpaddq	64(%rax), %ymm11, %ymm11
-	vpaddq	64(%rax,%r15), %ymm11, %ymm11
-	vpaddq	(%rax,%r15), %ymm10, %ymm10
-	vpaddq	32(%rax,%r15), %ymm2, %ymm2
-	vpaddq	96(%rax,%r15), %ymm1, %ymm1
-	vpblendd	$170, %ymm9, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm10, %ymm14 # ymm14 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm11, %ymm15 # ymm15 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
-	vmovdqu	%ymm15, 64(%rax)
-	vmovdqu	%ymm14, (%rax)
-	vmovdqu	%ymm13, 32(%rax)
-	vmovdqu	%ymm12, 96(%rax)
-	vpsrlq	$32, %ymm10, %ymm10
-	vpsrlq	$32, %ymm2, %ymm12
-	vpsrlq	$32, %ymm11, %ymm11
-	vpsrlq	$32, %ymm1, %ymm13
-	subq	$-128, %rax
-	decl	%ecx
-	jne	.LBB1_56
-.LBB1_57:                               # %bigAdd___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit457
-	vpaddq	%ymm3, %ymm10, %ymm3
-	vpaddq	%ymm4, %ymm12, %ymm4
-	vmovdqa	64(%rsp), %ymm1         # 32-byte Reload
-	vpaddq	%ymm1, %ymm11, %ymm1
-	vmovdqa	%ymm1, 64(%rsp)         # 32-byte Spill
-	vmovdqa	96(%rsp), %ymm1         # 32-byte Reload
-	vpaddq	%ymm1, %ymm13, %ymm1
-	testl	%edi, %edi
-	vmovdqa	%ymm3, 320(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm4, 352(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm1, 96(%rsp)         # 32-byte Spill
-	je	.LBB1_58
-# %bb.59:                               # %for_loop.i473.lr.ph
-	addq	%rbx, %r15
-	movq	160(%rsp), %rax         # 8-byte Reload
-	leal	(%rax,%rax), %ecx
-	orl	$1, %eax
-	movl	%ecx, %edx
-	subl	%eax, %edx
-	movl	%edi, %eax
-	andl	$2, %eax
-	cmpl	$3, %edx
-	jae	.LBB1_61
-# %bb.60:
-	vpxor	%xmm3, %xmm3, %xmm3
-	xorl	%ecx, %ecx
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm11, %xmm11, %xmm11
-	testl	%eax, %eax
-	jne	.LBB1_65
-	jmp	.LBB1_67
-.LBB1_58:
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 288(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 192(%rsp)        # 32-byte Spill
-	vpxor	%xmm1, %xmm1, %xmm1
-	vmovdqa	%ymm1, 224(%rsp)        # 32-byte Spill
-	jmp	.LBB1_68
-.LBB1_61:                               # %for_loop.i473.lr.ph.new
-	leal	(%rax,%r8,2), %edx
-	subl	%ecx, %edx
-	vpxor	%xmm13, %xmm13, %xmm13
-	movl	$384, %esi              # imm = 0x180
-	xorl	%ecx, %ecx
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm11, %xmm11, %xmm11
-	.p2align	4, 0x90
-.LBB1_62:                               # %for_loop.i473
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqu	-384(%r15,%rsi), %ymm1
-	vmovdqu	-352(%r15,%rsi), %ymm2
-	vmovdqu	-320(%r15,%rsi), %ymm9
-	vmovdqu	-288(%r15,%rsi), %ymm14
-	vpsubq	96(%rsp,%rsi), %ymm14, %ymm14
-	vpsubq	(%rsp,%rsi), %ymm1, %ymm1
-	vpaddq	%ymm11, %ymm14, %ymm12
-	vpaddq	%ymm3, %ymm1, %ymm1
-	vpsubq	32(%rsp,%rsi), %ymm2, %ymm2
-	vpaddq	%ymm2, %ymm10, %ymm2
-	vpsubq	64(%rsp,%rsi), %ymm9, %ymm9
-	vpaddq	%ymm4, %ymm9, %ymm9
-	vpblendd	$170, %ymm13, %ymm12, %ymm10 # ymm10 = ymm12[0],ymm13[1],ymm12[2],ymm13[3],ymm12[4],ymm13[5],ymm12[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm13[1],ymm1[2],ymm13[3],ymm1[4],ymm13[5],ymm1[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm2, %ymm14 # ymm14 = ymm2[0],ymm13[1],ymm2[2],ymm13[3],ymm2[4],ymm13[5],ymm2[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm9, %ymm15 # ymm15 = ymm9[0],ymm13[1],ymm9[2],ymm13[3],ymm9[4],ymm13[5],ymm9[6],ymm13[7]
-	vmovdqu	%ymm15, -320(%r15,%rsi)
-	vmovdqu	%ymm14, -352(%r15,%rsi)
-	vmovdqu	%ymm11, -384(%r15,%rsi)
-	vmovdqu	%ymm10, -288(%r15,%rsi)
-	vpsrad	$31, %ymm1, %ymm10
-	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm10[1],ymm1[2],ymm10[3],ymm1[4],ymm10[5],ymm1[6],ymm10[7]
-	vpsrad	$31, %ymm2, %ymm10
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm10[1],ymm2[2],ymm10[3],ymm2[4],ymm10[5],ymm2[6],ymm10[7]
-	vpsrad	$31, %ymm9, %ymm10
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
-	vpsrad	$31, %ymm12, %ymm10
-	vpshufd	$245, %ymm12, %ymm11    # ymm11 = ymm12[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm11, %ymm10 # ymm10 = ymm11[0],ymm10[1],ymm11[2],ymm10[3],ymm11[4],ymm10[5],ymm11[6],ymm10[7]
-	vmovdqu	-160(%r15,%rsi), %ymm11
-	vmovdqu	-192(%r15,%rsi), %ymm12
-	vmovdqu	-224(%r15,%rsi), %ymm14
-	vmovdqu	-256(%r15,%rsi), %ymm15
-	vpsubq	128(%rsp,%rsi), %ymm15, %ymm15
-	vpsubq	160(%rsp,%rsi), %ymm14, %ymm14
-	vpaddq	%ymm1, %ymm15, %ymm1
-	vpaddq	%ymm2, %ymm14, %ymm2
-	vpsubq	192(%rsp,%rsi), %ymm12, %ymm12
-	vpaddq	%ymm9, %ymm12, %ymm9
-	vpsubq	224(%rsp,%rsi), %ymm11, %ymm11
-	vpaddq	%ymm10, %ymm11, %ymm10
-	vpblendd	$170, %ymm13, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm13[1],ymm1[2],ymm13[3],ymm1[4],ymm13[5],ymm1[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm2, %ymm12 # ymm12 = ymm2[0],ymm13[1],ymm2[2],ymm13[3],ymm2[4],ymm13[5],ymm2[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm13[1],ymm9[2],ymm13[3],ymm9[4],ymm13[5],ymm9[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm10, %ymm15 # ymm15 = ymm10[0],ymm13[1],ymm10[2],ymm13[3],ymm10[4],ymm13[5],ymm10[6],ymm13[7]
-	vmovdqu	%ymm15, -160(%r15,%rsi)
-	vmovdqu	%ymm14, -192(%r15,%rsi)
-	vmovdqu	%ymm12, -224(%r15,%rsi)
-	vmovdqu	%ymm11, -256(%r15,%rsi)
-	vpsrad	$31, %ymm1, %ymm11
-	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
-	vpsrad	$31, %ymm2, %ymm11
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
-	vpsrad	$31, %ymm9, %ymm11
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vmovdqu	-32(%r15,%rsi), %ymm11
-	vmovdqu	-64(%r15,%rsi), %ymm12
-	vmovdqu	-96(%r15,%rsi), %ymm14
-	vmovdqu	-128(%r15,%rsi), %ymm15
-	vpsubq	256(%rsp,%rsi), %ymm15, %ymm15
-	vpsubq	288(%rsp,%rsi), %ymm14, %ymm14
-	vpaddq	%ymm1, %ymm15, %ymm1
-	vpaddq	%ymm2, %ymm14, %ymm2
-	vpsubq	320(%rsp,%rsi), %ymm12, %ymm12
-	vpaddq	%ymm9, %ymm12, %ymm9
-	vpsubq	352(%rsp,%rsi), %ymm11, %ymm11
-	vpaddq	%ymm10, %ymm11, %ymm10
-	vpblendd	$170, %ymm13, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm13[1],ymm1[2],ymm13[3],ymm1[4],ymm13[5],ymm1[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm2, %ymm12 # ymm12 = ymm2[0],ymm13[1],ymm2[2],ymm13[3],ymm2[4],ymm13[5],ymm2[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm9, %ymm14 # ymm14 = ymm9[0],ymm13[1],ymm9[2],ymm13[3],ymm9[4],ymm13[5],ymm9[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm10, %ymm15 # ymm15 = ymm10[0],ymm13[1],ymm10[2],ymm13[3],ymm10[4],ymm13[5],ymm10[6],ymm13[7]
-	vmovdqu	%ymm15, -32(%r15,%rsi)
-	vmovdqu	%ymm14, -64(%r15,%rsi)
-	vmovdqu	%ymm12, -96(%r15,%rsi)
-	vmovdqu	%ymm11, -128(%r15,%rsi)
-	vpsrad	$31, %ymm2, %ymm11
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm2, %ymm2 # ymm2 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
-	vpsrad	$31, %ymm1, %ymm11
-	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm1, %ymm1 # ymm1 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm10 # ymm10 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vpsrad	$31, %ymm9, %ymm11
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm9, %ymm9 # ymm9 = ymm9[0],ymm11[1],ymm9[2],ymm11[3],ymm9[4],ymm11[5],ymm9[6],ymm11[7]
-	vmovdqu	64(%r15,%rsi), %ymm11
-	vmovdqu	96(%r15,%rsi), %ymm12
-	vmovdqu	(%r15,%rsi), %ymm14
-	vmovdqu	32(%r15,%rsi), %ymm15
-	vpsubq	416(%rsp,%rsi), %ymm15, %ymm15
-	vpsubq	384(%rsp,%rsi), %ymm14, %ymm14
-	vpaddq	%ymm2, %ymm15, %ymm2
-	vpaddq	%ymm1, %ymm14, %ymm1
-	vpsubq	480(%rsp,%rsi), %ymm12, %ymm12
-	vpaddq	%ymm10, %ymm12, %ymm10
-	vpsubq	448(%rsp,%rsi), %ymm11, %ymm11
-	vpaddq	%ymm9, %ymm11, %ymm9
-	vpblendd	$170, %ymm13, %ymm2, %ymm11 # ymm11 = ymm2[0],ymm13[1],ymm2[2],ymm13[3],ymm2[4],ymm13[5],ymm2[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm13[1],ymm1[2],ymm13[3],ymm1[4],ymm13[5],ymm1[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm10, %ymm14 # ymm14 = ymm10[0],ymm13[1],ymm10[2],ymm13[3],ymm10[4],ymm13[5],ymm10[6],ymm13[7]
-	vpblendd	$170, %ymm13, %ymm9, %ymm15 # ymm15 = ymm9[0],ymm13[1],ymm9[2],ymm13[3],ymm9[4],ymm13[5],ymm9[6],ymm13[7]
-	vmovdqu	%ymm15, 64(%r15,%rsi)
-	vmovdqu	%ymm14, 96(%r15,%rsi)
-	vmovdqu	%ymm12, (%r15,%rsi)
-	vmovdqu	%ymm11, 32(%r15,%rsi)
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm11 # ymm11 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vpsrad	$31, %ymm9, %ymm10
-	vpshufd	$245, %ymm9, %ymm9      # ymm9 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm10, %ymm9, %ymm4 # ymm4 = ymm9[0],ymm10[1],ymm9[2],ymm10[3],ymm9[4],ymm10[5],ymm9[6],ymm10[7]
-	vpsrad	$31, %ymm2, %ymm9
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm10 # ymm10 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vpsrad	$31, %ymm1, %ymm2
-	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm2, %ymm1, %ymm3 # ymm3 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
-	addq	$512, %rsi              # imm = 0x200
-	addq	$-4, %rcx
-	cmpl	%ecx, %edx
-	jne	.LBB1_62
-# %bb.63:                               # %for_test.i461.bigSub___un_3C_vyU_3E_un_3C_CvyU_3E_un_3C_CvyU_3E_unu.exit474_crit_edge.unr-lcssa.loopexit
-	negq	%rcx
-	testl	%eax, %eax
-	je	.LBB1_67
-.LBB1_65:                               # %for_loop.i473.epil.preheader
-	shlq	$7, %rcx
-	negl	%eax
-	vpxor	%xmm9, %xmm9, %xmm9
-	.p2align	4, 0x90
-.LBB1_66:                               # %for_loop.i473.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqu	(%r15,%rcx), %ymm1
-	vmovdqu	32(%r15,%rcx), %ymm2
-	vmovdqu	64(%r15,%rcx), %ymm13
-	vmovdqu	96(%r15,%rcx), %ymm14
-	vpsubq	480(%rsp,%rcx), %ymm14, %ymm14
-	vpaddq	%ymm11, %ymm14, %ymm12
-	vpsubq	416(%rsp,%rcx), %ymm2, %ymm2
-	vpaddq	%ymm2, %ymm10, %ymm2
-	vpsubq	384(%rsp,%rcx), %ymm1, %ymm1
-	vpsubq	448(%rsp,%rcx), %ymm13, %ymm11
-	vpaddq	%ymm3, %ymm1, %ymm1
-	vpaddq	%ymm4, %ymm11, %ymm10
-	vpblendd	$170, %ymm9, %ymm12, %ymm11 # ymm11 = ymm12[0],ymm9[1],ymm12[2],ymm9[3],ymm12[4],ymm9[5],ymm12[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm2, %ymm13 # ymm13 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm1, %ymm14 # ymm14 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
-	vpblendd	$170, %ymm9, %ymm10, %ymm15 # ymm15 = ymm10[0],ymm9[1],ymm10[2],ymm9[3],ymm10[4],ymm9[5],ymm10[6],ymm9[7]
-	vmovdqu	%ymm15, 64(%r15,%rcx)
-	vmovdqu	%ymm14, (%r15,%rcx)
-	vmovdqu	%ymm13, 32(%r15,%rcx)
-	vmovdqu	%ymm11, 96(%r15,%rcx)
-	vpsrad	$31, %ymm10, %ymm11
-	vpshufd	$245, %ymm10, %ymm10    # ymm10 = ymm10[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm10, %ymm4 # ymm4 = ymm10[0],ymm11[1],ymm10[2],ymm11[3],ymm10[4],ymm11[5],ymm10[6],ymm11[7]
-	vpsrad	$31, %ymm2, %ymm11
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm11, %ymm2, %ymm10 # ymm10 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
-	vpsrad	$31, %ymm1, %ymm2
-	vpshufd	$245, %ymm1, %ymm1      # ymm1 = ymm1[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm2, %ymm1, %ymm3 # ymm3 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
-	vpsrad	$31, %ymm12, %ymm1
-	vpshufd	$245, %ymm12, %ymm2     # ymm2 = ymm12[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm11 # ymm11 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	subq	$-128, %rcx
-	incl	%eax
-	jne	.LBB1_66
-.LBB1_67:
-	vmovdqa	%ymm11, 224(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm10, 288(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm4, 192(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm3, 160(%rsp)        # 32-byte Spill
-	jmp	.LBB1_68
 .Lfunc_end1:
 	.size	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu, .Lfunc_end1-toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
                                         # -- End function
@@ -2521,52 +2369,10 @@ toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu: # @toom2SquareFull___UM_un_
 	.section	.rodata.cst4,"aM",@progbits,4
 	.p2align	2
 .LCPI2_5:
-	.long	1                       # 0x1
-	.section	.rodata.cst16,"aM",@progbits,16
-	.p2align	4
-.LCPI2_6:
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI2_7:
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI2_8:
-	.zero	16,128
-.LCPI2_10:
-	.zero	16,1
-.LCPI2_11:
-	.zero	16
+	.long	1                       # float 1.40129846E-45
 	.section	.rodata.cst8,"aM",@progbits,8
 	.p2align	3
-.LCPI2_9:
+.LCPI2_6:
 	.quad	1                       # 0x1
 	.text
 	.globl	fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu
@@ -2582,65 +2388,54 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	pushq	%r12
 	pushq	%rbx
 	andq	$-128, %rsp
-	subq	$90880, %rsp            # imm = 0x16300
-	vmovaps	%ymm1, %ymm9
+	subq	$91008, %rsp            # imm = 0x16380
+	vmovaps	%ymm1, %ymm14
 	vmovaps	%ymm0, %ymm15
-	movl	%r9d, 20(%rsp)          # 4-byte Spill
-	movl	%r8d, %r11d
-	movq	%rcx, %rbx
+                                        # kill: def $r9d killed $r9d def $r9
+	movq	%r9, 112(%rsp)          # 8-byte Spill
+	movl	%r8d, %r10d
+	movabsq	$4294967296, %r14       # imm = 0x100000000
 	vmovmskps	%ymm0, %eax
-	vmovmskps	%ymm1, %ecx
-	shll	$8, %ecx
-	orl	%eax, %ecx
-	vmovd	%r8d, %xmm0
+	vmovmskps	%ymm1, %ebx
+	shll	$8, %ebx
+	orl	%eax, %ebx
+	vmovd	%r10d, %xmm0
 	vpbroadcastd	%xmm0, %ymm1
 	vpmulld	.LCPI2_0(%rip), %ymm1, %ymm0
 	vpmulld	.LCPI2_1(%rip), %ymm1, %ymm1
-	cmpl	$65535, %ecx            # imm = 0xFFFF
-	movq	%r11, 24(%rsp)          # 8-byte Spill
+	cmpl	$65535, %ebx            # imm = 0xFFFF
+	movq	%r10, 104(%rsp)         # 8-byte Spill
+	movq	%rcx, 120(%rsp)         # 8-byte Spill
 	jne	.LBB2_1
-# %bb.5:                                # %for_test.preheader
-	testl	%r11d, %r11d
-	je	.LBB2_6
-# %bb.7:                                # %for_loop.lr.ph
-	cmpl	$1, %r11d
-	movq	%rbx, 8(%rsp)           # 8-byte Spill
-	jne	.LBB2_9
-# %bb.8:
-	xorl	%eax, %eax
-	jmp	.LBB2_12
-.LBB2_1:                                # %for_test488.preheader
-	movl	%r11d, %r15d
-	testl	%r11d, %r11d
-	vmovaps	%ymm9, 192(%rsp)        # 32-byte Spill
-	vmovaps	%ymm15, 160(%rsp)       # 32-byte Spill
-	je	.LBB2_2
-# %bb.3:                                # %for_loop489.lr.ph
-	cmpl	$1, %r11d
-	movq	%rbx, 8(%rsp)           # 8-byte Spill
-	jne	.LBB2_71
-# %bb.4:
-	xorl	%r10d, %r10d
-	jmp	.LBB2_74
-.LBB2_6:
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	jmp	.LBB2_62
-.LBB2_2:                                # %for_test720.preheader.thread
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	jmp	.LBB2_124
-.LBB2_9:                                # %for_loop.lr.ph.new
-	movl	%r11d, %r8d
+# %bb.4:                                # %for_test.preheader
+	testl	%r10d, %r10d
+	je	.LBB2_11
+# %bb.5:                                # %for_loop.lr.ph
+	cmpl	$1, %r10d
+	jne	.LBB2_7
+# %bb.6:
+	xorl	%r11d, %r11d
+	jmp	.LBB2_10
+.LBB2_1:                                # %for_test495.preheader
+	testl	%r10d, %r10d
+	je	.LBB2_84
+# %bb.2:                                # %for_loop497.lr.ph
+	cmpl	$1, %r10d
+	jne	.LBB2_80
+# %bb.3:
+	xorl	%r11d, %r11d
+	jmp	.LBB2_83
+.LBB2_7:                                # %for_loop.lr.ph.new
+	movl	%r10d, %r8d
 	andl	$1, %r8d
-	movl	%r11d, %r9d
+	movl	%r10d, %r9d
 	subl	%r8d, %r9d
-	movl	$64, %ecx
-	xorl	%eax, %eax
+	movl	$64, %eax
+	xorl	%r11d, %r11d
 	.p2align	4, 0x90
-.LBB2_10:                               # %for_loop
+.LBB2_8:                                # %for_loop
                                         # =>This Inner Loop Header: Depth=1
-	vmovd	%eax, %xmm2
+	vmovd	%r11d, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
 	vpaddd	%ymm1, %ymm2, %ymm3
 	vpaddd	%ymm0, %ymm2, %ymm2
@@ -2652,8 +2447,8 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpcmpeqd	%ymm4, %ymm4, %ymm4
 	vpxor	%xmm6, %xmm6, %xmm6
 	vpgatherdd	%ymm4, (%rdi,%ymm2), %ymm6
-	vmovdqa	%ymm6, 21088(%rsp,%rcx)
-	vmovdqa	%ymm5, 21056(%rsp,%rcx)
+	vmovdqa	%ymm6, 21216(%rsp,%rax)
+	vmovdqa	%ymm5, 21184(%rsp,%rax)
 	vpcmpeqd	%ymm4, %ymm4, %ymm4
 	vpxor	%xmm5, %xmm5, %xmm5
 	vpgatherdd	%ymm4, (%rdx,%ymm3), %ymm5
@@ -2663,28 +2458,28 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpmovzxdq	%xmm5, %ymm2    # ymm2 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
 	vextracti128	$1, %ymm5, %xmm3
 	vpmovzxdq	%xmm4, %ymm5    # ymm5 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vextracti128	$1, %ymm4, %xmm4
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vextracti128	$1, %ymm4, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	leal	1(%rax), %ebx
-	vmovdqa	%ymm5, 8768(%rsp,%rcx,2)
+	vmovdqa	%ymm5, 8896(%rsp,%rax,2)
+	leal	1(%r11), %ebx
 	vmovd	%ebx, %xmm5
 	vpbroadcastd	%xmm5, %ymm5
-	vmovdqa	%ymm2, 8704(%rsp,%rcx,2)
+	vmovdqa	%ymm2, 8832(%rsp,%rax,2)
 	vpaddd	%ymm1, %ymm5, %ymm2
 	vpaddd	%ymm0, %ymm5, %ymm5
-	vmovdqa	%ymm4, 8800(%rsp,%rcx,2)
+	vmovdqa	%ymm4, 8928(%rsp,%rax,2)
 	vpslld	$2, %ymm5, %ymm4
 	vpslld	$2, %ymm2, %ymm2
-	vmovdqa	%ymm3, 8736(%rsp,%rcx,2)
+	vmovdqa	%ymm3, 8864(%rsp,%rax,2)
 	vpcmpeqd	%ymm3, %ymm3, %ymm3
 	vpxor	%xmm5, %xmm5, %xmm5
 	vpgatherdd	%ymm3, (%rdi,%ymm2), %ymm5
 	vpcmpeqd	%ymm3, %ymm3, %ymm3
 	vpxor	%xmm6, %xmm6, %xmm6
 	vpgatherdd	%ymm3, (%rdi,%ymm4), %ymm6
-	vmovdqa	%ymm6, 21152(%rsp,%rcx)
-	vmovdqa	%ymm5, 21120(%rsp,%rcx)
+	vmovdqa	%ymm6, 21280(%rsp,%rax)
+	vmovdqa	%ymm5, 21248(%rsp,%rax)
 	vpcmpeqd	%ymm3, %ymm3, %ymm3
 	vpxor	%xmm5, %xmm5, %xmm5
 	vpgatherdd	%ymm3, (%rdx,%ymm2), %ymm5
@@ -2697,21 +2492,21 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpmovzxdq	%xmm3, %ymm5    # ymm5 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vextracti128	$1, %ymm3, %xmm3
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vmovdqa	%ymm5, 8896(%rsp,%rcx,2)
-	vmovdqa	%ymm3, 8928(%rsp,%rcx,2)
-	vmovdqa	%ymm2, 8832(%rsp,%rcx,2)
-	vmovdqa	%ymm4, 8864(%rsp,%rcx,2)
-	addq	$2, %rax
-	subq	$-128, %rcx
-	cmpl	%eax, %r9d
-	jne	.LBB2_10
-# %bb.11:                               # %for_test.for_exit_crit_edge.unr-lcssa
+	vmovdqa	%ymm5, 9024(%rsp,%rax,2)
+	vmovdqa	%ymm3, 9056(%rsp,%rax,2)
+	vmovdqa	%ymm2, 8960(%rsp,%rax,2)
+	vmovdqa	%ymm4, 8992(%rsp,%rax,2)
+	addq	$2, %r11
+	subq	$-128, %rax
+	cmpl	%r11d, %r9d
+	jne	.LBB2_8
+# %bb.9:                                # %for_test.for_exit_crit_edge.unr-lcssa
 	testl	%r8d, %r8d
-	je	.LBB2_13
-.LBB2_12:                               # %for_loop.epil.preheader
-	movq	%rax, %rcx
-	shlq	$6, %rcx
-	vmovd	%eax, %xmm2
+	je	.LBB2_11
+.LBB2_10:                               # %for_loop.epil.preheader
+	movq	%r11, %rbx
+	shlq	$6, %rbx
+	vmovd	%r11d, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
 	vpaddd	%ymm1, %ymm2, %ymm1
 	vpaddd	%ymm0, %ymm2, %ymm0
@@ -2723,284 +2518,291 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpcmpeqd	%ymm2, %ymm2, %ymm2
 	vpxor	%xmm4, %xmm4, %xmm4
 	vpgatherdd	%ymm2, (%rdi,%ymm0), %ymm4
-	vmovdqa	%ymm4, 21152(%rsp,%rcx)
-	vmovdqa	%ymm3, 21120(%rsp,%rcx)
+	vmovdqa	%ymm4, 21280(%rsp,%rbx)
+	vmovdqa	%ymm3, 21248(%rsp,%rbx)
 	vpcmpeqd	%ymm2, %ymm2, %ymm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpgatherdd	%ymm2, (%rdx,%ymm1), %ymm3
 	vpcmpeqd	%ymm1, %ymm1, %ymm1
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	%ymm1, (%rdx,%ymm0), %ymm2
-	shlq	$7, %rax
+	shlq	$7, %r11
 	vpmovzxdq	%xmm3, %ymm0    # ymm0 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vextracti128	$1, %ymm3, %xmm1
 	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
 	vpmovzxdq	%xmm2, %ymm3    # ymm3 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vextracti128	$1, %ymm2, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vmovdqa	%ymm2, 8928(%rsp,%rax)
-	vmovdqa	%ymm3, 8896(%rsp,%rax)
-	vmovdqa	%ymm1, 8864(%rsp,%rax)
-	vmovdqa	%ymm0, 8832(%rsp,%rax)
-.LBB2_13:                               # %for_exit
-	vmovups	(%rsi), %ymm0
-	vmovaps	%ymm0, 320(%rsp)        # 32-byte Spill
-	vmovdqu	32(%rsi), %ymm0
-	vmovdqa	%ymm0, 288(%rsp)        # 32-byte Spill
-	testl	%r11d, %r11d
-	jle	.LBB2_19
-# %bb.14:                               # %for_loop33.lr.ph
-	movl	$-2147483648, %eax      # imm = 0x80000000
-	movl	20(%rsp), %ecx          # 4-byte Reload
-	shrxl	%ecx, %eax, %esi
-	vmovd	%ecx, %xmm0
-	vpbroadcastd	%xmm0, %ymm2
-	movl	$32, %eax
+	vmovdqa	%ymm2, 9056(%rsp,%r11)
+	vmovdqa	%ymm3, 9024(%rsp,%r11)
+	vmovdqa	%ymm1, 8992(%rsp,%r11)
+	vmovdqa	%ymm0, 8960(%rsp,%r11)
+.LBB2_11:                               # %for_exit
+	xorl	%ecx, %ecx
+	cmpl	$23, 112(%rsp)          # 4-byte Folded Reload
+	seta	%cl
+	movl	%r10d, %eax
 	subl	%ecx, %eax
-	vmovd	%eax, %xmm0
-	vpbroadcastd	%xmm0, %ymm7
-	movl	%r11d, %r15d
-	leaq	21184(%rsp), %r8
-	movl	%r11d, %r13d
-	andl	$-2, %r13d
-	movq	%r15, %r12
-	shlq	$7, %r12
-	movq	%r15, %r14
-	shlq	$6, %r14
-	movq	%r15, %rax
-	vmovdqa	%ymm2, 256(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm7, 224(%rsp)        # 32-byte Spill
-	jmp	.LBB2_15
-	.p2align	4, 0x90
-.LBB2_18:                               # %for_test32.loopexit
-                                        #   in Loop: Header=BB2_15 Depth=1
-	movl	$-2147483648, %esi      # imm = 0x80000000
-	cmpq	$1, 384(%rsp)           # 8-byte Folded Reload
-	movq	352(%rsp), %rax         # 8-byte Reload
+	vmovups	(%rsi), %ymm0
+	vmovaps	%ymm0, 288(%rsp)        # 32-byte Spill
+	vmovdqu	32(%rsi), %ymm0
+	vmovdqa	%ymm0, 256(%rsp)        # 32-byte Spill
+	testl	%eax, %eax
 	jle	.LBB2_19
-.LBB2_15:                               # %for_loop33
+# %bb.12:                               # %for_loop38.lr.ph
+	movq	112(%rsp), %rsi         # 8-byte Reload
+	cmpl	$24, %esi
+	setb	%cl
+	shlb	$5, %cl
+	movzbl	%cl, %ecx
+	leal	(%rcx,%rsi), %ecx
+	addl	$-24, %ecx
+	movl	$-2147483648, %edx      # imm = 0x80000000
+	shrxl	%ecx, %edx, %r8d
+	vmovd	%esi, %xmm0
+	vpbroadcastd	%xmm0, %ymm10
+	movl	$32, %ecx
+	subl	%esi, %ecx
+	vmovd	%ecx, %xmm0
+	vpbroadcastd	%xmm0, %ymm11
+	movl	%r10d, %r9d
+	movslq	%eax, %rcx
+	leaq	21312(%rsp), %r15
+	movl	%r10d, %eax
+	andl	$1, %eax
+	movl	%r10d, %r13d
+	subl	%eax, %r13d
+	movq	%r9, %r12
+	shlq	$7, %r12
+	vmovdqa	%ymm10, 384(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm11, 352(%rsp)       # 32-byte Spill
+	movq	%r9, 480(%rsp)          # 8-byte Spill
+	.p2align	4, 0x90
+.LBB2_13:                               # %for_loop38
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_43 Depth 2
-                                        #       Child Loop BB2_44 Depth 3
-                                        #         Child Loop BB2_31 Depth 4
-                                        #       Child Loop BB2_36 Depth 3
-                                        #       Child Loop BB2_38 Depth 3
-                                        #         Child Loop BB2_40 Depth 4
-	movq	%rax, 384(%rsp)         # 8-byte Spill
-	leaq	-1(%rax), %rcx
+                                        #     Child Loop BB2_16 Depth 2
+                                        #       Child Loop BB2_29 Depth 3
+                                        #         Child Loop BB2_32 Depth 4
+                                        #       Child Loop BB2_42 Depth 3
+                                        #       Child Loop BB2_39 Depth 3
+                                        #         Child Loop BB2_44 Depth 4
+	addq	$-1, %rcx
 	movq	%rcx, %rax
 	shlq	$6, %rax
 	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	movq	%rcx, 352(%rsp)         # 8-byte Spill
+	movq	%rcx, 544(%rsp)         # 8-byte Spill
 	testq	%rcx, %rcx
-	je	.LBB2_17
-# %bb.16:                               # %for_loop33
-                                        #   in Loop: Header=BB2_15 Depth=1
+	je	.LBB2_15
+# %bb.14:                               # %for_loop38
+                                        #   in Loop: Header=BB2_13 Depth=1
 	vpxor	%xmm0, %xmm0, %xmm0
-.LBB2_17:                               # %for_loop33
-                                        #   in Loop: Header=BB2_15 Depth=1
-	vpaddd	21152(%rsp,%rax), %ymm0, %ymm1
-	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
-	vpaddd	21120(%rsp,%rax), %ymm0, %ymm0
-	vmovdqa	%ymm0, 416(%rsp)        # 32-byte Spill
-	jmp	.LBB2_43
+.LBB2_15:                               # %for_loop38
+                                        #   in Loop: Header=BB2_13 Depth=1
+	vpaddd	21280(%rsp,%rax), %ymm0, %ymm1
+	vmovdqa	%ymm1, 448(%rsp)        # 32-byte Spill
+	vpaddd	21248(%rsp,%rax), %ymm0, %ymm0
+	vmovdqa	%ymm0, 576(%rsp)        # 32-byte Spill
 	.p2align	4, 0x90
-.LBB2_42:                               # %for_exit129
-                                        #   in Loop: Header=BB2_43 Depth=2
-	shrl	%esi
-	je	.LBB2_18
-.LBB2_43:                               # %for_loop50.lr.ph.split.us
-                                        #   Parent Loop BB2_15 Depth=1
+.LBB2_16:                               # %do_loop
+                                        #   Parent Loop BB2_13 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB2_44 Depth 3
-                                        #         Child Loop BB2_31 Depth 4
-                                        #       Child Loop BB2_36 Depth 3
-                                        #       Child Loop BB2_38 Depth 3
-                                        #         Child Loop BB2_40 Depth 4
-	movl	%esi, 192(%rsp)         # 4-byte Spill
-	leaq	74368(%rsp), %rdi
-	leaq	8832(%rsp), %rsi
-	movl	%r11d, %edx
-	movq	%r8, %rbx
+                                        #       Child Loop BB2_29 Depth 3
+                                        #         Child Loop BB2_32 Depth 4
+                                        #       Child Loop BB2_42 Depth 3
+                                        #       Child Loop BB2_39 Depth 3
+                                        #         Child Loop BB2_44 Depth 4
+	movl	%r8d, %ebx
+	leaq	74496(%rsp), %rdi
+	leaq	8960(%rsp), %rsi
+	movl	%r10d, %edx
 	vzeroupper
 	callq	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	vpxor	%xmm15, %xmm15, %xmm15
-	movq	%rbx, %r8
-	movq	24(%rsp), %r11          # 8-byte Reload
+	movq	104(%rsp), %r10         # 8-byte Reload
+	testl	%r10d, %r10d
+	je	.LBB2_17
+# %bb.28:                               # %for_loop70.lr.ph.us.preheader
+                                        #   in Loop: Header=BB2_16 Depth=2
 	movl	$1, %eax
 	xorl	%ecx, %ecx
-	vmovdqa	320(%rsp), %ymm12       # 32-byte Reload
-	vmovdqa	288(%rsp), %ymm13       # 32-byte Reload
-	vmovdqa	.LCPI2_2(%rip), %ymm14  # ymm14 = [0,2,4,6,4,6,6,7]
-	jmp	.LBB2_44
+	movl	%ebx, %r8d
+	movq	480(%rsp), %r9          # 8-byte Reload
+	vpxor	%xmm12, %xmm12, %xmm12
 	.p2align	4, 0x90
-.LBB2_45:                               #   in Loop: Header=BB2_44 Depth=3
-	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%esi, %esi
-.LBB2_33:                               # %for_loop61.us.epil.preheader
-                                        #   in Loop: Header=BB2_44 Depth=3
-	movq	%rsi, %rdi
-	shlq	$6, %rdi
-	vpmovzxdq	21152(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21168(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21120(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21136(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	vpmuludq	%ymm0, %ymm9, %ymm0
-	vpmuludq	%ymm1, %ymm8, %ymm1
-	addl	%ecx, %esi
-	shlq	$7, %rsi
-	vpaddq	74400(%rsp,%rsi), %ymm7, %ymm7
-	vpaddq	74368(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	%ymm3, %ymm4, %ymm3
-	vpaddq	74464(%rsp,%rsi), %ymm6, %ymm4
-	vpaddq	%ymm0, %ymm4, %ymm0
-	vpaddq	74432(%rsp,%rsi), %ymm5, %ymm4
-	vpaddq	%ymm1, %ymm4, %ymm1
-	vpblendd	$170, %ymm15, %ymm2, %ymm4 # ymm4 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm0, %ymm6 # ymm6 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm15[1],ymm1[2],ymm15[3],ymm1[4],ymm15[5],ymm1[6],ymm15[7]
-	vmovdqa	%ymm7, 74432(%rsp,%rsi)
-	vmovdqa	%ymm6, 74464(%rsp,%rsi)
-	vmovdqa	%ymm5, 74368(%rsp,%rsi)
-	vmovdqa	%ymm4, 74400(%rsp,%rsi)
-	vpsrlq	$32, %ymm0, %ymm6
-	vpsrlq	$32, %ymm1, %ymm5
-	vpsrlq	$32, %ymm2, %ymm7
-	vpsrlq	$32, %ymm3, %ymm4
-.LBB2_34:                               # %for_exit63.us
-                                        #   in Loop: Header=BB2_44 Depth=3
-	vmovdqa	%ymm7, 8864(%rsp,%rdx)
-	vmovdqa	%ymm4, 8832(%rsp,%rdx)
-	vmovdqa	%ymm5, 8896(%rsp,%rdx)
-	vmovdqa	%ymm6, 8928(%rsp,%rdx)
-	incq	%rcx
-	incq	%rax
-	cmpq	%r15, %rcx
-	je	.LBB2_35
-.LBB2_44:                               # %for_loop61.lr.ph.us
-                                        #   Parent Loop BB2_15 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
+.LBB2_29:                               # %for_loop70.lr.ph.us
+                                        #   Parent Loop BB2_13 Depth=1
+                                        #     Parent Loop BB2_16 Depth=2
                                         # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_31 Depth 4
+                                        #         Child Loop BB2_32 Depth 4
 	movq	%rcx, %rdx
 	shlq	$7, %rdx
-	vpermd	74432(%rsp,%rdx), %ymm14, %ymm0
-	vpermd	74464(%rsp,%rdx), %ymm14, %ymm1
-	vpermd	74368(%rsp,%rdx), %ymm14, %ymm2
+	vmovdqa	.LCPI2_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
+	vmovdqa	%ymm0, %ymm3
+	vpermd	74560(%rsp,%rdx), %ymm0, %ymm0
+	vpermd	74592(%rsp,%rdx), %ymm3, %ymm1
+	vpermd	74496(%rsp,%rdx), %ymm3, %ymm2
 	vinserti128	$1, %xmm1, %ymm0, %ymm0
-	vpermd	74400(%rsp,%rdx), %ymm14, %ymm1
+	vpermd	74528(%rsp,%rdx), %ymm3, %ymm1
 	vinserti128	$1, %xmm1, %ymm2, %ymm1
-	vpmulld	%ymm1, %ymm12, %ymm3
-	vpmulld	%ymm0, %ymm13, %ymm1
+	vpmulld	288(%rsp), %ymm1, %ymm3 # 32-byte Folded Reload
+	vpmulld	256(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
 	vextracti128	$1, %ymm1, %xmm0
 	vpmovzxdq	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
 	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpxor	%xmm5, %xmm5, %xmm5
+	cmpl	$1, %r10d
+	jne	.LBB2_31
+# %bb.30:                               #   in Loop: Header=BB2_29 Depth=3
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm4, %xmm4, %xmm4
-	cmpl	$1, %r11d
-	je	.LBB2_45
-# %bb.30:                               # %for_loop61.lr.ph.us.new
-                                        #   in Loop: Header=BB2_44 Depth=3
-	movq	%r8, %rdi
+	xorl	%esi, %esi
+	jmp	.LBB2_34
+	.p2align	4, 0x90
+.LBB2_31:                               # %for_loop70.lr.ph.us.new
+                                        #   in Loop: Header=BB2_29 Depth=3
+	movq	%r15, %rdi
 	xorl	%esi, %esi
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
 	vpxor	%xmm6, %xmm6, %xmm6
+	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB2_31:                               # %for_loop61.us
-                                        #   Parent Loop BB2_15 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        #       Parent Loop BB2_44 Depth=3
+.LBB2_32:                               # %for_loop70.us
+                                        #   Parent Loop BB2_13 Depth=1
+                                        #     Parent Loop BB2_16 Depth=2
+                                        #       Parent Loop BB2_29 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vpmovzxdq	-32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm0, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm2, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmovzxdq	-16(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm0, %ymm8, %ymm8
 	leal	(%rcx,%rsi), %ebx
 	shlq	$7, %rbx
-	vpaddq	74464(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm11, %ymm6
-	vpaddq	74368(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vpaddq	74400(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	74432(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm7, %ymm9, %ymm7
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 74432(%rsp,%rbx)
-	vmovdqa	%ymm10, 74400(%rsp,%rbx)
-	vmovdqa	%ymm9, 74368(%rsp,%rbx)
-	vmovdqa	%ymm8, 74464(%rsp,%rbx)
+	vpaddq	74496(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm11, %ymm5, %ymm5
+	vpaddq	74528(%rsp,%rbx), %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm7, %ymm7
+	vpaddq	74560(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	74592(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	%ymm8, %ymm4, %ymm4
+	vpblendd	$170, %ymm12, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+	vmovdqa	%ymm11, 74592(%rsp,%rbx)
+	vmovdqa	%ymm10, 74560(%rsp,%rbx)
+	vmovdqa	%ymm9, 74528(%rsp,%rbx)
+	vmovdqa	%ymm8, 74496(%rsp,%rbx)
 	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm7, %ymm7
-	vpmovzxdq	32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rdi), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	(%rdi), %ymm8   # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmovzxdq	16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm0, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmuludq	%ymm0, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm3, %ymm8, %ymm8
 	leal	(%rax,%rsi), %ebx
 	shlq	$7, %rbx
-	vpaddq	74400(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	74368(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm7, %ymm11, %ymm7
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vpaddq	74464(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm9, %ymm6
-	vpaddq	74432(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 74432(%rsp,%rbx)
-	vmovdqa	%ymm10, 74464(%rsp,%rbx)
-	vmovdqa	%ymm9, 74368(%rsp,%rbx)
-	vmovdqa	%ymm8, 74400(%rsp,%rbx)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm5, %ymm5
-	vpsrlq	$32, %ymm7, %ymm7
+	vpaddq	74528(%rsp,%rbx), %ymm7, %ymm7
+	vpaddq	74592(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vpaddq	74560(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	74496(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm8, %ymm5, %ymm5
+	vpblendd	$170, %ymm12, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+	vmovdqa	%ymm11, 74496(%rsp,%rbx)
+	vmovdqa	%ymm10, 74560(%rsp,%rbx)
+	vmovdqa	%ymm9, 74592(%rsp,%rbx)
+	vmovdqa	%ymm8, 74528(%rsp,%rbx)
 	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm5, %ymm5
 	addq	$2, %rsi
 	subq	$-128, %rdi
 	cmpl	%esi, %r13d
-	jne	.LBB2_31
-# %bb.32:                               # %for_test60.for_exit63_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_44 Depth=3
-	testb	$1, %r11b
-	jne	.LBB2_33
-	jmp	.LBB2_34
-	.p2align	4, 0x90
-.LBB2_35:                               # %for_loop91.lr.ph
-                                        #   in Loop: Header=BB2_43 Depth=2
-	movl	192(%rsp), %esi         # 4-byte Reload
-	vmovd	%esi, %xmm0
+	jne	.LBB2_32
+# %bb.33:                               # %for_test68.for_exit71_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_29 Depth=3
+	testb	$1, %r10b
+	je	.LBB2_35
+.LBB2_34:                               # %for_loop70.us.epil.preheader
+                                        #   in Loop: Header=BB2_29 Depth=3
+	movq	%rsi, %rdi
+	shlq	$6, %rdi
+	vpmovzxdq	21296(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21280(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21264(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21248(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	vpmuludq	%ymm1, %ymm9, %ymm1
+	vpmuludq	%ymm0, %ymm8, %ymm0
+	addl	%ecx, %esi
+	shlq	$7, %rsi
+	vpaddq	74496(%rsp,%rsi), %ymm5, %ymm5
+	vpaddq	74528(%rsp,%rsi), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm5, %ymm3
+	vpaddq	%ymm2, %ymm7, %ymm2
+	vpaddq	74560(%rsp,%rsi), %ymm6, %ymm5
+	vpaddq	%ymm1, %ymm5, %ymm1
+	vpaddq	74592(%rsp,%rsi), %ymm4, %ymm4
+	vpaddq	%ymm0, %ymm4, %ymm0
+	vpblendd	$170, %ymm12, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm12[1],ymm2[2],ymm12[3],ymm2[4],ymm12[5],ymm2[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vmovdqa	%ymm7, 74592(%rsp,%rsi)
+	vmovdqa	%ymm6, 74560(%rsp,%rsi)
+	vmovdqa	%ymm5, 74528(%rsp,%rsi)
+	vmovdqa	%ymm4, 74496(%rsp,%rsi)
+	vpsrlq	$32, %ymm0, %ymm4
+	vpsrlq	$32, %ymm1, %ymm6
+	vpsrlq	$32, %ymm2, %ymm7
+	vpsrlq	$32, %ymm3, %ymm5
+.LBB2_35:                               # %for_exit71.us
+                                        #   in Loop: Header=BB2_29 Depth=3
+	vmovdqa	%ymm7, 8992(%rsp,%rdx)
+	vmovdqa	%ymm5, 8960(%rsp,%rdx)
+	vmovdqa	%ymm6, 9024(%rsp,%rdx)
+	vmovdqa	%ymm4, 9056(%rsp,%rdx)
+	addq	$1, %rcx
+	addq	$1, %rax
+	cmpq	%r9, %rcx
+	jne	.LBB2_29
+# %bb.36:                               # %for_test98.preheader
+                                        #   in Loop: Header=BB2_16 Depth=2
+	testl	%r10d, %r10d
+	vmovdqa	384(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	352(%rsp), %ymm11       # 32-byte Reload
+	je	.LBB2_37
+# %bb.41:                               # %for_loop100.lr.ph
+                                        #   in Loop: Header=BB2_16 Depth=2
+	vmovd	%r8d, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
-	vpand	416(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
-	vpand	160(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
-	vpcmpeqd	%ymm0, %ymm15, %ymm0
+	vpand	576(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
+	vpand	448(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpcmpeqd	%ymm13, %ymm0, %ymm0
 	vpcmpeqd	%ymm2, %ymm2, %ymm2
 	vpxor	%ymm2, %ymm0, %ymm0
-	vpcmpeqd	%ymm1, %ymm15, %ymm1
+	vpcmpeqd	%ymm13, %ymm1, %ymm1
 	vpxor	%ymm2, %ymm1, %ymm1
 	vmovdqa	.LCPI2_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
 	vpermd	%ymm1, %ymm2, %ymm4
@@ -3008,294 +2810,366 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpermd	%ymm1, %ymm3, %ymm5
 	vpermd	%ymm0, %ymm2, %ymm6
 	vpermd	%ymm0, %ymm3, %ymm7
-	vpxor	%xmm11, %xmm11, %xmm11
-	movl	%r11d, %eax
-	xorl	%ecx, %ecx
-	vpxor	%xmm12, %xmm12, %xmm12
+	xorl	%eax, %eax
+	leaq	8960(%rsp), %rcx
 	vpxor	%xmm14, %xmm14, %xmm14
-	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
 	.p2align	4, 0x90
-.LBB2_36:                               # %for_loop91
-                                        #   Parent Loop BB2_15 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
+.LBB2_42:                               # %for_loop100
+                                        #   Parent Loop BB2_13 Depth=1
+                                        #     Parent Loop BB2_16 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	movl	%eax, %edx
+	cltq
+	movq	%rax, %rdx
 	shlq	$7, %rdx
-	vmovdqa	74368(%rsp,%rdx), %ymm0
-	vmovdqa	74400(%rsp,%rdx), %ymm1
-	vmovdqa	74432(%rsp,%rdx), %ymm8
-	vmovdqa	74464(%rsp,%rdx), %ymm9
-	vpaddq	8832(%rsp,%rcx), %ymm0, %ymm0
-	vpaddq	8864(%rsp,%rcx), %ymm1, %ymm1
-	vpaddq	8896(%rsp,%rcx), %ymm8, %ymm8
-	vpaddq	8928(%rsp,%rcx), %ymm9, %ymm9
-	vpaddq	%ymm0, %ymm0, %ymm10
-	vblendvpd	%ymm4, %ymm10, %ymm0, %ymm0
-	vpaddq	%ymm1, %ymm1, %ymm10
-	vblendvpd	%ymm5, %ymm10, %ymm1, %ymm1
-	vpaddq	%ymm8, %ymm8, %ymm10
-	vblendvpd	%ymm6, %ymm10, %ymm8, %ymm8
-	vpaddq	%ymm9, %ymm9, %ymm10
-	vblendvpd	%ymm7, %ymm10, %ymm9, %ymm9
-	vpaddq	%ymm8, %ymm14, %ymm3
-	vpblendd	$170, %ymm15, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vmovdqa	%ymm8, 8896(%rsp,%rcx)
-	vpaddq	%ymm9, %ymm13, %ymm2
-	vpblendd	$170, %ymm15, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vmovdqa	%ymm8, 8928(%rsp,%rcx)
-	vpaddq	%ymm0, %ymm11, %ymm0
-	vpblendd	$170, %ymm15, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vmovdqa	%ymm8, 8832(%rsp,%rcx)
-	vpaddq	%ymm1, %ymm12, %ymm1
-	vpblendd	$170, %ymm15, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm15[1],ymm1[2],ymm15[3],ymm1[4],ymm15[5],ymm1[6],ymm15[7]
-	vmovdqa	%ymm8, 8864(%rsp,%rcx)
-	vpsrlq	$32, %ymm2, %ymm13
-	vpsrlq	$32, %ymm3, %ymm14
-	vpsrlq	$32, %ymm1, %ymm12
-	vpsrlq	$32, %ymm0, %ymm11
+	leal	(%r10,%rax), %esi
+	movslq	%esi, %rsi
+	shlq	$7, %rsi
+	vmovdqa	74496(%rsp,%rsi), %ymm0
+	vmovdqa	74528(%rsp,%rsi), %ymm1
+	vmovdqa	74560(%rsp,%rsi), %ymm2
+	vmovdqa	74592(%rsp,%rsi), %ymm3
+	vpaddq	8960(%rsp,%rdx), %ymm0, %ymm0
+	vpaddq	8992(%rsp,%rdx), %ymm1, %ymm1
+	vpaddq	9024(%rsp,%rdx), %ymm2, %ymm2
+	vpaddq	9056(%rsp,%rdx), %ymm3, %ymm3
+	vpaddq	%ymm0, %ymm0, %ymm8
+	vblendvpd	%ymm4, %ymm8, %ymm0, %ymm0
+	vpaddq	%ymm1, %ymm1, %ymm8
+	vblendvpd	%ymm5, %ymm8, %ymm1, %ymm1
+	vpaddq	%ymm2, %ymm2, %ymm8
+	vblendvpd	%ymm6, %ymm8, %ymm2, %ymm2
+	vpaddq	%ymm3, %ymm3, %ymm8
+	vblendvpd	%ymm7, %ymm8, %ymm3, %ymm3
+	vpaddq	%ymm3, %ymm9, %ymm3
+	vpblendd	$170, %ymm12, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+	vmovdqa	%ymm8, 96(%rcx)
+	vpaddq	%ymm2, %ymm15, %ymm2
+	vpblendd	$170, %ymm12, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm12[1],ymm2[2],ymm12[3],ymm2[4],ymm12[5],ymm2[6],ymm12[7]
+	vmovdqa	%ymm8, 64(%rcx)
+	vpaddq	%ymm1, %ymm14, %ymm1
+	vpblendd	$170, %ymm12, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vmovdqa	%ymm8, 32(%rcx)
+	vpaddq	%ymm0, %ymm13, %ymm0
+	vpblendd	$170, %ymm12, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vmovdqa	%ymm8, (%rcx)
+	vpsrlq	$32, %ymm3, %ymm9
+	vpsrlq	$32, %ymm2, %ymm15
+	vpsrlq	$32, %ymm1, %ymm14
+	vpsrlq	$32, %ymm0, %ymm13
+	addl	$1, %eax
 	subq	$-128, %rcx
-	incl	%eax
-	cmpq	%rcx, %r12
-	jne	.LBB2_36
-# %bb.37:                               # %for_test126.preheader
-                                        #   in Loop: Header=BB2_43 Depth=2
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vmovdqa	256(%rsp), %ymm2        # 32-byte Reload
-	vmovdqa	224(%rsp), %ymm7        # 32-byte Reload
+	cmpl	%eax, %r10d
+	jne	.LBB2_42
+	jmp	.LBB2_38
 	.p2align	4, 0x90
-.LBB2_38:                               # %for_test126
-                                        #   Parent Loop BB2_15 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_40 Depth 4
-	vpcmpeqq	%ymm15, %ymm12, %ymm0
+.LBB2_17:                               #   in Loop: Header=BB2_16 Depth=2
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
+	movl	%ebx, %r8d
+	vmovdqa	384(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	352(%rsp), %ymm11       # 32-byte Reload
+	vpxor	%xmm12, %xmm12, %xmm12
+	jmp	.LBB2_38
+	.p2align	4, 0x90
+.LBB2_37:                               #   in Loop: Header=BB2_16 Depth=2
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
+.LBB2_38:                               # %for_test134.preheader
+                                        #   in Loop: Header=BB2_16 Depth=2
+	vmovdqa	%ymm9, 416(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm12, %ymm9, %ymm0
+	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm15, %ymm11, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm3, %ymm0, %ymm3
-	vpcmpeqq	%ymm15, %ymm13, %ymm0
+	vpcmpeqq	%ymm12, %ymm15, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm4
+	vpcmpeqq	%ymm12, %ymm14, %ymm0
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm15, %ymm14, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm4, %ymm0, %ymm4
-	vmovmskps	%ymm3, %eax
+	vpcmpeqq	%ymm12, %ymm13, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm2
+	vmovmskps	%ymm2, %eax
 	vmovmskps	%ymm4, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_42
-# %bb.39:                               # %for_loop141.lr.ph
-                                        #   in Loop: Header=BB2_38 Depth=3
-	vmovdqa	%ymm14, 512(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm13, 544(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm12, 576(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm11, 608(%rsp)       # 32-byte Spill
-	vmovaps	.LCPI2_3(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
-	vpermps	%ymm3, %ymm0, %ymm1
-	vmovaps	%ymm1, 64(%rsp)         # 32-byte Spill
-	vmovaps	.LCPI2_4(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
-	vmovaps	%ymm3, 480(%rsp)        # 32-byte Spill
-	vpermps	%ymm3, %ymm1, %ymm3
-	vmovaps	%ymm3, 32(%rsp)         # 32-byte Spill
-	vpermps	%ymm4, %ymm0, %ymm0
-	vmovaps	%ymm0, 96(%rsp)         # 32-byte Spill
-	vmovaps	%ymm4, 448(%rsp)        # 32-byte Spill
-	vpermps	%ymm4, %ymm1, %ymm9
-	vmovdqa	%ymm2, %ymm6
+	je	.LBB2_46
+	.p2align	4, 0x90
+.LBB2_39:                               # %for_test148.preheader
+                                        #   Parent Loop BB2_13 Depth=1
+                                        #     Parent Loop BB2_16 Depth=2
+                                        # =>    This Loop Header: Depth=3
+                                        #         Child Loop BB2_44 Depth 4
+	vmovdqa	.LCPI2_3(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
+	vpermd	%ymm2, %ymm0, %ymm3
+	vmovdqa	.LCPI2_4(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
+	vpermd	%ymm2, %ymm1, %ymm5
+	vpermd	%ymm4, %ymm0, %ymm0
+	vpermd	%ymm4, %ymm1, %ymm1
+	testl	%r10d, %r10d
+	vmovdqa	%ymm13, 512(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm14, 704(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm15, 672(%rsp)       # 32-byte Spill
+	vmovaps	%ymm4, 640(%rsp)        # 32-byte Spill
+	vmovaps	%ymm2, 608(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm5, 224(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm3, 192(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm11, %ymm8
 	vpxor	%xmm11, %xmm11, %xmm11
-	movl	$0, %eax
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpxor	%xmm12, %xmm12, %xmm12
+	je	.LBB2_40
+# %bb.43:                               # %for_loop150.preheader
+                                        #   in Loop: Header=BB2_39 Depth=3
+	xorl	%eax, %eax
+	xorl	%ecx, %ecx
 	vpxor	%xmm13, %xmm13, %xmm13
-	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vmovdqa	%ymm10, %ymm7
+	vpxor	%xmm10, %xmm10, %xmm10
 	vpxor	%xmm15, %xmm15, %xmm15
 	vpxor	%xmm14, %xmm14, %xmm14
 	.p2align	4, 0x90
-.LBB2_40:                               # %for_loop141
-                                        #   Parent Loop BB2_15 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        #       Parent Loop BB2_38 Depth=3
+.LBB2_44:                               # %for_loop150
+                                        #   Parent Loop BB2_13 Depth=1
+                                        #     Parent Loop BB2_16 Depth=2
+                                        #       Parent Loop BB2_39 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vmovdqa	8832(%rsp,%rax,2), %ymm2
-	vmovdqa	21120(%rsp,%rax), %ymm0
-	vmovdqa	21152(%rsp,%rax), %ymm1
-	vpsllvd	%ymm6, %ymm0, %ymm3
-	vpor	%ymm3, %ymm15, %ymm3
-	vpsllvd	%ymm6, %ymm1, %ymm15
-	vmovdqa	8928(%rsp,%rax,2), %ymm4
+	vmovdqa	8960(%rsp,%rax), %ymm2
+	vmovdqa	8992(%rsp,%rax), %ymm3
+	movq	%rcx, %rdx
+	sarq	$26, %rdx
+	vmovdqa	21248(%rsp,%rdx), %ymm0
+	vmovdqa	21280(%rsp,%rdx), %ymm1
+	vpsllvd	%ymm7, %ymm0, %ymm4
+	vpor	%ymm15, %ymm4, %ymm4
+	vpsllvd	%ymm7, %ymm1, %ymm15
 	vpor	%ymm14, %ymm15, %ymm14
-	vextracti128	$1, %ymm14, %xmm5
+	vextracti128	$1, %ymm4, %xmm5
 	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpsubq	%ymm5, %ymm4, %ymm5
-	vpaddq	%ymm5, %ymm13, %ymm5
-	vmovdqa	8896(%rsp,%rax,2), %ymm13
-	vpmovzxdq	%xmm14, %ymm14  # ymm14 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vpsubq	%ymm14, %ymm13, %ymm14
-	vpaddq	%ymm12, %ymm14, %ymm12
-	vpmovzxdq	%xmm3, %ymm14   # ymm14 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm14, %ymm2, %ymm14
-	vpaddq	%ymm11, %ymm14, %ymm11
-	vpblendd	$170, %ymm8, %ymm11, %ymm14 # ymm14 = ymm11[0],ymm8[1],ymm11[2],ymm8[3],ymm11[4],ymm8[5],ymm11[6],ymm8[7]
-	vmovapd	64(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm2, %ymm2
-	vmovdqa	8864(%rsp,%rax,2), %ymm14
-	vextracti128	$1, %ymm3, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm3, %ymm14, %ymm3
-	vpaddq	%ymm3, %ymm10, %ymm3
-	vpblendd	$170, %ymm8, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
-	vmovapd	32(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm10, %ymm14, %ymm10
-	vpblendd	$170, %ymm8, %ymm12, %ymm14 # ymm14 = ymm12[0],ymm8[1],ymm12[2],ymm8[3],ymm12[4],ymm8[5],ymm12[6],ymm8[7]
-	vmovapd	96(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm13, %ymm13
-	vpblendd	$170, %ymm8, %ymm5, %ymm14 # ymm14 = ymm5[0],ymm8[1],ymm5[2],ymm8[3],ymm5[4],ymm8[5],ymm5[6],ymm8[7]
-	vblendvpd	%ymm9, %ymm14, %ymm4, %ymm4
-	vmovapd	%ymm13, 8896(%rsp,%rax,2)
-	vmovapd	%ymm4, 8928(%rsp,%rax,2)
-	vmovapd	%ymm2, 8832(%rsp,%rax,2)
-	vpsrlvd	%ymm7, %ymm1, %ymm14
-	vpsrlvd	%ymm7, %ymm0, %ymm15
-	vmovapd	%ymm10, 8864(%rsp,%rax,2)
-	vpsrad	$31, %ymm5, %ymm0
-	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm12, %ymm0
-	vpshufd	$245, %ymm12, %ymm1     # ymm1 = ymm12[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm3, %ymm0
-	vpshufd	$245, %ymm3, %ymm1      # ymm1 = ymm3[1,1,3,3,5,5,7,7]
+	vpsubq	%ymm5, %ymm3, %ymm5
+	vpaddq	%ymm13, %ymm5, %ymm5
+	vmovdqa	9024(%rsp,%rax), %ymm13
+	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm11, %ymm4, %ymm4
+	vpblendd	$170, %ymm9, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm9[1],ymm4[2],ymm9[3],ymm4[4],ymm9[5],ymm4[6],ymm9[7]
+	vmovapd	192(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm11, %ymm2, %ymm2
+	vpblendd	$170, %ymm9, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm9[1],ymm5[2],ymm9[3],ymm5[4],ymm9[5],ymm5[6],ymm9[7]
+	vmovapd	224(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm11, %ymm3, %ymm3
+	vpmovzxdq	%xmm14, %ymm11  # ymm11 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vpsubq	%ymm11, %ymm13, %ymm11
+	vpaddq	%ymm12, %ymm11, %ymm11
+	vpblendd	$170, %ymm9, %ymm11, %ymm12 # ymm12 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
+	vmovapd	128(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm12, %ymm13, %ymm12
+	vmovdqa	9056(%rsp,%rax), %ymm13
+	vextracti128	$1, %ymm14, %xmm6
+	vpmovzxdq	%xmm6, %ymm6    # ymm6 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero
+	vpsubq	%ymm6, %ymm13, %ymm6
+	vpaddq	%ymm10, %ymm6, %ymm6
+	vpblendd	$170, %ymm9, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm9[1],ymm6[2],ymm9[3],ymm6[4],ymm9[5],ymm6[6],ymm9[7]
+	vmovapd	160(%rsp), %ymm14       # 32-byte Reload
+	vblendvpd	%ymm14, %ymm10, %ymm13, %ymm10
+	vmovapd	%ymm10, 9056(%rsp,%rax)
+	vmovapd	%ymm12, 9024(%rsp,%rax)
+	vpsrlvd	%ymm8, %ymm1, %ymm14
+	vpsrlvd	%ymm8, %ymm0, %ymm15
+	vmovapd	%ymm3, 8992(%rsp,%rax)
+	vmovapd	%ymm2, 8960(%rsp,%rax)
+	vpsrad	$31, %ymm6, %ymm0
+	vpshufd	$245, %ymm6, %ymm1      # ymm1 = ymm6[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm10 # ymm10 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
 	vpsrad	$31, %ymm11, %ymm0
 	vpshufd	$245, %ymm11, %ymm1     # ymm1 = ymm11[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpsrad	$31, %ymm5, %ymm0
+	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpsrad	$31, %ymm4, %ymm0
+	vpshufd	$245, %ymm4, %ymm1      # ymm1 = ymm4[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	addq	$64, %rax
-	cmpq	%rax, %r14
-	jne	.LBB2_40
-# %bb.41:                               # %for_exit143
-                                        #   in Loop: Header=BB2_38 Depth=3
-	vmovdqa	544(%rsp), %ymm1        # 32-byte Reload
-	vpaddq	%ymm1, %ymm13, %ymm0
-	vmovdqa	%ymm1, %ymm13
-	vmovdqa	512(%rsp), %ymm14       # 32-byte Reload
-	vpaddq	%ymm14, %ymm12, %ymm1
-	vmovdqa	576(%rsp), %ymm12       # 32-byte Reload
-	vpaddq	%ymm12, %ymm10, %ymm2
-	vmovdqa	608(%rsp), %ymm4        # 32-byte Reload
-	vpaddq	%ymm4, %ymm11, %ymm3
-	vmovdqa	%ymm4, %ymm11
-	vmovapd	64(%rsp), %ymm4         # 32-byte Reload
-	vblendvpd	%ymm4, %ymm3, %ymm11, %ymm11
-	vmovapd	32(%rsp), %ymm3         # 32-byte Reload
-	vblendvpd	%ymm3, %ymm2, %ymm12, %ymm12
-	vmovapd	96(%rsp), %ymm2         # 32-byte Reload
-	vblendvpd	%ymm2, %ymm1, %ymm14, %ymm14
-	vblendvpd	%ymm9, %ymm0, %ymm13, %ymm13
-	vmovdqa	%ymm6, %ymm2
-	vpxor	%xmm15, %xmm15, %xmm15
-	vmovaps	480(%rsp), %ymm3        # 32-byte Reload
-	vmovaps	448(%rsp), %ymm4        # 32-byte Reload
-	jmp	.LBB2_38
-.LBB2_19:                               # %for_test188.preheader
-	testl	%r11d, %r11d
+	addq	%r14, %rcx
+	subq	$-128, %rax
+	cmpq	%rax, %r12
+	jne	.LBB2_44
+	jmp	.LBB2_45
+	.p2align	4, 0x90
+.LBB2_40:                               #   in Loop: Header=BB2_39 Depth=3
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vmovdqa	%ymm10, %ymm7
+	vpxor	%xmm10, %xmm10, %xmm10
+.LBB2_45:                               # %for_exit151
+                                        #   in Loop: Header=BB2_39 Depth=3
+	vmovdqa	416(%rsp), %ymm4        # 32-byte Reload
+	vpaddq	%ymm4, %ymm10, %ymm0
+	vmovdqa	672(%rsp), %ymm15       # 32-byte Reload
+	vpaddq	%ymm15, %ymm12, %ymm1
+	vmovdqa	704(%rsp), %ymm14       # 32-byte Reload
+	vpaddq	%ymm14, %ymm13, %ymm2
+	vmovdqa	512(%rsp), %ymm13       # 32-byte Reload
+	vpaddq	%ymm13, %ymm11, %ymm3
+	vmovapd	192(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm3, %ymm13, %ymm13
+	vmovapd	224(%rsp), %ymm3        # 32-byte Reload
+	vblendvpd	%ymm3, %ymm2, %ymm14, %ymm14
+	vmovapd	128(%rsp), %ymm2        # 32-byte Reload
+	vblendvpd	%ymm2, %ymm1, %ymm15, %ymm15
+	vmovapd	160(%rsp), %ymm1        # 32-byte Reload
+	vblendvpd	%ymm1, %ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm9, %ymm14, %ymm0
+	vextracti128	$1, %ymm0, %xmm1
+	vpackssdw	%xmm1, %xmm0, %xmm0
+	vpcmpeqq	%ymm9, %ymm13, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm0
+	vmovapd	%ymm4, 416(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm4, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vpcmpeqq	%ymm9, %ymm15, %ymm2
+	vextracti128	$1, %ymm2, %xmm3
+	vpackssdw	%xmm3, %xmm2, %xmm2
+	vinserti128	$1, %xmm1, %ymm2, %ymm1
+	vmovdqa	640(%rsp), %ymm4        # 32-byte Reload
+	vpandn	%ymm4, %ymm1, %ymm4
+	vmovdqa	608(%rsp), %ymm2        # 32-byte Reload
+	vpandn	%ymm2, %ymm0, %ymm2
+	vmovmskps	%ymm2, %eax
+	vmovmskps	%ymm4, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	vmovdqa	%ymm7, %ymm10
+	vmovdqa	%ymm8, %ymm11
+	jne	.LBB2_39
+.LBB2_46:                               # %for_exit137
+                                        #   in Loop: Header=BB2_16 Depth=2
+	shrl	%r8d
+	jne	.LBB2_16
+# %bb.18:                               # %for_test36.loopexit
+                                        #   in Loop: Header=BB2_13 Depth=1
+	movl	$-2147483648, %r8d      # imm = 0x80000000
+	movq	544(%rsp), %rcx         # 8-byte Reload
+	testq	%rcx, %rcx
+	jg	.LBB2_13
+.LBB2_19:                               # %for_test196.preheader
+	testl	%r10d, %r10d
 	je	.LBB2_20
-# %bb.21:                               # %for_loop189.lr.ph
-	leal	-1(%r11), %r8d
-	movl	%r11d, %eax
+# %bb.21:                               # %for_loop198.lr.ph
+	leal	-1(%r10), %ecx
+	movl	%r10d, %eax
 	andl	$3, %eax
-	cmpl	$3, %r8d
-	jae	.LBB2_54
+	cmpl	$3, %ecx
+	jae	.LBB2_58
 # %bb.22:
 	xorl	%ecx, %ecx
 	jmp	.LBB2_23
-.LBB2_71:                               # %for_loop489.lr.ph.new
-	movl	%r11d, %r8d
+.LBB2_20:
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	movq	120(%rsp), %r15         # 8-byte Reload
+	jmp	.LBB2_65
+.LBB2_80:                               # %for_loop497.lr.ph.new
+	movl	%r10d, %r8d
 	andl	$1, %r8d
-	movl	%r11d, %r9d
+	movl	%r10d, %r9d
 	subl	%r8d, %r9d
-	movl	$64, %ecx
-	xorl	%r10d, %r10d
+	movl	$64, %eax
+	xorl	%r11d, %r11d
 	.p2align	4, 0x90
-.LBB2_72:                               # %for_loop489
+.LBB2_81:                               # %for_loop497
                                         # =>This Inner Loop Header: Depth=1
-	vmovd	%r10d, %xmm2
+	vmovd	%r11d, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
 	vpaddd	%ymm1, %ymm2, %ymm3
 	vpaddd	%ymm0, %ymm2, %ymm2
 	vpslld	$2, %ymm3, %ymm3
-	vmovaps	%ymm15, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdi,%ymm3), %ymm5
-	vpslld	$2, %ymm2, %ymm2
-	vmovaps	%ymm9, %ymm4
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpgatherdd	%ymm4, (%rdi,%ymm2), %ymm6
-	vmovdqa	%ymm6, 16992(%rsp,%rcx)
-	vmovdqa	%ymm5, 16960(%rsp,%rcx)
-	vmovaps	%ymm15, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdx,%ymm3), %ymm5
-	vmovaps	%ymm9, %ymm3
 	vpxor	%xmm4, %xmm4, %xmm4
-	vpgatherdd	%ymm3, (%rdx,%ymm2), %ymm4
-	vpmovzxdq	%xmm5, %ymm2    # ymm2 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vextracti128	$1, %ymm5, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpmovzxdq	%xmm4, %ymm5    # ymm5 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vmovaps	%ymm15, %ymm5
+	vpgatherdd	%ymm5, (%rdi,%ymm3), %ymm4
+	vpslld	$2, %ymm2, %ymm2
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovaps	%ymm14, %ymm6
+	vpgatherdd	%ymm6, (%rdi,%ymm2), %ymm5
+	vmovdqa	%ymm5, 17120(%rsp,%rax)
+	vmovdqa	%ymm4, 17088(%rsp,%rax)
+	vpxor	%xmm4, %xmm4, %xmm4
+	vmovaps	%ymm15, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm3), %ymm4
+	vpxor	%xmm3, %xmm3, %xmm3
+	vmovaps	%ymm14, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm2), %ymm3
+	vpmovzxdq	%xmm4, %ymm2    # ymm2 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
 	vextracti128	$1, %ymm4, %xmm4
-	vmovdqa	%ymm5, 576(%rsp,%rcx,2)
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	leal	1(%r10), %eax
-	vmovdqa	%ymm2, 512(%rsp,%rcx,2)
-	vmovd	%eax, %xmm2
+	vpmovzxdq	%xmm3, %ymm5    # ymm5 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vextracti128	$1, %ymm3, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vmovdqa	%ymm5, 704(%rsp,%rax,2)
+	vmovdqa	%ymm2, 640(%rsp,%rax,2)
+	leal	1(%r11), %ebx
+	vmovd	%ebx, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
-	vmovdqa	%ymm4, 608(%rsp,%rcx,2)
-	vpaddd	%ymm1, %ymm2, %ymm4
+	vmovdqa	%ymm3, 736(%rsp,%rax,2)
+	vpaddd	%ymm1, %ymm2, %ymm3
 	vpaddd	%ymm0, %ymm2, %ymm2
-	vmovdqa	%ymm3, 544(%rsp,%rcx,2)
-	vpslld	$2, %ymm4, %ymm3
-	vmovaps	%ymm15, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdi,%ymm3), %ymm5
-	vpslld	$2, %ymm2, %ymm2
-	vmovaps	%ymm9, %ymm4
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpgatherdd	%ymm4, (%rdi,%ymm2), %ymm6
-	vmovdqa	%ymm6, 17056(%rsp,%rcx)
-	vmovdqa	%ymm5, 17024(%rsp,%rcx)
-	vmovaps	%ymm15, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdx,%ymm3), %ymm5
-	vmovaps	%ymm9, %ymm3
+	vmovdqa	%ymm4, 672(%rsp,%rax,2)
+	vpslld	$2, %ymm3, %ymm3
 	vpxor	%xmm4, %xmm4, %xmm4
-	vpgatherdd	%ymm3, (%rdx,%ymm2), %ymm4
-	vpmovzxdq	%xmm5, %ymm2    # ymm2 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vextracti128	$1, %ymm5, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpmovzxdq	%xmm4, %ymm5    # ymm5 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vmovaps	%ymm15, %ymm5
+	vpgatherdd	%ymm5, (%rdi,%ymm3), %ymm4
+	vpslld	$2, %ymm2, %ymm2
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovaps	%ymm14, %ymm6
+	vpgatherdd	%ymm6, (%rdi,%ymm2), %ymm5
+	vmovdqa	%ymm5, 17184(%rsp,%rax)
+	vmovdqa	%ymm4, 17152(%rsp,%rax)
+	vpxor	%xmm4, %xmm4, %xmm4
+	vmovaps	%ymm15, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm3), %ymm4
+	vpxor	%xmm3, %xmm3, %xmm3
+	vmovaps	%ymm14, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm2), %ymm3
+	vpmovzxdq	%xmm4, %ymm2    # ymm2 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
 	vextracti128	$1, %ymm4, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vmovdqa	%ymm5, 704(%rsp,%rcx,2)
-	vmovdqa	%ymm4, 736(%rsp,%rcx,2)
-	vmovdqa	%ymm2, 640(%rsp,%rcx,2)
-	vmovdqa	%ymm3, 672(%rsp,%rcx,2)
-	addq	$2, %r10
-	subq	$-128, %rcx
-	cmpl	%r10d, %r9d
-	jne	.LBB2_72
-# %bb.73:                               # %for_test488.for_exit491_crit_edge.unr-lcssa
+	vpmovzxdq	%xmm3, %ymm5    # ymm5 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vextracti128	$1, %ymm3, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vmovdqa	%ymm5, 832(%rsp,%rax,2)
+	vmovdqa	%ymm3, 864(%rsp,%rax,2)
+	vmovdqa	%ymm2, 768(%rsp,%rax,2)
+	vmovdqa	%ymm4, 800(%rsp,%rax,2)
+	addq	$2, %r11
+	subq	$-128, %rax
+	cmpl	%r11d, %r9d
+	jne	.LBB2_81
+# %bb.82:                               # %for_test495.for_exit498_crit_edge.unr-lcssa
 	testl	%r8d, %r8d
-	je	.LBB2_75
-.LBB2_74:                               # %for_loop489.epil.preheader
-	movq	%r10, %rax
-	shlq	$6, %rax
-	vmovd	%r10d, %xmm2
+	je	.LBB2_84
+.LBB2_83:                               # %for_loop497.epil.preheader
+	movq	%r11, %rcx
+	shlq	$6, %rcx
+	vmovd	%r11d, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
 	vpaddd	%ymm1, %ymm2, %ymm1
 	vpaddd	%ymm0, %ymm2, %ymm0
@@ -3304,180 +3178,136 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpgatherdd	%ymm2, (%rdi,%ymm1), %ymm3
 	vpslld	$2, %ymm0, %ymm0
-	vmovaps	%ymm9, %ymm2
+	vmovaps	%ymm14, %ymm2
 	vpxor	%xmm4, %xmm4, %xmm4
 	vpgatherdd	%ymm2, (%rdi,%ymm0), %ymm4
-	vmovdqa	%ymm4, 17056(%rsp,%rax)
-	vmovdqa	%ymm3, 17024(%rsp,%rax)
+	vmovdqa	%ymm4, 17184(%rsp,%rcx)
+	vmovdqa	%ymm3, 17152(%rsp,%rcx)
 	vmovaps	%ymm15, %ymm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpgatherdd	%ymm2, (%rdx,%ymm1), %ymm3
 	vpxor	%xmm1, %xmm1, %xmm1
-	vmovaps	%ymm9, %ymm2
+	vmovaps	%ymm14, %ymm2
 	vpgatherdd	%ymm2, (%rdx,%ymm0), %ymm1
-	shlq	$7, %r10
+	shlq	$7, %r11
 	vpmovzxdq	%xmm3, %ymm0    # ymm0 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm1, %ymm3    # ymm3 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
 	vextracti128	$1, %ymm1, %xmm1
 	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
-	vmovdqa	%ymm1, 736(%rsp,%r10)
-	vmovdqa	%ymm3, 704(%rsp,%r10)
-	vmovdqa	%ymm2, 672(%rsp,%r10)
-	vmovdqa	%ymm0, 640(%rsp,%r10)
-.LBB2_75:                               # %for_exit491
-	vmaskmovps	(%rsi), %ymm15, %ymm0
-	vmovaps	%ymm0, 256(%rsp)        # 32-byte Spill
-	vmaskmovps	32(%rsi), %ymm9, %ymm0
-	vmovaps	%ymm0, 224(%rsp)        # 32-byte Spill
-	testl	%r11d, %r11d
-	jle	.LBB2_81
-# %bb.76:                               # %for_loop529.lr.ph
-	movl	$-2147483648, %eax      # imm = 0x80000000
-	movl	20(%rsp), %ecx          # 4-byte Reload
-	shrxl	%ecx, %eax, %esi
-	vmovd	%ecx, %xmm0
-	vpbroadcastd	%xmm0, %ymm2
-	movl	$32, %eax
+	vmovdqa	%ymm1, 864(%rsp,%r11)
+	vmovdqa	%ymm3, 832(%rsp,%r11)
+	vmovdqa	%ymm2, 800(%rsp,%r11)
+	vmovdqa	%ymm0, 768(%rsp,%r11)
+.LBB2_84:                               # %for_exit498
+	xorl	%ecx, %ecx
+	cmpl	$23, 112(%rsp)          # 4-byte Folded Reload
+	seta	%cl
+	movl	%r10d, %eax
 	subl	%ecx, %eax
-	vmovd	%eax, %xmm0
-	vpbroadcastd	%xmm0, %ymm3
-	leaq	17088(%rsp), %r8
-	movl	%r11d, %r12d
-	andl	$-2, %r12d
-	movq	%r15, %r14
-	shlq	$7, %r14
-	movq	%r15, %r13
-	shlq	$6, %r13
-	movq	%r15, %rax
-	vmovdqa	%ymm2, 384(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm3, 352(%rsp)        # 32-byte Spill
-	jmp	.LBB2_77
+	vmaskmovps	(%rsi), %ymm15, %ymm0
+	vmovaps	%ymm0, 480(%rsp)        # 32-byte Spill
+	vmaskmovps	32(%rsi), %ymm14, %ymm0
+	vmovaps	%ymm0, 448(%rsp)        # 32-byte Spill
+	testl	%eax, %eax
+	vmovaps	%ymm14, 288(%rsp)       # 32-byte Spill
+	vmovaps	%ymm15, 256(%rsp)       # 32-byte Spill
+	jle	.LBB2_92
+# %bb.85:                               # %for_loop545.lr.ph
+	movq	112(%rsp), %rsi         # 8-byte Reload
+	cmpl	$24, %esi
+	setb	%cl
+	shlb	$5, %cl
+	movzbl	%cl, %ecx
+	leal	(%rcx,%rsi), %ecx
+	addl	$-24, %ecx
+	movl	$-2147483648, %edx      # imm = 0x80000000
+	shrxl	%ecx, %edx, %r8d
+	vmovd	%esi, %xmm0
+	vpbroadcastd	%xmm0, %ymm10
+	movl	$32, %ecx
+	subl	%esi, %ecx
+	vmovd	%ecx, %xmm0
+	vpbroadcastd	%xmm0, %ymm11
+	movl	%r10d, %r11d
+	movslq	%eax, %rcx
+	leaq	17216(%rsp), %r13
+	movl	%r10d, %eax
+	andl	$1, %eax
+	movl	%r10d, %r15d
+	subl	%eax, %r15d
+	movq	%r11, %r12
+	shlq	$7, %r12
+	vmovdqa	%ymm10, 384(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm11, 352(%rsp)       # 32-byte Spill
+	movq	%r11, 576(%rsp)         # 8-byte Spill
 	.p2align	4, 0x90
-.LBB2_80:                               # %for_test528.loopexit
-                                        #   in Loop: Header=BB2_77 Depth=1
-	movl	$-2147483648, %esi      # imm = 0x80000000
-	cmpq	$1, 152(%rsp)           # 8-byte Folded Reload
-	movq	144(%rsp), %rax         # 8-byte Reload
-	jle	.LBB2_81
-.LBB2_77:                               # %for_loop529
+.LBB2_86:                               # %for_loop545
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_105 Depth 2
-                                        #       Child Loop BB2_106 Depth 3
-                                        #         Child Loop BB2_93 Depth 4
-                                        #       Child Loop BB2_98 Depth 3
-                                        #       Child Loop BB2_100 Depth 3
-                                        #         Child Loop BB2_102 Depth 4
-	movq	%rax, 152(%rsp)         # 8-byte Spill
-	leaq	-1(%rax), %rcx
+                                        #     Child Loop BB2_89 Depth 2
+                                        #       Child Loop BB2_102 Depth 3
+                                        #         Child Loop BB2_105 Depth 4
+                                        #       Child Loop BB2_116 Depth 3
+                                        #       Child Loop BB2_113 Depth 3
+                                        #         Child Loop BB2_118 Depth 4
+	addq	$-1, %rcx
 	movq	%rcx, %rax
 	shlq	$6, %rax
 	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	movq	%rcx, 144(%rsp)         # 8-byte Spill
+	movq	%rcx, 344(%rsp)         # 8-byte Spill
 	testq	%rcx, %rcx
-	je	.LBB2_79
-# %bb.78:                               # %for_loop529
-                                        #   in Loop: Header=BB2_77 Depth=1
+	je	.LBB2_88
+# %bb.87:                               # %for_loop545
+                                        #   in Loop: Header=BB2_86 Depth=1
 	vpxor	%xmm0, %xmm0, %xmm0
-.LBB2_79:                               # %for_loop529
-                                        #   in Loop: Header=BB2_77 Depth=1
-	vpaddd	17056(%rsp,%rax), %ymm0, %ymm1
-	vmovdqa	%ymm1, 320(%rsp)        # 32-byte Spill
-	vpaddd	17024(%rsp,%rax), %ymm0, %ymm0
-	vmovdqa	%ymm0, 288(%rsp)        # 32-byte Spill
-	jmp	.LBB2_105
+.LBB2_88:                               # %for_loop545
+                                        #   in Loop: Header=BB2_86 Depth=1
+	vpaddd	17184(%rsp,%rax), %ymm0, %ymm1
+	vmovdqa	%ymm1, 544(%rsp)        # 32-byte Spill
+	vpaddd	17152(%rsp,%rax), %ymm0, %ymm0
+	vmovdqa	%ymm0, 736(%rsp)        # 32-byte Spill
 	.p2align	4, 0x90
-.LBB2_104:                              # %for_exit651
-                                        #   in Loop: Header=BB2_105 Depth=2
-	shrl	%esi
-	je	.LBB2_80
-.LBB2_105:                              # %for_loop558.lr.ph.split.us
-                                        #   Parent Loop BB2_77 Depth=1
+.LBB2_89:                               # %do_loop563
+                                        #   Parent Loop BB2_86 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB2_106 Depth 3
-                                        #         Child Loop BB2_93 Depth 4
-                                        #       Child Loop BB2_98 Depth 3
-                                        #       Child Loop BB2_100 Depth 3
-                                        #         Child Loop BB2_102 Depth 4
-	movl	%esi, 416(%rsp)         # 4-byte Spill
-	leaq	57984(%rsp), %rdi
-	leaq	640(%rsp), %rsi
-	movl	%r11d, %edx
-	movq	%r8, %rbx
+                                        #       Child Loop BB2_102 Depth 3
+                                        #         Child Loop BB2_105 Depth 4
+                                        #       Child Loop BB2_116 Depth 3
+                                        #       Child Loop BB2_113 Depth 3
+                                        #         Child Loop BB2_118 Depth 4
+	movl	%r8d, %ebx
+	leaq	58112(%rsp), %rdi
+	leaq	768(%rsp), %rsi
+	movl	%r10d, %edx
 	vzeroupper
 	callq	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	movq	%rbx, %r8
-	movq	24(%rsp), %r11          # 8-byte Reload
+	movq	104(%rsp), %r10         # 8-byte Reload
+	testl	%r10d, %r10d
+	je	.LBB2_90
+# %bb.101:                              # %for_loop590.lr.ph.us.preheader
+                                        #   in Loop: Header=BB2_89 Depth=2
 	movl	$1, %eax
 	xorl	%ecx, %ecx
-	vmovdqa	256(%rsp), %ymm12       # 32-byte Reload
-	vmovdqa	224(%rsp), %ymm13       # 32-byte Reload
-	vmovdqa	.LCPI2_2(%rip), %ymm14  # ymm14 = [0,2,4,6,4,6,6,7]
-	vxorps	%xmm15, %xmm15, %xmm15
-	jmp	.LBB2_106
+	vmovdqa	480(%rsp), %ymm12       # 32-byte Reload
+	vmovdqa	448(%rsp), %ymm13       # 32-byte Reload
+	movl	%ebx, %r8d
+	movq	576(%rsp), %r11         # 8-byte Reload
+	vxorps	%xmm14, %xmm14, %xmm14
+	vmovdqa	.LCPI2_2(%rip), %ymm15  # ymm15 = [0,2,4,6,4,6,6,7]
 	.p2align	4, 0x90
-.LBB2_107:                              #   in Loop: Header=BB2_106 Depth=3
-	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%esi, %esi
-.LBB2_95:                               # %for_loop574.us.epil.preheader
-                                        #   in Loop: Header=BB2_106 Depth=3
-	movq	%rsi, %rdi
-	shlq	$6, %rdi
-	vpmovzxdq	17056(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17072(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17024(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17040(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	vpmuludq	%ymm0, %ymm9, %ymm0
-	vpmuludq	%ymm1, %ymm8, %ymm1
-	addl	%ecx, %esi
-	shlq	$7, %rsi
-	vpaddq	58016(%rsp,%rsi), %ymm7, %ymm7
-	vpaddq	57984(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	%ymm3, %ymm4, %ymm3
-	vpaddq	58080(%rsp,%rsi), %ymm6, %ymm4
-	vpaddq	%ymm0, %ymm4, %ymm0
-	vpaddq	58048(%rsp,%rsi), %ymm5, %ymm4
-	vpaddq	%ymm1, %ymm4, %ymm1
-	vpblendd	$170, %ymm15, %ymm2, %ymm4 # ymm4 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm0, %ymm6 # ymm6 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm15[1],ymm1[2],ymm15[3],ymm1[4],ymm15[5],ymm1[6],ymm15[7]
-	vmovdqa	%ymm7, 58048(%rsp,%rsi)
-	vmovdqa	%ymm6, 58080(%rsp,%rsi)
-	vmovdqa	%ymm5, 57984(%rsp,%rsi)
-	vmovdqa	%ymm4, 58016(%rsp,%rsi)
-	vpsrlq	$32, %ymm0, %ymm6
-	vpsrlq	$32, %ymm1, %ymm5
-	vpsrlq	$32, %ymm2, %ymm7
-	vpsrlq	$32, %ymm3, %ymm4
-.LBB2_96:                               # %for_exit576.us
-                                        #   in Loop: Header=BB2_106 Depth=3
-	vmovdqa	%ymm7, 672(%rsp,%rdx)
-	vmovdqa	%ymm4, 640(%rsp,%rdx)
-	vmovdqa	%ymm5, 704(%rsp,%rdx)
-	vmovdqa	%ymm6, 736(%rsp,%rdx)
-	incq	%rcx
-	incq	%rax
-	cmpq	%r15, %rcx
-	je	.LBB2_97
-.LBB2_106:                              # %for_loop574.lr.ph.us
-                                        #   Parent Loop BB2_77 Depth=1
-                                        #     Parent Loop BB2_105 Depth=2
+.LBB2_102:                              # %for_loop590.lr.ph.us
+                                        #   Parent Loop BB2_86 Depth=1
+                                        #     Parent Loop BB2_89 Depth=2
                                         # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_93 Depth 4
+                                        #         Child Loop BB2_105 Depth 4
 	movq	%rcx, %rdx
 	shlq	$7, %rdx
-	vpermd	58048(%rsp,%rdx), %ymm14, %ymm0
-	vpermd	58080(%rsp,%rdx), %ymm14, %ymm1
-	vpermd	57984(%rsp,%rdx), %ymm14, %ymm2
+	vpermd	58176(%rsp,%rdx), %ymm15, %ymm0
+	vpermd	58208(%rsp,%rdx), %ymm15, %ymm1
+	vpermd	58112(%rsp,%rdx), %ymm15, %ymm2
 	vinserti128	$1, %xmm1, %ymm0, %ymm0
-	vpermd	58016(%rsp,%rdx), %ymm14, %ymm1
+	vpermd	58144(%rsp,%rdx), %ymm15, %ymm1
 	vinserti128	$1, %xmm1, %ymm2, %ymm1
 	vpmulld	%ymm12, %ymm1, %ymm3
 	vpmulld	%ymm13, %ymm0, %ymm1
@@ -3487,103 +3317,156 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpxor	%xmm5, %xmm5, %xmm5
+	cmpl	$1, %r10d
+	jne	.LBB2_104
+# %bb.103:                              #   in Loop: Header=BB2_102 Depth=3
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm4, %xmm4, %xmm4
-	cmpl	$1, %r11d
-	je	.LBB2_107
-# %bb.92:                               # %for_loop574.lr.ph.us.new
-                                        #   in Loop: Header=BB2_106 Depth=3
-	movq	%r8, %rdi
+	xorl	%esi, %esi
+	jmp	.LBB2_107
+	.p2align	4, 0x90
+.LBB2_104:                              # %for_loop590.lr.ph.us.new
+                                        #   in Loop: Header=BB2_102 Depth=3
+	movq	%r13, %rdi
 	xorl	%esi, %esi
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
 	vpxor	%xmm6, %xmm6, %xmm6
+	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB2_93:                               # %for_loop574.us
-                                        #   Parent Loop BB2_77 Depth=1
-                                        #     Parent Loop BB2_105 Depth=2
-                                        #       Parent Loop BB2_106 Depth=3
+.LBB2_105:                              # %for_loop590.us
+                                        #   Parent Loop BB2_86 Depth=1
+                                        #     Parent Loop BB2_89 Depth=2
+                                        #       Parent Loop BB2_102 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vpmovzxdq	-32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm0, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm2, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmovzxdq	-16(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm0, %ymm8, %ymm8
 	leal	(%rcx,%rsi), %ebx
 	shlq	$7, %rbx
-	vpaddq	58080(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm11, %ymm6
-	vpaddq	57984(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vpaddq	58016(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	58048(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm7, %ymm9, %ymm7
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 58048(%rsp,%rbx)
-	vmovdqa	%ymm10, 58016(%rsp,%rbx)
-	vmovdqa	%ymm9, 57984(%rsp,%rbx)
-	vmovdqa	%ymm8, 58080(%rsp,%rbx)
+	vpaddq	58112(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm11, %ymm5, %ymm5
+	vpaddq	58144(%rsp,%rbx), %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm7, %ymm7
+	vpaddq	58176(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	58208(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	%ymm8, %ymm4, %ymm4
+	vpblendd	$170, %ymm14, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm14[1],ymm5[2],ymm14[3],ymm5[4],ymm14[5],ymm5[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm14[1],ymm7[2],ymm14[3],ymm7[4],ymm14[5],ymm7[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm14[1],ymm6[2],ymm14[3],ymm6[4],ymm14[5],ymm6[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm14[1],ymm4[2],ymm14[3],ymm4[4],ymm14[5],ymm4[6],ymm14[7]
+	vmovdqa	%ymm11, 58208(%rsp,%rbx)
+	vmovdqa	%ymm10, 58176(%rsp,%rbx)
+	vmovdqa	%ymm9, 58144(%rsp,%rbx)
+	vmovdqa	%ymm8, 58112(%rsp,%rbx)
 	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm7, %ymm7
-	vpmovzxdq	32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rdi), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	(%rdi), %ymm8   # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmovzxdq	16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm0, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmuludq	%ymm0, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm3, %ymm8, %ymm8
 	leal	(%rax,%rsi), %ebx
 	shlq	$7, %rbx
-	vpaddq	58016(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	57984(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm7, %ymm11, %ymm7
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vpaddq	58080(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm9, %ymm6
-	vpaddq	58048(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 58048(%rsp,%rbx)
-	vmovdqa	%ymm10, 58080(%rsp,%rbx)
-	vmovdqa	%ymm9, 57984(%rsp,%rbx)
-	vmovdqa	%ymm8, 58016(%rsp,%rbx)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm5, %ymm5
-	vpsrlq	$32, %ymm7, %ymm7
+	vpaddq	58144(%rsp,%rbx), %ymm7, %ymm7
+	vpaddq	58208(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vpaddq	58176(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	58112(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm8, %ymm5, %ymm5
+	vpblendd	$170, %ymm14, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm14[1],ymm7[2],ymm14[3],ymm7[4],ymm14[5],ymm7[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm14[1],ymm4[2],ymm14[3],ymm4[4],ymm14[5],ymm4[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm14[1],ymm6[2],ymm14[3],ymm6[4],ymm14[5],ymm6[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm14[1],ymm5[2],ymm14[3],ymm5[4],ymm14[5],ymm5[6],ymm14[7]
+	vmovdqa	%ymm11, 58112(%rsp,%rbx)
+	vmovdqa	%ymm10, 58176(%rsp,%rbx)
+	vmovdqa	%ymm9, 58208(%rsp,%rbx)
+	vmovdqa	%ymm8, 58144(%rsp,%rbx)
 	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm5, %ymm5
 	addq	$2, %rsi
 	subq	$-128, %rdi
-	cmpl	%esi, %r12d
-	jne	.LBB2_93
-# %bb.94:                               # %for_test573.for_exit576_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_106 Depth=3
-	testb	$1, %r11b
-	jne	.LBB2_95
-	jmp	.LBB2_96
-	.p2align	4, 0x90
-.LBB2_97:                               # %for_loop607.lr.ph
-                                        #   in Loop: Header=BB2_105 Depth=2
-	movl	416(%rsp), %esi         # 4-byte Reload
-	vmovd	%esi, %xmm0
+	cmpl	%esi, %r15d
+	jne	.LBB2_105
+# %bb.106:                              # %for_test588.for_exit591_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_102 Depth=3
+	testb	$1, %r10b
+	je	.LBB2_108
+.LBB2_107:                              # %for_loop590.us.epil.preheader
+                                        #   in Loop: Header=BB2_102 Depth=3
+	movq	%rsi, %rdi
+	shlq	$6, %rdi
+	vpmovzxdq	17200(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17184(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17168(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17152(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	vpmuludq	%ymm1, %ymm9, %ymm1
+	vpmuludq	%ymm0, %ymm8, %ymm0
+	addl	%ecx, %esi
+	shlq	$7, %rsi
+	vpaddq	58112(%rsp,%rsi), %ymm5, %ymm5
+	vpaddq	58144(%rsp,%rsi), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm5, %ymm3
+	vpaddq	%ymm2, %ymm7, %ymm2
+	vpaddq	58176(%rsp,%rsi), %ymm6, %ymm5
+	vpaddq	%ymm1, %ymm5, %ymm1
+	vpaddq	58208(%rsp,%rsi), %ymm4, %ymm4
+	vpaddq	%ymm0, %ymm4, %ymm0
+	vpblendd	$170, %ymm14, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm14[1],ymm3[2],ymm14[3],ymm3[4],ymm14[5],ymm3[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm14[1],ymm2[2],ymm14[3],ymm2[4],ymm14[5],ymm2[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm14[1],ymm1[2],ymm14[3],ymm1[4],ymm14[5],ymm1[6],ymm14[7]
+	vpblendd	$170, %ymm14, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm14[1],ymm0[2],ymm14[3],ymm0[4],ymm14[5],ymm0[6],ymm14[7]
+	vmovdqa	%ymm7, 58208(%rsp,%rsi)
+	vmovdqa	%ymm6, 58176(%rsp,%rsi)
+	vmovdqa	%ymm5, 58144(%rsp,%rsi)
+	vmovdqa	%ymm4, 58112(%rsp,%rsi)
+	vpsrlq	$32, %ymm0, %ymm4
+	vpsrlq	$32, %ymm1, %ymm6
+	vpsrlq	$32, %ymm2, %ymm7
+	vpsrlq	$32, %ymm3, %ymm5
+.LBB2_108:                              # %for_exit591.us
+                                        #   in Loop: Header=BB2_102 Depth=3
+	vmovdqa	%ymm7, 800(%rsp,%rdx)
+	vmovdqa	%ymm5, 768(%rsp,%rdx)
+	vmovdqa	%ymm6, 832(%rsp,%rdx)
+	vmovdqa	%ymm4, 864(%rsp,%rdx)
+	addq	$1, %rcx
+	addq	$1, %rax
+	cmpq	%r11, %rcx
+	jne	.LBB2_102
+# %bb.109:                              # %for_test621.preheader
+                                        #   in Loop: Header=BB2_89 Depth=2
+	testl	%r10d, %r10d
+	je	.LBB2_110
+# %bb.115:                              # %for_loop623.lr.ph
+                                        #   in Loop: Header=BB2_89 Depth=2
+	vmovd	%r8d, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
-	vpand	288(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
-	vpand	320(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
-	vpcmpeqd	%ymm0, %ymm15, %ymm0
+	vpand	736(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
+	vpand	544(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpcmpeqd	%ymm12, %ymm0, %ymm0
 	vpcmpeqd	%ymm2, %ymm2, %ymm2
 	vpxor	%ymm2, %ymm0, %ymm0
-	vpcmpeqd	%ymm1, %ymm15, %ymm1
+	vpcmpeqd	%ymm12, %ymm1, %ymm1
 	vpxor	%ymm2, %ymm1, %ymm1
 	vmovdqa	.LCPI2_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
 	vpermd	%ymm1, %ymm2, %ymm4
@@ -3591,950 +3474,988 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vpermd	%ymm1, %ymm3, %ymm5
 	vpermd	%ymm0, %ymm2, %ymm6
 	vpermd	%ymm0, %ymm3, %ymm7
-	vpxor	%xmm12, %xmm12, %xmm12
-	movl	%r11d, %eax
-	xorl	%ecx, %ecx
+	xorl	%eax, %eax
+	leaq	768(%rsp), %rcx
 	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm15, %xmm15, %xmm15
 	vpxor	%xmm14, %xmm14, %xmm14
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm11, %xmm11, %xmm11
-	vmovdqa	160(%rsp), %ymm15       # 32-byte Reload
+	vmovdqa	384(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	352(%rsp), %ymm11       # 32-byte Reload
+	vpxor	%xmm9, %xmm9, %xmm9
 	.p2align	4, 0x90
-.LBB2_98:                               # %for_loop607
-                                        #   Parent Loop BB2_77 Depth=1
-                                        #     Parent Loop BB2_105 Depth=2
+.LBB2_116:                              # %for_loop623
+                                        #   Parent Loop BB2_86 Depth=1
+                                        #     Parent Loop BB2_89 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	movl	%eax, %edx
+	cltq
+	movq	%rax, %rdx
 	shlq	$7, %rdx
-	vmovdqa	57984(%rsp,%rdx), %ymm0
-	vmovdqa	58016(%rsp,%rdx), %ymm1
-	vmovdqa	%ymm8, %ymm2
-	vmovdqa	58048(%rsp,%rdx), %ymm8
-	vmovdqa	58080(%rsp,%rdx), %ymm9
-	vpaddq	640(%rsp,%rcx), %ymm0, %ymm0
-	vpaddq	672(%rsp,%rcx), %ymm1, %ymm1
-	vpaddq	704(%rsp,%rcx), %ymm8, %ymm8
-	vpaddq	736(%rsp,%rcx), %ymm9, %ymm9
-	vpaddq	%ymm0, %ymm0, %ymm10
-	vblendvpd	%ymm4, %ymm10, %ymm0, %ymm0
-	vpaddq	%ymm1, %ymm1, %ymm10
-	vblendvpd	%ymm5, %ymm10, %ymm1, %ymm1
-	vpaddq	%ymm8, %ymm8, %ymm10
-	vblendvpd	%ymm6, %ymm10, %ymm8, %ymm8
-	vpaddq	%ymm9, %ymm9, %ymm10
-	vblendvpd	%ymm7, %ymm10, %ymm9, %ymm9
-	vpaddq	%ymm8, %ymm14, %ymm3
-	vpblendd	$170, %ymm11, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm11[1],ymm3[2],ymm11[3],ymm3[4],ymm11[5],ymm3[6],ymm11[7]
-	vmovdqa	%ymm8, 704(%rsp,%rcx)
-	vpaddq	%ymm2, %ymm9, %ymm2
-	vpblendd	$170, %ymm11, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm11[1],ymm2[2],ymm11[3],ymm2[4],ymm11[5],ymm2[6],ymm11[7]
-	vmovdqa	%ymm8, 736(%rsp,%rcx)
-	vpaddq	%ymm0, %ymm12, %ymm0
-	vpblendd	$170, %ymm11, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm11[1],ymm0[2],ymm11[3],ymm0[4],ymm11[5],ymm0[6],ymm11[7]
-	vmovdqa	%ymm8, 640(%rsp,%rcx)
+	leal	(%r10,%rax), %esi
+	movslq	%esi, %rsi
+	shlq	$7, %rsi
+	vmovdqa	58112(%rsp,%rsi), %ymm0
+	vmovdqa	58144(%rsp,%rsi), %ymm1
+	vmovdqa	58176(%rsp,%rsi), %ymm2
+	vmovdqa	58208(%rsp,%rsi), %ymm3
+	vpaddq	768(%rsp,%rdx), %ymm0, %ymm0
+	vpaddq	800(%rsp,%rdx), %ymm1, %ymm1
+	vpaddq	832(%rsp,%rdx), %ymm2, %ymm2
+	vpaddq	864(%rsp,%rdx), %ymm3, %ymm3
+	vpaddq	%ymm0, %ymm0, %ymm8
+	vblendvpd	%ymm4, %ymm8, %ymm0, %ymm0
+	vpaddq	%ymm1, %ymm1, %ymm8
+	vblendvpd	%ymm5, %ymm8, %ymm1, %ymm1
+	vpaddq	%ymm2, %ymm2, %ymm8
+	vblendvpd	%ymm6, %ymm8, %ymm2, %ymm2
+	vpaddq	%ymm3, %ymm3, %ymm8
+	vblendvpd	%ymm7, %ymm8, %ymm3, %ymm3
+	vpaddq	%ymm3, %ymm14, %ymm3
+	vpblendd	$170, %ymm9, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm9[1],ymm3[2],ymm9[3],ymm3[4],ymm9[5],ymm3[6],ymm9[7]
+	vmovdqa	%ymm8, 96(%rcx)
+	vpaddq	%ymm2, %ymm15, %ymm2
+	vpblendd	$170, %ymm9, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm9[1],ymm2[2],ymm9[3],ymm2[4],ymm9[5],ymm2[6],ymm9[7]
+	vmovdqa	%ymm8, 64(%rcx)
 	vpaddq	%ymm1, %ymm13, %ymm1
-	vpblendd	$170, %ymm11, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm11[1],ymm1[2],ymm11[3],ymm1[4],ymm11[5],ymm1[6],ymm11[7]
-	vmovdqa	%ymm8, 672(%rsp,%rcx)
-	vpsrlq	$32, %ymm2, %ymm8
+	vpblendd	$170, %ymm9, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm9[1],ymm1[2],ymm9[3],ymm1[4],ymm9[5],ymm1[6],ymm9[7]
+	vmovdqa	%ymm8, 32(%rcx)
+	vpaddq	%ymm0, %ymm12, %ymm0
+	vpblendd	$170, %ymm9, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm9[1],ymm0[2],ymm9[3],ymm0[4],ymm9[5],ymm0[6],ymm9[7]
+	vmovdqa	%ymm8, (%rcx)
 	vpsrlq	$32, %ymm3, %ymm14
+	vpsrlq	$32, %ymm2, %ymm15
 	vpsrlq	$32, %ymm1, %ymm13
 	vpsrlq	$32, %ymm0, %ymm12
+	addl	$1, %eax
 	subq	$-128, %rcx
-	incl	%eax
-	cmpq	%rcx, %r14
-	jne	.LBB2_98
-# %bb.99:                               # %for_test648.preheader
-                                        #   in Loop: Header=BB2_105 Depth=2
-	vpcmpeqd	%ymm5, %ymm5, %ymm5
-	vpcmpeqd	%ymm7, %ymm7, %ymm7
-	vmovdqa	384(%rsp), %ymm2        # 32-byte Reload
-	vmovdqa	352(%rsp), %ymm3        # 32-byte Reload
-	vmovdqa	192(%rsp), %ymm9        # 32-byte Reload
+	cmpl	%eax, %r10d
+	jne	.LBB2_116
+	jmp	.LBB2_112
 	.p2align	4, 0x90
-.LBB2_100:                              # %for_test648
-                                        #   Parent Loop BB2_77 Depth=1
-                                        #     Parent Loop BB2_105 Depth=2
-                                        # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_102 Depth 4
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpcmpeqq	%ymm4, %ymm13, %ymm0
+.LBB2_90:                               #   in Loop: Header=BB2_89 Depth=2
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm13, %xmm13, %xmm13
+	vxorps	%xmm15, %xmm15, %xmm15
+	vxorps	%xmm14, %xmm14, %xmm14
+	movl	%ebx, %r8d
+	jmp	.LBB2_111
+	.p2align	4, 0x90
+.LBB2_110:                              #   in Loop: Header=BB2_89 Depth=2
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm15, %xmm15, %xmm15
+	vxorps	%xmm14, %xmm14, %xmm14
+.LBB2_111:                              # %for_test663.preheader
+                                        #   in Loop: Header=BB2_89 Depth=2
+	vmovdqa	384(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	352(%rsp), %ymm11       # 32-byte Reload
+	vpxor	%xmm9, %xmm9, %xmm9
+.LBB2_112:                              # %for_test663.preheader
+                                        #   in Loop: Header=BB2_89 Depth=2
+	vmovdqa	%ymm14, 512(%rsp)       # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm14, %ymm0
+	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm4, %ymm12, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm5, %ymm0, %ymm5
-	vpcmpeqq	%ymm4, %ymm8, %ymm0
+	vmovdqa	%ymm15, 416(%rsp)       # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm15, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm4
+	vpcmpeqq	%ymm9, %ymm13, %ymm0
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm4, %ymm14, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm7, %ymm0, %ymm7
-	vpand	%ymm5, %ymm15, %ymm0
+	vpcmpeqq	%ymm9, %ymm12, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm2
+	vmovdqa	256(%rsp), %ymm15       # 32-byte Reload
+	vpand	%ymm15, %ymm2, %ymm0
 	vmovmskps	%ymm0, %eax
-	vpand	%ymm7, %ymm9, %ymm0
+	vmovdqa	288(%rsp), %ymm14       # 32-byte Reload
+	vpand	%ymm14, %ymm4, %ymm0
 	vmovmskps	%ymm0, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_104
-# %bb.101:                              # %for_loop667.lr.ph
-                                        #   in Loop: Header=BB2_100 Depth=3
-	vmovdqa	%ymm14, 512(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm8, 544(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm13, 576(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm12, 608(%rsp)       # 32-byte Spill
+	je	.LBB2_120
+	.p2align	4, 0x90
+.LBB2_113:                              # %for_test681.preheader
+                                        #   Parent Loop BB2_86 Depth=1
+                                        #     Parent Loop BB2_89 Depth=2
+                                        # =>    This Loop Header: Depth=3
+                                        #         Child Loop BB2_118 Depth 4
 	vmovdqa	.LCPI2_3(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm5, %ymm0, %ymm1
-	vmovdqa	%ymm1, 64(%rsp)         # 32-byte Spill
+	vpermd	%ymm2, %ymm0, %ymm3
 	vmovdqa	.LCPI2_4(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
-	vmovdqa	%ymm5, 480(%rsp)        # 32-byte Spill
-	vpermd	%ymm5, %ymm1, %ymm4
-	vmovdqa	%ymm4, 32(%rsp)         # 32-byte Spill
-	vpermd	%ymm7, %ymm0, %ymm0
-	vmovdqa	%ymm0, 96(%rsp)         # 32-byte Spill
-	vmovdqa	%ymm7, 448(%rsp)        # 32-byte Spill
-	vpermd	%ymm7, %ymm1, %ymm9
+	vpermd	%ymm2, %ymm1, %ymm5
+	vpermd	%ymm4, %ymm0, %ymm0
+	vpermd	%ymm4, %ymm1, %ymm1
+	testl	%r10d, %r10d
+	vmovdqa	%ymm12, 704(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm13, 672(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm4, 640(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm2, 608(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm5, 224(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm3, 192(%rsp)        # 32-byte Spill
+	je	.LBB2_114
+# %bb.117:                              # %for_loop683.preheader
+                                        #   in Loop: Header=BB2_113 Depth=3
 	vpxor	%xmm14, %xmm14, %xmm14
-	movl	$0, %eax
+	xorl	%eax, %eax
+	xorl	%ecx, %ecx
 	vpxor	%xmm15, %xmm15, %xmm15
-	vmovdqa	%ymm2, %ymm6
-	vmovdqa	%ymm3, %ymm7
-	vpxor	%xmm11, %xmm11, %xmm11
-	vpxor	%xmm10, %xmm10, %xmm10
+	vmovdqa	%ymm10, %ymm7
+	vmovdqa	%ymm11, %ymm8
 	vpxor	%xmm12, %xmm12, %xmm12
 	vpxor	%xmm13, %xmm13, %xmm13
-	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm9, %xmm9, %xmm9
 	.p2align	4, 0x90
-.LBB2_102:                              # %for_loop667
-                                        #   Parent Loop BB2_77 Depth=1
-                                        #     Parent Loop BB2_105 Depth=2
-                                        #       Parent Loop BB2_100 Depth=3
+.LBB2_118:                              # %for_loop683
+                                        #   Parent Loop BB2_86 Depth=1
+                                        #     Parent Loop BB2_89 Depth=2
+                                        #       Parent Loop BB2_113 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vmovdqa	640(%rsp,%rax,2), %ymm2
-	vmovdqa	17024(%rsp,%rax), %ymm0
-	vmovdqa	17056(%rsp,%rax), %ymm1
-	vpsllvd	%ymm6, %ymm0, %ymm3
-	vpor	%ymm3, %ymm14, %ymm3
-	vpsllvd	%ymm6, %ymm1, %ymm14
-	vmovdqa	736(%rsp,%rax,2), %ymm4
+	vmovdqa	768(%rsp,%rax), %ymm2
+	vmovdqa	800(%rsp,%rax), %ymm3
+	movq	%rcx, %rdx
+	sarq	$26, %rdx
+	vmovdqa	17152(%rsp,%rdx), %ymm0
+	vmovdqa	17184(%rsp,%rdx), %ymm1
+	vpsllvd	%ymm7, %ymm0, %ymm4
+	vpor	%ymm14, %ymm4, %ymm4
+	vpsllvd	%ymm7, %ymm1, %ymm14
 	vpor	%ymm15, %ymm14, %ymm14
-	vextracti128	$1, %ymm14, %xmm5
+	vextracti128	$1, %ymm4, %xmm5
 	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpsubq	%ymm5, %ymm4, %ymm5
-	vpaddq	%ymm5, %ymm13, %ymm5
-	vmovdqa	704(%rsp,%rax,2), %ymm13
-	vpmovzxdq	%xmm14, %ymm14  # ymm14 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vpsubq	%ymm14, %ymm13, %ymm14
-	vpaddq	%ymm12, %ymm14, %ymm12
-	vpmovzxdq	%xmm3, %ymm14   # ymm14 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm14, %ymm2, %ymm14
-	vpaddq	%ymm11, %ymm14, %ymm11
-	vpblendd	$170, %ymm8, %ymm11, %ymm14 # ymm14 = ymm11[0],ymm8[1],ymm11[2],ymm8[3],ymm11[4],ymm8[5],ymm11[6],ymm8[7]
-	vmovapd	64(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm2, %ymm2
-	vmovdqa	672(%rsp,%rax,2), %ymm14
-	vextracti128	$1, %ymm3, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm3, %ymm14, %ymm3
-	vpaddq	%ymm3, %ymm10, %ymm3
-	vpblendd	$170, %ymm8, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
-	vmovapd	32(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm10, %ymm14, %ymm10
-	vpblendd	$170, %ymm8, %ymm12, %ymm14 # ymm14 = ymm12[0],ymm8[1],ymm12[2],ymm8[3],ymm12[4],ymm8[5],ymm12[6],ymm8[7]
-	vmovapd	96(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm13, %ymm13
-	vpblendd	$170, %ymm8, %ymm5, %ymm14 # ymm14 = ymm5[0],ymm8[1],ymm5[2],ymm8[3],ymm5[4],ymm8[5],ymm5[6],ymm8[7]
-	vblendvpd	%ymm9, %ymm14, %ymm4, %ymm4
-	vmovapd	%ymm13, 704(%rsp,%rax,2)
-	vmovapd	%ymm4, 736(%rsp,%rax,2)
-	vmovapd	%ymm2, 640(%rsp,%rax,2)
-	vpsrlvd	%ymm7, %ymm1, %ymm15
-	vpsrlvd	%ymm7, %ymm0, %ymm14
-	vmovapd	%ymm10, 672(%rsp,%rax,2)
-	vpsrad	$31, %ymm5, %ymm0
-	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm12, %ymm0
-	vpshufd	$245, %ymm12, %ymm1     # ymm1 = ymm12[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm3, %ymm0
-	vpshufd	$245, %ymm3, %ymm1      # ymm1 = ymm3[1,1,3,3,5,5,7,7]
+	vpsubq	%ymm5, %ymm3, %ymm5
+	vpaddq	%ymm13, %ymm5, %ymm5
+	vmovdqa	832(%rsp,%rax), %ymm13
+	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm12, %ymm4, %ymm4
+	vpblendd	$170, %ymm9, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm9[1],ymm4[2],ymm9[3],ymm4[4],ymm9[5],ymm4[6],ymm9[7]
+	vmovapd	192(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm12, %ymm2, %ymm2
+	vpblendd	$170, %ymm9, %ymm5, %ymm12 # ymm12 = ymm5[0],ymm9[1],ymm5[2],ymm9[3],ymm5[4],ymm9[5],ymm5[6],ymm9[7]
+	vmovapd	224(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm12, %ymm3, %ymm3
+	vpmovzxdq	%xmm14, %ymm12  # ymm12 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vpsubq	%ymm12, %ymm13, %ymm12
+	vpaddq	%ymm11, %ymm12, %ymm11
+	vpblendd	$170, %ymm9, %ymm11, %ymm12 # ymm12 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
+	vmovapd	128(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm12, %ymm13, %ymm12
+	vmovdqa	864(%rsp,%rax), %ymm13
+	vextracti128	$1, %ymm14, %xmm6
+	vpmovzxdq	%xmm6, %ymm6    # ymm6 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero
+	vpsubq	%ymm6, %ymm13, %ymm6
+	vpaddq	%ymm10, %ymm6, %ymm6
+	vpblendd	$170, %ymm9, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm9[1],ymm6[2],ymm9[3],ymm6[4],ymm9[5],ymm6[6],ymm9[7]
+	vmovapd	160(%rsp), %ymm14       # 32-byte Reload
+	vblendvpd	%ymm14, %ymm10, %ymm13, %ymm10
+	vmovapd	%ymm10, 864(%rsp,%rax)
+	vmovapd	%ymm12, 832(%rsp,%rax)
+	vpsrlvd	%ymm8, %ymm1, %ymm15
+	vpsrlvd	%ymm8, %ymm0, %ymm14
+	vmovapd	%ymm3, 800(%rsp,%rax)
+	vmovapd	%ymm2, 768(%rsp,%rax)
+	vpsrad	$31, %ymm6, %ymm0
+	vpshufd	$245, %ymm6, %ymm1      # ymm1 = ymm6[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm10 # ymm10 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
 	vpsrad	$31, %ymm11, %ymm0
 	vpshufd	$245, %ymm11, %ymm1     # ymm1 = ymm11[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	addq	$64, %rax
-	cmpq	%rax, %r13
-	jne	.LBB2_102
-# %bb.103:                              # %for_exit669
-                                        #   in Loop: Header=BB2_100 Depth=3
-	vmovdqa	544(%rsp), %ymm8        # 32-byte Reload
-	vpaddq	%ymm8, %ymm13, %ymm0
-	vmovdqa	512(%rsp), %ymm14       # 32-byte Reload
-	vpaddq	%ymm14, %ymm12, %ymm1
-	vmovdqa	576(%rsp), %ymm13       # 32-byte Reload
-	vpaddq	%ymm13, %ymm10, %ymm2
-	vmovdqa	608(%rsp), %ymm12       # 32-byte Reload
-	vpaddq	%ymm12, %ymm11, %ymm3
-	vmovapd	64(%rsp), %ymm4         # 32-byte Reload
-	vblendvpd	%ymm4, %ymm3, %ymm12, %ymm12
-	vmovapd	32(%rsp), %ymm3         # 32-byte Reload
-	vblendvpd	%ymm3, %ymm2, %ymm13, %ymm13
-	vmovapd	96(%rsp), %ymm2         # 32-byte Reload
-	vblendvpd	%ymm2, %ymm1, %ymm14, %ymm14
-	vblendvpd	%ymm9, %ymm0, %ymm8, %ymm8
-	vmovdqa	192(%rsp), %ymm9        # 32-byte Reload
-	vmovdqa	160(%rsp), %ymm15       # 32-byte Reload
-	vmovdqa	%ymm6, %ymm2
-	vmovdqa	%ymm7, %ymm3
-	vmovdqa	480(%rsp), %ymm5        # 32-byte Reload
-	vmovdqa	448(%rsp), %ymm7        # 32-byte Reload
-	jmp	.LBB2_100
-.LBB2_81:                               # %for_test720.preheader
-	testl	%r11d, %r11d
-	je	.LBB2_82
-# %bb.83:                               # %for_loop721.lr.ph
-	leal	-1(%r11), %r8d
-	movl	%r11d, %eax
+	vpsrad	$31, %ymm5, %ymm0
+	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpsrad	$31, %ymm4, %ymm0
+	vpshufd	$245, %ymm4, %ymm1      # ymm1 = ymm4[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	addq	%r14, %rcx
+	subq	$-128, %rax
+	cmpq	%rax, %r12
+	jne	.LBB2_118
+	jmp	.LBB2_119
+	.p2align	4, 0x90
+.LBB2_114:                              #   in Loop: Header=BB2_113 Depth=3
+	vmovdqa	%ymm10, %ymm7
+	vmovdqa	%ymm11, %ymm8
+	vpxor	%xmm12, %xmm12, %xmm12
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm9, %xmm9, %xmm9
+.LBB2_119:                              # %for_exit684
+                                        #   in Loop: Header=BB2_113 Depth=3
+	vmovdqa	704(%rsp), %ymm1        # 32-byte Reload
+	vpaddq	%ymm1, %ymm12, %ymm0
+	vmovdqa	%ymm1, %ymm12
+	vmovapd	192(%rsp), %ymm1        # 32-byte Reload
+	vblendvpd	%ymm1, %ymm0, %ymm12, %ymm12
+	vmovdqa	672(%rsp), %ymm1        # 32-byte Reload
+	vpaddq	%ymm1, %ymm13, %ymm0
+	vmovdqa	%ymm1, %ymm13
+	vmovapd	224(%rsp), %ymm1        # 32-byte Reload
+	vblendvpd	%ymm1, %ymm0, %ymm13, %ymm13
+	vmovdqa	512(%rsp), %ymm4        # 32-byte Reload
+	vpaddq	%ymm4, %ymm10, %ymm0
+	vmovdqa	416(%rsp), %ymm3        # 32-byte Reload
+	vpaddq	%ymm3, %ymm11, %ymm1
+	vmovapd	128(%rsp), %ymm2        # 32-byte Reload
+	vblendvpd	%ymm2, %ymm1, %ymm3, %ymm3
+	vmovapd	160(%rsp), %ymm1        # 32-byte Reload
+	vblendvpd	%ymm1, %ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm9, %ymm13, %ymm0
+	vextracti128	$1, %ymm0, %xmm1
+	vpackssdw	%xmm1, %xmm0, %xmm0
+	vpcmpeqq	%ymm9, %ymm12, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm0
+	vmovapd	%ymm4, 512(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm4, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vmovapd	%ymm3, 416(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm3, %ymm2
+	vextracti128	$1, %ymm2, %xmm3
+	vpackssdw	%xmm3, %xmm2, %xmm2
+	vinserti128	$1, %xmm1, %ymm2, %ymm1
+	vmovdqa	640(%rsp), %ymm4        # 32-byte Reload
+	vpandn	%ymm4, %ymm1, %ymm4
+	vmovdqa	608(%rsp), %ymm2        # 32-byte Reload
+	vpandn	%ymm2, %ymm0, %ymm2
+	vmovdqa	256(%rsp), %ymm15       # 32-byte Reload
+	vpand	%ymm15, %ymm2, %ymm0
+	vmovmskps	%ymm0, %eax
+	vmovdqa	288(%rsp), %ymm14       # 32-byte Reload
+	vpand	%ymm14, %ymm4, %ymm0
+	vmovmskps	%ymm0, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	vmovdqa	%ymm7, %ymm10
+	vmovdqa	%ymm8, %ymm11
+	jne	.LBB2_113
+.LBB2_120:                              # %for_exit666
+                                        #   in Loop: Header=BB2_89 Depth=2
+	shrl	%r8d
+	jne	.LBB2_89
+# %bb.91:                               # %for_test543.loopexit
+                                        #   in Loop: Header=BB2_86 Depth=1
+	movl	$-2147483648, %r8d      # imm = 0x80000000
+	movq	344(%rsp), %rcx         # 8-byte Reload
+	testq	%rcx, %rcx
+	jg	.LBB2_86
+.LBB2_92:                               # %for_test735.preheader
+	testl	%r10d, %r10d
+	je	.LBB2_93
+# %bb.94:                               # %for_loop737.lr.ph
+	leal	-1(%r10), %ecx
+	movl	%r10d, %eax
 	andl	$3, %eax
-	cmpl	$3, %r8d
-	jae	.LBB2_116
-# %bb.84:
+	cmpl	$3, %ecx
+	jae	.LBB2_132
+# %bb.95:
 	xorl	%ecx, %ecx
-	jmp	.LBB2_85
-.LBB2_54:                               # %for_loop189.lr.ph.new
-	movl	%r11d, %r9d
-	movl	%r11d, %esi
-	subl	%eax, %esi
+	jmp	.LBB2_96
+.LBB2_93:
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	movq	120(%rsp), %r15         # 8-byte Reload
+	jmp	.LBB2_139
+.LBB2_58:                               # %for_loop198.lr.ph.new
+	movl	%r10d, %edx
+	subl	%eax, %edx
+	movl	%r10d, %r8d
 	movl	$384, %edi              # imm = 0x180
 	xorl	%ecx, %ecx
 	vpxor	%xmm0, %xmm0, %xmm0
 	.p2align	4, 0x90
-.LBB2_55:                               # %for_loop189
+.LBB2_59:                               # %for_loop198
                                         # =>This Inner Loop Header: Depth=1
-	vmovaps	8448(%rsp,%rdi), %ymm1
-	vmovaps	8512(%rsp,%rdi), %ymm2
-	vmovaps	8544(%rsp,%rdi), %ymm3
-	vmovaps	%ymm1, 41216(%rsp,%rdi)
-	vmovaps	%ymm3, 41312(%rsp,%rdi)
-	vmovaps	%ymm2, 41280(%rsp,%rdi)
-	vmovaps	8480(%rsp,%rdi), %ymm1
-	vmovaps	%ymm1, 41248(%rsp,%rdi)
-	leaq	(%r9,%rcx), %rbx
-	movl	%ebx, %edx
-	shlq	$7, %rdx
-	vmovdqa	%ymm0, 41600(%rsp,%rdx)
-	vmovdqa	%ymm0, 41696(%rsp,%rdx)
-	vmovdqa	%ymm0, 41664(%rsp,%rdx)
-	vmovdqa	%ymm0, 41632(%rsp,%rdx)
 	vmovaps	8608(%rsp,%rdi), %ymm1
 	vmovaps	8640(%rsp,%rdi), %ymm2
 	vmovaps	8672(%rsp,%rdi), %ymm3
-	vmovaps	8576(%rsp,%rdi), %ymm4
-	vmovaps	%ymm4, 41344(%rsp,%rdi)
 	vmovaps	%ymm3, 41440(%rsp,%rdi)
 	vmovaps	%ymm2, 41408(%rsp,%rdi)
 	vmovaps	%ymm1, 41376(%rsp,%rdi)
-	leal	1(%rbx), %edx
-	shlq	$7, %rdx
-	vmovdqa	%ymm0, 41600(%rsp,%rdx)
-	vmovdqa	%ymm0, 41696(%rsp,%rdx)
-	vmovdqa	%ymm0, 41664(%rsp,%rdx)
-	vmovdqa	%ymm0, 41632(%rsp,%rdx)
-	vmovaps	8736(%rsp,%rdi), %ymm1
-	vmovaps	8768(%rsp,%rdi), %ymm2
-	vmovaps	8800(%rsp,%rdi), %ymm3
-	vmovaps	8704(%rsp,%rdi), %ymm4
-	vmovaps	%ymm4, 41472(%rsp,%rdi)
-	vmovaps	%ymm3, 41568(%rsp,%rdi)
-	vmovaps	%ymm2, 41536(%rsp,%rdi)
-	vmovaps	%ymm1, 41504(%rsp,%rdi)
-	leal	2(%rbx), %edx
-	shlq	$7, %rdx
-	vmovdqa	%ymm0, 41600(%rsp,%rdx)
-	vmovdqa	%ymm0, 41696(%rsp,%rdx)
-	vmovdqa	%ymm0, 41664(%rsp,%rdx)
-	vmovdqa	%ymm0, 41632(%rsp,%rdx)
-	vmovdqa	8832(%rsp,%rdi), %ymm1
-	vmovdqa	8864(%rsp,%rdi), %ymm2
-	vmovdqa	8896(%rsp,%rdi), %ymm3
-	vmovdqa	8928(%rsp,%rdi), %ymm4
-	vmovdqa	%ymm4, 41696(%rsp,%rdi)
-	vmovdqa	%ymm3, 41664(%rsp,%rdi)
-	vmovdqa	%ymm2, 41632(%rsp,%rdi)
-	vmovdqa	%ymm1, 41600(%rsp,%rdi)
+	vmovaps	8576(%rsp,%rdi), %ymm1
+	vmovaps	%ymm1, 41344(%rsp,%rdi)
+	leaq	(%r8,%rcx), %rbx
+	movl	%ebx, %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 41824(%rsp,%rsi)
+	vmovdqa	%ymm0, 41792(%rsp,%rsi)
+	vmovdqa	%ymm0, 41760(%rsp,%rsi)
+	vmovdqa	%ymm0, 41728(%rsp,%rsi)
+	vmovaps	8704(%rsp,%rdi), %ymm1
+	vmovaps	8736(%rsp,%rdi), %ymm2
+	vmovaps	8768(%rsp,%rdi), %ymm3
+	vmovaps	8800(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 41568(%rsp,%rdi)
+	vmovaps	%ymm3, 41536(%rsp,%rdi)
+	vmovaps	%ymm2, 41504(%rsp,%rdi)
+	vmovaps	%ymm1, 41472(%rsp,%rdi)
+	leal	1(%rbx), %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 41792(%rsp,%rsi)
+	vmovdqa	%ymm0, 41728(%rsp,%rsi)
+	vmovdqa	%ymm0, 41824(%rsp,%rsi)
+	vmovdqa	%ymm0, 41760(%rsp,%rsi)
+	vmovaps	8832(%rsp,%rdi), %ymm1
+	vmovaps	8864(%rsp,%rdi), %ymm2
+	vmovaps	8896(%rsp,%rdi), %ymm3
+	vmovaps	8928(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 41696(%rsp,%rdi)
+	vmovaps	%ymm3, 41664(%rsp,%rdi)
+	vmovaps	%ymm2, 41632(%rsp,%rdi)
+	vmovaps	%ymm1, 41600(%rsp,%rdi)
+	leal	2(%rbx), %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 41824(%rsp,%rsi)
+	vmovdqa	%ymm0, 41792(%rsp,%rsi)
+	vmovdqa	%ymm0, 41760(%rsp,%rsi)
+	vmovdqa	%ymm0, 41728(%rsp,%rsi)
+	vmovdqa	8960(%rsp,%rdi), %ymm1
+	vmovdqa	8992(%rsp,%rdi), %ymm2
+	vmovdqa	9024(%rsp,%rdi), %ymm3
+	vmovdqa	9056(%rsp,%rdi), %ymm4
+	vmovdqa	%ymm4, 41824(%rsp,%rdi)
+	vmovdqa	%ymm3, 41792(%rsp,%rdi)
+	vmovdqa	%ymm2, 41760(%rsp,%rdi)
+	vmovdqa	%ymm1, 41728(%rsp,%rdi)
 	addl	$3, %ebx
 	shlq	$7, %rbx
-	vmovdqa	%ymm0, 41696(%rsp,%rbx)
-	vmovdqa	%ymm0, 41664(%rsp,%rbx)
-	vmovdqa	%ymm0, 41632(%rsp,%rbx)
-	vmovdqa	%ymm0, 41600(%rsp,%rbx)
+	vmovdqa	%ymm0, 41824(%rsp,%rbx)
+	vmovdqa	%ymm0, 41792(%rsp,%rbx)
+	vmovdqa	%ymm0, 41760(%rsp,%rbx)
+	vmovdqa	%ymm0, 41728(%rsp,%rbx)
 	addq	$4, %rcx
 	addq	$512, %rdi              # imm = 0x200
-	cmpl	%ecx, %esi
-	jne	.LBB2_55
-.LBB2_23:                               # %for_test188.for_test206.preheader_crit_edge.unr-lcssa
+	cmpl	%ecx, %edx
+	jne	.LBB2_59
+.LBB2_23:                               # %for_test196.for_test214.preheader_crit_edge.unr-lcssa
 	testl	%eax, %eax
-	vmovdqa	320(%rsp), %ymm14       # 32-byte Reload
-	vmovdqa	288(%rsp), %ymm15       # 32-byte Reload
+	movq	120(%rsp), %r15         # 8-byte Reload
 	je	.LBB2_26
-# %bb.24:                               # %for_loop189.epil.preheader
-	leal	(%r11,%rcx), %edx
+# %bb.24:                               # %for_loop198.epil.preheader
+	leal	(%r10,%rcx), %edx
 	shlq	$7, %rcx
+	negl	%eax
 	vpxor	%xmm0, %xmm0, %xmm0
 	.p2align	4, 0x90
-.LBB2_25:                               # %for_loop189.epil
+.LBB2_25:                               # %for_loop198.epil
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqa	8832(%rsp,%rcx), %ymm1
-	vmovdqa	8864(%rsp,%rcx), %ymm2
-	vmovdqa	8896(%rsp,%rcx), %ymm3
-	vmovdqa	8928(%rsp,%rcx), %ymm4
-	vmovdqa	%ymm3, 41664(%rsp,%rcx)
-	vmovdqa	%ymm4, 41696(%rsp,%rcx)
-	vmovdqa	%ymm1, 41600(%rsp,%rcx)
-	vmovdqa	%ymm2, 41632(%rsp,%rcx)
+	vmovdqa	8960(%rsp,%rcx), %ymm1
+	vmovdqa	8992(%rsp,%rcx), %ymm2
+	vmovdqa	9024(%rsp,%rcx), %ymm3
+	vmovdqa	9056(%rsp,%rcx), %ymm4
+	vmovdqa	%ymm4, 41824(%rsp,%rcx)
+	vmovdqa	%ymm3, 41792(%rsp,%rcx)
+	vmovdqa	%ymm2, 41760(%rsp,%rcx)
+	vmovdqa	%ymm1, 41728(%rsp,%rcx)
 	movl	%edx, %esi
 	shlq	$7, %rsi
-	vmovdqa	%ymm0, 41664(%rsp,%rsi)
-	vmovdqa	%ymm0, 41696(%rsp,%rsi)
-	vmovdqa	%ymm0, 41600(%rsp,%rsi)
-	vmovdqa	%ymm0, 41632(%rsp,%rsi)
-	incl	%edx
+	vmovdqa	%ymm0, 41824(%rsp,%rsi)
+	vmovdqa	%ymm0, 41792(%rsp,%rsi)
+	vmovdqa	%ymm0, 41760(%rsp,%rsi)
+	vmovdqa	%ymm0, 41728(%rsp,%rsi)
+	addl	$1, %edx
 	subq	$-128, %rcx
-	decl	%eax
+	addl	$1, %eax
 	jne	.LBB2_25
-.LBB2_26:                               # %for_test206.preheader
-	testl	%r11d, %r11d
-	je	.LBB2_20
-# %bb.27:                               # %for_loop207.lr.ph.split.us
-	movl	%r11d, %r10d
-	leaq	21184(%rsp), %r9
-	movl	%r11d, %esi
-	andl	$-2, %esi
-	movl	$1, %edi
-	xorl	%ebx, %ebx
-	vmovdqa	.LCPI2_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
-	vpxor	%xmm1, %xmm1, %xmm1
-	jmp	.LBB2_28
-	.p2align	4, 0x90
-.LBB2_29:                               #   in Loop: Header=BB2_28 Depth=1
-	vpxor	%xmm7, %xmm7, %xmm7
-	vxorps	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpxor	%xmm8, %xmm8, %xmm8
-	xorl	%edx, %edx
-.LBB2_49:                               # %for_loop223.us.epil.preheader
-                                        #   in Loop: Header=BB2_28 Depth=1
-	movq	%rdx, %rax
-	shlq	$6, %rax
-	vpmovzxdq	21152(%rsp,%rax), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21168(%rsp,%rax), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21120(%rsp,%rax), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	21136(%rsp,%rax), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm4, %ymm13, %ymm4
-	vpmuludq	%ymm5, %ymm12, %ymm5
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	addl	%ebx, %edx
-	shlq	$7, %rdx
-	vpaddq	41632(%rsp,%rdx), %ymm9, %ymm9
-	vpaddq	41600(%rsp,%rdx), %ymm7, %ymm7
-	vpaddq	%ymm4, %ymm9, %ymm4
-	vpaddq	%ymm5, %ymm7, %ymm5
-	vpaddq	41696(%rsp,%rdx), %ymm8, %ymm7
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	41664(%rsp,%rdx), %ymm6, %ymm6
-	vpaddq	%ymm3, %ymm6, %ymm3
-	vpblendd	$170, %ymm1, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vmovdqa	%ymm9, 41664(%rsp,%rdx)
-	vmovdqa	%ymm8, 41696(%rsp,%rdx)
-	vmovdqa	%ymm7, 41600(%rsp,%rdx)
-	vmovdqa	%ymm6, 41632(%rsp,%rdx)
-	vpsrlq	$32, %ymm2, %ymm8
-	vpsrlq	$32, %ymm3, %ymm6
-	vpsrlq	$32, %ymm4, %ymm9
-	vpsrlq	$32, %ymm5, %ymm7
-.LBB2_50:                               # %for_exit225.us
-                                        #   in Loop: Header=BB2_28 Depth=1
-	vmovdqa	%ymm9, 8864(%rsp,%r11)
-	vmovdqa	%ymm7, 8832(%rsp,%r11)
-	vmovdqa	%ymm6, 8896(%rsp,%r11)
-	vmovdqa	%ymm8, 8928(%rsp,%r11)
-	incq	%rbx
-	incq	%rdi
-	cmpq	%r10, %rbx
-	je	.LBB2_51
-.LBB2_28:                               # %for_loop223.lr.ph.us
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_47 Depth 2
-	movq	%rbx, %r11
-	shlq	$7, %r11
-	vpermd	41664(%rsp,%r11), %ymm0, %ymm2
-	vpermd	41696(%rsp,%r11), %ymm0, %ymm3
-	vpermd	41600(%rsp,%r11), %ymm0, %ymm4
-	vinserti128	$1, %xmm3, %ymm2, %ymm2
-	vpermd	41632(%rsp,%r11), %ymm0, %ymm3
-	vinserti128	$1, %xmm3, %ymm4, %ymm3
-	vpmulld	%ymm3, %ymm14, %ymm5
-	vpmulld	%ymm2, %ymm15, %ymm3
-	vextracti128	$1, %ymm3, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vextracti128	$1, %ymm5, %xmm4
-	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	cmpl	$1, 24(%rsp)            # 4-byte Folded Reload
-	je	.LBB2_29
-# %bb.46:                               # %for_loop223.lr.ph.us.new
-                                        #   in Loop: Header=BB2_28 Depth=1
-	vpxor	%xmm7, %xmm7, %xmm7
-	movq	%r9, %rcx
-	xorl	%edx, %edx
-	vxorps	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpxor	%xmm8, %xmm8, %xmm8
-	.p2align	4, 0x90
-.LBB2_47:                               # %for_loop223.us
-                                        #   Parent Loop BB2_28 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	vpmovzxdq	-32(%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm4, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rbx,%rdx), %eax
-	shlq	$7, %rax
-	vpaddq	41696(%rsp,%rax), %ymm8, %ymm8
-	vpaddq	%ymm13, %ymm8, %ymm8
-	vpaddq	41600(%rsp,%rax), %ymm7, %ymm7
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	41632(%rsp,%rax), %ymm9, %ymm9
-	vpaddq	41664(%rsp,%rax), %ymm6, %ymm6
-	vpaddq	%ymm11, %ymm9, %ymm9
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 41664(%rsp,%rax)
-	vmovdqa	%ymm12, 41632(%rsp,%rax)
-	vmovdqa	%ymm11, 41600(%rsp,%rax)
-	vmovdqa	%ymm10, 41696(%rsp,%rax)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm9, %ymm9
-	vpmovzxdq	32(%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rcx), %ymm12  # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	16(%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm4, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rdi,%rdx), %eax
-	shlq	$7, %rax
-	vpaddq	41632(%rsp,%rax), %ymm9, %ymm9
-	vpaddq	41600(%rsp,%rax), %ymm7, %ymm7
-	vpaddq	%ymm13, %ymm9, %ymm9
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	41696(%rsp,%rax), %ymm8, %ymm8
-	vpaddq	%ymm11, %ymm8, %ymm8
-	vpaddq	41664(%rsp,%rax), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpblendd	$170, %ymm1, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 41664(%rsp,%rax)
-	vmovdqa	%ymm12, 41696(%rsp,%rax)
-	vmovdqa	%ymm11, 41600(%rsp,%rax)
-	vmovdqa	%ymm10, 41632(%rsp,%rax)
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm7, %ymm7
-	addq	$2, %rdx
-	subq	$-128, %rcx
-	cmpl	%edx, %esi
-	jne	.LBB2_47
-# %bb.48:                               # %for_test222.for_exit225_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_28 Depth=1
-	testb	$1, 24(%rsp)            # 1-byte Folded Reload
-	jne	.LBB2_49
-	jmp	.LBB2_50
-.LBB2_51:                               # %for_test255.preheader
-	movq	24(%rsp), %r11          # 8-byte Reload
-	testl	%r11d, %r11d
-	je	.LBB2_20
-# %bb.52:                               # %for_loop256.lr.ph
-	movl	%r11d, %ecx
-	andl	$3, %ecx
-	cmpl	$3, %r8d
-	jae	.LBB2_56
-# %bb.53:
-	vpxor	%xmm2, %xmm2, %xmm2
-	xorl	%eax, %eax
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm1, %xmm1, %xmm1
-	vpxor	%xmm3, %xmm3, %xmm3
-	jmp	.LBB2_58
-.LBB2_20:
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	movq	8(%rsp), %rbx           # 8-byte Reload
-	jmp	.LBB2_62
-.LBB2_116:                              # %for_loop721.lr.ph.new
-	movl	%r11d, %edx
-	subl	%eax, %edx
-	movl	$384, %esi              # imm = 0x180
-	xorl	%ecx, %ecx
-	vxorps	%xmm0, %xmm0, %xmm0
-	.p2align	4, 0x90
-.LBB2_117:                              # %for_loop721
-                                        # =>This Inner Loop Header: Depth=1
-	vmovaps	256(%rsp,%rsi), %ymm1
-	vmovaps	320(%rsp,%rsi), %ymm2
-	vmovaps	352(%rsp,%rsi), %ymm3
-	vmovaps	%ymm1, 24832(%rsp,%rsi)
-	vmovaps	%ymm3, 24928(%rsp,%rsi)
-	vmovaps	%ymm2, 24896(%rsp,%rsi)
-	vmovaps	288(%rsp,%rsi), %ymm1
-	vmovaps	%ymm1, 24864(%rsp,%rsi)
-	leaq	(%r15,%rcx), %rdi
-	movl	%edi, %ebx
-	shlq	$7, %rbx
-	vmovaps	%ymm0, 25216(%rsp,%rbx)
-	vmovaps	%ymm0, 25312(%rsp,%rbx)
-	vmovaps	%ymm0, 25280(%rsp,%rbx)
-	vmovaps	%ymm0, 25248(%rsp,%rbx)
-	vmovaps	416(%rsp,%rsi), %ymm1
-	vmovaps	448(%rsp,%rsi), %ymm2
-	vmovaps	480(%rsp,%rsi), %ymm3
-	vmovaps	384(%rsp,%rsi), %ymm4
-	vmovaps	%ymm4, 24960(%rsp,%rsi)
-	vmovaps	%ymm3, 25056(%rsp,%rsi)
-	vmovaps	%ymm2, 25024(%rsp,%rsi)
-	vmovaps	%ymm1, 24992(%rsp,%rsi)
-	leal	1(%rdi), %ebx
-	shlq	$7, %rbx
-	vmovaps	%ymm0, 25216(%rsp,%rbx)
-	vmovaps	%ymm0, 25312(%rsp,%rbx)
-	vmovaps	%ymm0, 25280(%rsp,%rbx)
-	vmovaps	%ymm0, 25248(%rsp,%rbx)
-	vmovaps	544(%rsp,%rsi), %ymm1
-	vmovaps	576(%rsp,%rsi), %ymm2
-	vmovaps	608(%rsp,%rsi), %ymm3
-	vmovaps	512(%rsp,%rsi), %ymm4
-	vmovaps	%ymm4, 25088(%rsp,%rsi)
-	vmovaps	%ymm3, 25184(%rsp,%rsi)
-	vmovaps	%ymm2, 25152(%rsp,%rsi)
-	vmovaps	%ymm1, 25120(%rsp,%rsi)
-	leal	2(%rdi), %ebx
-	shlq	$7, %rbx
-	vmovaps	%ymm0, 25216(%rsp,%rbx)
-	vmovaps	%ymm0, 25312(%rsp,%rbx)
-	vmovaps	%ymm0, 25280(%rsp,%rbx)
-	vmovaps	%ymm0, 25248(%rsp,%rbx)
-	vmovdqa	640(%rsp,%rsi), %ymm1
-	vmovdqa	672(%rsp,%rsi), %ymm2
-	vmovdqa	704(%rsp,%rsi), %ymm3
-	vmovdqa	736(%rsp,%rsi), %ymm4
-	vmovdqa	%ymm4, 25312(%rsp,%rsi)
-	vmovdqa	%ymm3, 25280(%rsp,%rsi)
-	vmovdqa	%ymm2, 25248(%rsp,%rsi)
-	vmovdqa	%ymm1, 25216(%rsp,%rsi)
-	addl	$3, %edi
-	shlq	$7, %rdi
-	vmovaps	%ymm0, 25312(%rsp,%rdi)
-	vmovaps	%ymm0, 25280(%rsp,%rdi)
-	vmovaps	%ymm0, 25248(%rsp,%rdi)
-	vmovaps	%ymm0, 25216(%rsp,%rdi)
-	addq	$4, %rcx
-	addq	$512, %rsi              # imm = 0x200
-	cmpl	%ecx, %edx
-	jne	.LBB2_117
-.LBB2_85:                               # %for_test720.for_test738.preheader_crit_edge.unr-lcssa
-	testl	%eax, %eax
-	je	.LBB2_88
-# %bb.86:                               # %for_loop721.epil.preheader
-	leal	(%r11,%rcx), %edx
-	shlq	$7, %rcx
-	vxorps	%xmm0, %xmm0, %xmm0
-	.p2align	4, 0x90
-.LBB2_87:                               # %for_loop721.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqa	640(%rsp,%rcx), %ymm1
-	vmovdqa	672(%rsp,%rcx), %ymm2
-	vmovdqa	704(%rsp,%rcx), %ymm3
-	vmovdqa	736(%rsp,%rcx), %ymm4
-	vmovdqa	%ymm3, 25280(%rsp,%rcx)
-	vmovdqa	%ymm4, 25312(%rsp,%rcx)
-	vmovdqa	%ymm1, 25216(%rsp,%rcx)
-	vmovdqa	%ymm2, 25248(%rsp,%rcx)
-	movl	%edx, %esi
-	shlq	$7, %rsi
-	vmovaps	%ymm0, 25280(%rsp,%rsi)
-	vmovaps	%ymm0, 25312(%rsp,%rsi)
-	vmovaps	%ymm0, 25216(%rsp,%rsi)
-	vmovaps	%ymm0, 25248(%rsp,%rsi)
-	incl	%edx
-	subq	$-128, %rcx
-	decl	%eax
-	jne	.LBB2_87
-.LBB2_88:                               # %for_test738.preheader
-	testl	%r11d, %r11d
-	je	.LBB2_82
-# %bb.89:                               # %for_loop739.lr.ph.split.us
-	leaq	17088(%rsp), %r9
-	movl	%r11d, %edx
-	andl	$-2, %edx
+.LBB2_26:                               # %for_test214.preheader
+	testl	%r10d, %r10d
+	je	.LBB2_27
+# %bb.47:                               # %for_loop232.lr.ph.us.preheader
+	leaq	21312(%rsp), %r9
+	movl	%r10d, %r8d
+	andl	$1, %r8d
+	movl	%r10d, %r11d
+	subl	%r8d, %r11d
 	movl	$1, %esi
 	xorl	%edi, %edi
 	vmovdqa	.LCPI2_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
 	vpxor	%xmm1, %xmm1, %xmm1
-	vmovaps	%ymm9, %ymm14
-	jmp	.LBB2_90
+	movl	%r10d, %r10d
 	.p2align	4, 0x90
-.LBB2_91:                               #   in Loop: Header=BB2_90 Depth=1
-	vxorps	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpxor	%xmm8, %xmm8, %xmm8
-	xorl	%ecx, %ecx
-.LBB2_111:                              # %for_loop755.us.epil.preheader
-                                        #   in Loop: Header=BB2_90 Depth=1
-	movq	%rcx, %rax
-	shlq	$6, %rax
-	vpmovzxdq	17056(%rsp,%rax), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17072(%rsp,%rax), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17024(%rsp,%rax), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	17040(%rsp,%rax), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm4, %ymm13, %ymm4
-	vpmuludq	%ymm5, %ymm12, %ymm5
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	addl	%edi, %ecx
-	shlq	$7, %rcx
-	vpaddq	25248(%rsp,%rcx), %ymm9, %ymm9
-	vpaddq	25216(%rsp,%rcx), %ymm7, %ymm7
-	vpaddq	%ymm4, %ymm9, %ymm4
-	vpaddq	%ymm5, %ymm7, %ymm5
-	vpaddq	25312(%rsp,%rcx), %ymm8, %ymm7
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	25280(%rsp,%rcx), %ymm6, %ymm6
-	vpaddq	%ymm3, %ymm6, %ymm3
-	vpblendd	$170, %ymm1, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vmovdqa	%ymm9, 25280(%rsp,%rcx)
-	vmovdqa	%ymm8, 25312(%rsp,%rcx)
-	vmovdqa	%ymm7, 25216(%rsp,%rcx)
-	vmovdqa	%ymm6, 25248(%rsp,%rcx)
-	vpsrlq	$32, %ymm2, %ymm8
-	vpsrlq	$32, %ymm3, %ymm6
-	vpsrlq	$32, %ymm4, %ymm9
-	vpsrlq	$32, %ymm5, %ymm7
-.LBB2_112:                              # %for_exit757.us
-                                        #   in Loop: Header=BB2_90 Depth=1
-	vmovdqa	%ymm9, 672(%rsp,%r10)
-	vmovdqa	%ymm7, 640(%rsp,%r10)
-	vmovdqa	%ymm6, 704(%rsp,%r10)
-	vmovdqa	%ymm8, 736(%rsp,%r10)
-	incq	%rdi
-	incq	%rsi
-	cmpq	%r15, %rdi
-	je	.LBB2_113
-.LBB2_90:                               # %for_loop755.lr.ph.us
+.LBB2_48:                               # %for_loop232.lr.ph.us
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_109 Depth 2
-	movq	%rdi, %r10
-	shlq	$7, %r10
-	vpermd	25280(%rsp,%r10), %ymm0, %ymm2
-	vpermd	25312(%rsp,%r10), %ymm0, %ymm3
-	vpermd	25216(%rsp,%r10), %ymm0, %ymm4
+                                        #     Child Loop BB2_51 Depth 2
+	movq	%rdi, %rax
+	shlq	$7, %rax
+	vpermd	41792(%rsp,%rax), %ymm0, %ymm2
+	vpermd	41824(%rsp,%rax), %ymm0, %ymm3
+	vpermd	41728(%rsp,%rax), %ymm0, %ymm4
 	vinserti128	$1, %xmm3, %ymm2, %ymm2
-	vpermd	25248(%rsp,%r10), %ymm0, %ymm3
+	vpermd	41760(%rsp,%rax), %ymm0, %ymm3
 	vinserti128	$1, %xmm3, %ymm4, %ymm3
-	vpmulld	256(%rsp), %ymm3, %ymm5 # 32-byte Folded Reload
-	vpmulld	224(%rsp), %ymm2, %ymm3 # 32-byte Folded Reload
+	vpmulld	288(%rsp), %ymm3, %ymm5 # 32-byte Folded Reload
+	vpmulld	256(%rsp), %ymm2, %ymm3 # 32-byte Folded Reload
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vextracti128	$1, %ymm5, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
 	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpxor	%xmm7, %xmm7, %xmm7
-	cmpl	$1, %r11d
-	je	.LBB2_91
-# %bb.108:                              # %for_loop755.lr.ph.us.new
-                                        #   in Loop: Header=BB2_90 Depth=1
-	movq	%r9, %rax
-	xorl	%ecx, %ecx
-	vxorps	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
+	cmpl	$1, 104(%rsp)           # 4-byte Folded Reload
+	jne	.LBB2_50
+# %bb.49:                               #   in Loop: Header=BB2_48 Depth=1
 	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	xorl	%edx, %edx
+	jmp	.LBB2_53
 	.p2align	4, 0x90
-.LBB2_109:                              # %for_loop755.us
-                                        #   Parent Loop BB2_90 Depth=1
+.LBB2_50:                               # %for_loop232.lr.ph.us.new
+                                        #   in Loop: Header=BB2_48 Depth=1
+	vpxor	%xmm8, %xmm8, %xmm8
+	movq	%r9, %rbx
+	xorl	%edx, %edx
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	.p2align	4, 0x90
+.LBB2_51:                               # %for_loop232.us
+                                        #   Parent Loop BB2_48 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	vpmovzxdq	-32(%rax), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rax), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rax), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rax), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm4, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rdi,%rcx), %ebx
-	shlq	$7, %rbx
-	vpaddq	25312(%rsp,%rbx), %ymm8, %ymm8
+	vpmovzxdq	-16(%rbx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm13
+	vpmuludq	%ymm4, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	leal	(%rdi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	41728(%rsp,%rcx), %ymm8, %ymm8
 	vpaddq	%ymm13, %ymm8, %ymm8
-	vpaddq	25216(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	25248(%rsp,%rbx), %ymm9, %ymm9
-	vpaddq	25280(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm11, %ymm9, %ymm9
-	vpaddq	%ymm6, %ymm10, %ymm6
+	vpaddq	41760(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	%ymm12, %ymm9, %ymm9
+	vpaddq	41792(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	41824(%rsp,%rcx), %ymm6, %ymm6
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm6, %ymm6
 	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
 	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 25280(%rsp,%rbx)
-	vmovdqa	%ymm12, 25248(%rsp,%rbx)
-	vmovdqa	%ymm11, 25216(%rsp,%rbx)
-	vmovdqa	%ymm10, 25312(%rsp,%rbx)
-	vpsrlq	$32, %ymm6, %ymm6
+	vmovdqa	%ymm13, 41824(%rsp,%rcx)
+	vmovdqa	%ymm12, 41792(%rsp,%rcx)
+	vmovdqa	%ymm11, 41760(%rsp,%rcx)
+	vmovdqa	%ymm10, 41728(%rsp,%rcx)
 	vpsrlq	$32, %ymm8, %ymm8
 	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm9, %ymm9
-	vpmovzxdq	32(%rax), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rax), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rax), %ymm12  # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	16(%rax), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	(%rbx), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	16(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmuludq	%ymm4, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rsi,%rcx), %ebx
-	shlq	$7, %rbx
-	vpaddq	25248(%rsp,%rbx), %ymm9, %ymm9
-	vpaddq	25216(%rsp,%rbx), %ymm7, %ymm7
+	vpmuludq	%ymm2, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm5, %ymm10, %ymm10
+	leal	(%rsi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	41760(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	41824(%rsp,%rcx), %ymm6, %ymm6
 	vpaddq	%ymm13, %ymm9, %ymm9
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	25312(%rsp,%rbx), %ymm8, %ymm8
-	vpaddq	%ymm11, %ymm8, %ymm8
-	vpaddq	25280(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm10, %ymm6
+	vpaddq	%ymm12, %ymm6, %ymm6
+	vpaddq	41792(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	41728(%rsp,%rcx), %ymm8, %ymm8
+	vpaddq	%ymm10, %ymm8, %ymm8
 	vpblendd	$170, %ymm1, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 25280(%rsp,%rbx)
-	vmovdqa	%ymm12, 25312(%rsp,%rbx)
-	vmovdqa	%ymm11, 25216(%rsp,%rbx)
-	vmovdqa	%ymm10, 25248(%rsp,%rbx)
-	vpsrlq	$32, %ymm8, %ymm8
+	vpblendd	$170, %ymm1, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
+	vmovdqa	%ymm13, 41728(%rsp,%rcx)
+	vmovdqa	%ymm12, 41792(%rsp,%rcx)
+	vmovdqa	%ymm11, 41824(%rsp,%rcx)
+	vmovdqa	%ymm10, 41760(%rsp,%rcx)
 	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm9, %ymm9
 	vpsrlq	$32, %ymm7, %ymm7
-	addq	$2, %rcx
-	subq	$-128, %rax
-	cmpl	%ecx, %edx
-	jne	.LBB2_109
-# %bb.110:                              # %for_test754.for_exit757_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_90 Depth=1
-	testb	$1, %r11b
-	jne	.LBB2_111
-	jmp	.LBB2_112
-.LBB2_113:                              # %for_test787.preheader
-	vmovaps	%ymm14, %ymm9
-	testl	%r11d, %r11d
-	je	.LBB2_82
-# %bb.114:                              # %for_loop788.lr.ph
-	movl	%r11d, %ecx
-	andl	$3, %ecx
-	cmpl	$3, %r8d
-	jae	.LBB2_118
-# %bb.115:
-	vpxor	%xmm2, %xmm2, %xmm2
+	vpsrlq	$32, %ymm9, %ymm9
+	vpsrlq	$32, %ymm8, %ymm8
+	addq	$2, %rdx
+	subq	$-128, %rbx
+	cmpl	%edx, %r11d
+	jne	.LBB2_51
+# %bb.52:                               # %for_test230.for_exit233_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_48 Depth=1
+	testb	$1, 104(%rsp)           # 1-byte Folded Reload
+	je	.LBB2_54
+.LBB2_53:                               # %for_loop232.us.epil.preheader
+                                        #   in Loop: Header=BB2_48 Depth=1
+	movq	%rdx, %rcx
+	shlq	$6, %rcx
+	vpmovzxdq	21296(%rsp,%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21280(%rsp,%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21264(%rsp,%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	21248(%rsp,%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm5
+	vpmuludq	%ymm4, %ymm12, %ymm4
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	addl	%edi, %edx
+	shlq	$7, %rdx
+	vpaddq	41728(%rsp,%rdx), %ymm8, %ymm8
+	vpaddq	41760(%rsp,%rdx), %ymm9, %ymm9
+	vpaddq	%ymm5, %ymm8, %ymm5
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpaddq	41792(%rsp,%rdx), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm7, %ymm3
+	vpaddq	41824(%rsp,%rdx), %ymm6, %ymm6
+	vpaddq	%ymm2, %ymm6, %ymm2
+	vpblendd	$170, %ymm1, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm2, %ymm9 # ymm9 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
+	vmovdqa	%ymm9, 41824(%rsp,%rdx)
+	vmovdqa	%ymm8, 41792(%rsp,%rdx)
+	vmovdqa	%ymm7, 41760(%rsp,%rdx)
+	vmovdqa	%ymm6, 41728(%rsp,%rdx)
+	vpsrlq	$32, %ymm2, %ymm6
+	vpsrlq	$32, %ymm3, %ymm7
+	vpsrlq	$32, %ymm4, %ymm9
+	vpsrlq	$32, %ymm5, %ymm8
+.LBB2_54:                               # %for_exit233.us
+                                        #   in Loop: Header=BB2_48 Depth=1
+	vmovdqa	%ymm9, 8992(%rsp,%rax)
+	vmovdqa	%ymm8, 8960(%rsp,%rax)
+	vmovdqa	%ymm7, 9024(%rsp,%rax)
+	vmovdqa	%ymm6, 9056(%rsp,%rax)
+	addq	$1, %rdi
+	addq	$1, %rsi
+	cmpq	%r10, %rdi
+	jne	.LBB2_48
+# %bb.55:                               # %for_test263.preheader
+	movq	104(%rsp), %r10         # 8-byte Reload
+	testl	%r10d, %r10d
+	je	.LBB2_27
+# %bb.56:                               # %for_loop265.lr.ph
+	vpxor	%xmm0, %xmm0, %xmm0
+	cmpl	$1, %r10d
+	jne	.LBB2_60
+# %bb.57:
 	xorl	%eax, %eax
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm1, %xmm1, %xmm1
-	vpxor	%xmm3, %xmm3, %xmm3
-	jmp	.LBB2_120
-.LBB2_82:
 	vpxor	%xmm4, %xmm4, %xmm4
 	vpxor	%xmm5, %xmm5, %xmm5
-	movq	8(%rsp), %rbx           # 8-byte Reload
-	jmp	.LBB2_124
-.LBB2_56:                               # %for_loop256.lr.ph.new
-	leaq	9216(%rsp), %rdx
-	movl	%r11d, %esi
-	subl	%ecx, %esi
-	vpxor	%xmm0, %xmm0, %xmm0
-	xorl	%eax, %eax
-	movl	%r11d, %edi
-	vpxor	%xmm2, %xmm2, %xmm2
+	vpxor	%xmm1, %xmm1, %xmm1
+	vpxor	%xmm3, %xmm3, %xmm3
+	jmp	.LBB2_63
+.LBB2_27:
 	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	jmp	.LBB2_65
+.LBB2_132:                              # %for_loop737.lr.ph.new
+	movl	%r10d, %edx
+	subl	%eax, %edx
+	movl	%r10d, %r8d
+	movl	$384, %edi              # imm = 0x180
+	xorl	%ecx, %ecx
+	vxorps	%xmm0, %xmm0, %xmm0
+	.p2align	4, 0x90
+.LBB2_133:                              # %for_loop737
+                                        # =>This Inner Loop Header: Depth=1
+	vmovaps	416(%rsp,%rdi), %ymm1
+	vmovaps	448(%rsp,%rdi), %ymm2
+	vmovaps	480(%rsp,%rdi), %ymm3
+	vmovaps	%ymm3, 25056(%rsp,%rdi)
+	vmovaps	%ymm2, 25024(%rsp,%rdi)
+	vmovaps	%ymm1, 24992(%rsp,%rdi)
+	vmovaps	384(%rsp,%rdi), %ymm1
+	vmovaps	%ymm1, 24960(%rsp,%rdi)
+	leaq	(%r8,%rcx), %rbx
+	movl	%ebx, %esi
+	shlq	$7, %rsi
+	vmovaps	%ymm0, 25440(%rsp,%rsi)
+	vmovaps	%ymm0, 25408(%rsp,%rsi)
+	vmovaps	%ymm0, 25376(%rsp,%rsi)
+	vmovaps	%ymm0, 25344(%rsp,%rsi)
+	vmovaps	512(%rsp,%rdi), %ymm1
+	vmovaps	544(%rsp,%rdi), %ymm2
+	vmovaps	576(%rsp,%rdi), %ymm3
+	vmovaps	608(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 25184(%rsp,%rdi)
+	vmovaps	%ymm3, 25152(%rsp,%rdi)
+	vmovaps	%ymm2, 25120(%rsp,%rdi)
+	vmovaps	%ymm1, 25088(%rsp,%rdi)
+	leal	1(%rbx), %esi
+	shlq	$7, %rsi
+	vmovaps	%ymm0, 25408(%rsp,%rsi)
+	vmovaps	%ymm0, 25344(%rsp,%rsi)
+	vmovaps	%ymm0, 25440(%rsp,%rsi)
+	vmovaps	%ymm0, 25376(%rsp,%rsi)
+	vmovaps	640(%rsp,%rdi), %ymm1
+	vmovaps	672(%rsp,%rdi), %ymm2
+	vmovaps	704(%rsp,%rdi), %ymm3
+	vmovaps	736(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 25312(%rsp,%rdi)
+	vmovaps	%ymm3, 25280(%rsp,%rdi)
+	vmovaps	%ymm2, 25248(%rsp,%rdi)
+	vmovaps	%ymm1, 25216(%rsp,%rdi)
+	leal	2(%rbx), %esi
+	shlq	$7, %rsi
+	vmovaps	%ymm0, 25440(%rsp,%rsi)
+	vmovaps	%ymm0, 25408(%rsp,%rsi)
+	vmovaps	%ymm0, 25376(%rsp,%rsi)
+	vmovaps	%ymm0, 25344(%rsp,%rsi)
+	vmovdqa	768(%rsp,%rdi), %ymm1
+	vmovdqa	800(%rsp,%rdi), %ymm2
+	vmovdqa	832(%rsp,%rdi), %ymm3
+	vmovdqa	864(%rsp,%rdi), %ymm4
+	vmovdqa	%ymm4, 25440(%rsp,%rdi)
+	vmovdqa	%ymm3, 25408(%rsp,%rdi)
+	vmovdqa	%ymm2, 25376(%rsp,%rdi)
+	vmovdqa	%ymm1, 25344(%rsp,%rdi)
+	addl	$3, %ebx
+	shlq	$7, %rbx
+	vmovaps	%ymm0, 25440(%rsp,%rbx)
+	vmovaps	%ymm0, 25408(%rsp,%rbx)
+	vmovaps	%ymm0, 25376(%rsp,%rbx)
+	vmovaps	%ymm0, 25344(%rsp,%rbx)
+	addq	$4, %rcx
+	addq	$512, %rdi              # imm = 0x200
+	cmpl	%ecx, %edx
+	jne	.LBB2_133
+.LBB2_96:                               # %for_test735.for_test753.preheader_crit_edge.unr-lcssa
+	testl	%eax, %eax
+	movq	120(%rsp), %r15         # 8-byte Reload
+	je	.LBB2_99
+# %bb.97:                               # %for_loop737.epil.preheader
+	leal	(%r10,%rcx), %edx
+	shlq	$7, %rcx
+	negl	%eax
+	vxorps	%xmm0, %xmm0, %xmm0
+	.p2align	4, 0x90
+.LBB2_98:                               # %for_loop737.epil
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqa	768(%rsp,%rcx), %ymm1
+	vmovdqa	800(%rsp,%rcx), %ymm2
+	vmovdqa	832(%rsp,%rcx), %ymm3
+	vmovdqa	864(%rsp,%rcx), %ymm4
+	vmovdqa	%ymm4, 25440(%rsp,%rcx)
+	vmovdqa	%ymm3, 25408(%rsp,%rcx)
+	vmovdqa	%ymm2, 25376(%rsp,%rcx)
+	vmovdqa	%ymm1, 25344(%rsp,%rcx)
+	movl	%edx, %esi
+	shlq	$7, %rsi
+	vmovaps	%ymm0, 25440(%rsp,%rsi)
+	vmovaps	%ymm0, 25408(%rsp,%rsi)
+	vmovaps	%ymm0, 25376(%rsp,%rsi)
+	vmovaps	%ymm0, 25344(%rsp,%rsi)
+	addl	$1, %edx
+	subq	$-128, %rcx
+	addl	$1, %eax
+	jne	.LBB2_98
+.LBB2_99:                               # %for_test753.preheader
+	testl	%r10d, %r10d
+	je	.LBB2_100
+# %bb.121:                              # %for_loop771.lr.ph.us.preheader
+	leaq	17216(%rsp), %r9
+	movl	%r10d, %r8d
+	andl	$1, %r8d
+	movl	%r10d, %r11d
+	subl	%r8d, %r11d
+	movl	$1, %esi
+	xorl	%edi, %edi
+	vmovdqa	.LCPI2_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
+	vpxor	%xmm1, %xmm1, %xmm1
+	movl	%r10d, %r10d
+	.p2align	4, 0x90
+.LBB2_122:                              # %for_loop771.lr.ph.us
+                                        # =>This Loop Header: Depth=1
+                                        #     Child Loop BB2_125 Depth 2
+	movq	%rdi, %rax
+	shlq	$7, %rax
+	vpermd	25408(%rsp,%rax), %ymm0, %ymm2
+	vpermd	25440(%rsp,%rax), %ymm0, %ymm3
+	vpermd	25344(%rsp,%rax), %ymm0, %ymm4
+	vinserti128	$1, %xmm3, %ymm2, %ymm2
+	vpermd	25376(%rsp,%rax), %ymm0, %ymm3
+	vinserti128	$1, %xmm3, %ymm4, %ymm3
+	vpmulld	480(%rsp), %ymm3, %ymm5 # 32-byte Folded Reload
+	vpmulld	448(%rsp), %ymm2, %ymm3 # 32-byte Folded Reload
+	vextracti128	$1, %ymm3, %xmm2
+	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vextracti128	$1, %ymm5, %xmm4
+	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
+	cmpl	$1, 104(%rsp)           # 4-byte Folded Reload
+	jne	.LBB2_124
+# %bb.123:                              #   in Loop: Header=BB2_122 Depth=1
+	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	xorl	%edx, %edx
+	jmp	.LBB2_127
+	.p2align	4, 0x90
+.LBB2_124:                              # %for_loop771.lr.ph.us.new
+                                        #   in Loop: Header=BB2_122 Depth=1
+	vpxor	%xmm8, %xmm8, %xmm8
+	movq	%r9, %rbx
+	xorl	%edx, %edx
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	.p2align	4, 0x90
+.LBB2_125:                              # %for_loop771.us
+                                        #   Parent Loop BB2_122 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	vpmovzxdq	-16(%rbx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm13
+	vpmuludq	%ymm4, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	leal	(%rdi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	25344(%rsp,%rcx), %ymm8, %ymm8
+	vpaddq	%ymm13, %ymm8, %ymm8
+	vpaddq	25376(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	%ymm12, %ymm9, %ymm9
+	vpaddq	25408(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	25440(%rsp,%rcx), %ymm6, %ymm6
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm6, %ymm6
+	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
+	vmovdqa	%ymm13, 25440(%rsp,%rcx)
+	vmovdqa	%ymm12, 25408(%rsp,%rcx)
+	vmovdqa	%ymm11, 25376(%rsp,%rcx)
+	vmovdqa	%ymm10, 25344(%rsp,%rcx)
+	vpsrlq	$32, %ymm8, %ymm8
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm9, %ymm9
+	vpmovzxdq	(%rbx), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	16(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm4, %ymm13, %ymm13
+	vpmuludq	%ymm2, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm5, %ymm10, %ymm10
+	leal	(%rsi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	25376(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	25440(%rsp,%rcx), %ymm6, %ymm6
+	vpaddq	%ymm13, %ymm9, %ymm9
+	vpaddq	%ymm12, %ymm6, %ymm6
+	vpaddq	25408(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	25344(%rsp,%rcx), %ymm8, %ymm8
+	vpaddq	%ymm10, %ymm8, %ymm8
+	vpblendd	$170, %ymm1, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
+	vmovdqa	%ymm13, 25344(%rsp,%rcx)
+	vmovdqa	%ymm12, 25408(%rsp,%rcx)
+	vmovdqa	%ymm11, 25440(%rsp,%rcx)
+	vmovdqa	%ymm10, 25376(%rsp,%rcx)
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm9, %ymm9
+	vpsrlq	$32, %ymm8, %ymm8
+	addq	$2, %rdx
+	subq	$-128, %rbx
+	cmpl	%edx, %r11d
+	jne	.LBB2_125
+# %bb.126:                              # %for_test769.for_exit772_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_122 Depth=1
+	testb	$1, 104(%rsp)           # 1-byte Folded Reload
+	je	.LBB2_128
+.LBB2_127:                              # %for_loop771.us.epil.preheader
+                                        #   in Loop: Header=BB2_122 Depth=1
+	movq	%rdx, %rcx
+	shlq	$6, %rcx
+	vpmovzxdq	17200(%rsp,%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17184(%rsp,%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17168(%rsp,%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	17152(%rsp,%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm5
+	vpmuludq	%ymm4, %ymm12, %ymm4
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	addl	%edi, %edx
+	shlq	$7, %rdx
+	vpaddq	25344(%rsp,%rdx), %ymm8, %ymm8
+	vpaddq	25376(%rsp,%rdx), %ymm9, %ymm9
+	vpaddq	%ymm5, %ymm8, %ymm5
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpaddq	25408(%rsp,%rdx), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm7, %ymm3
+	vpaddq	25440(%rsp,%rdx), %ymm6, %ymm6
+	vpaddq	%ymm2, %ymm6, %ymm2
+	vpblendd	$170, %ymm1, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm2, %ymm9 # ymm9 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
+	vmovdqa	%ymm9, 25440(%rsp,%rdx)
+	vmovdqa	%ymm8, 25408(%rsp,%rdx)
+	vmovdqa	%ymm7, 25376(%rsp,%rdx)
+	vmovdqa	%ymm6, 25344(%rsp,%rdx)
+	vpsrlq	$32, %ymm2, %ymm6
+	vpsrlq	$32, %ymm3, %ymm7
+	vpsrlq	$32, %ymm4, %ymm9
+	vpsrlq	$32, %ymm5, %ymm8
+.LBB2_128:                              # %for_exit772.us
+                                        #   in Loop: Header=BB2_122 Depth=1
+	vmovdqa	%ymm9, 800(%rsp,%rax)
+	vmovdqa	%ymm8, 768(%rsp,%rax)
+	vmovdqa	%ymm7, 832(%rsp,%rax)
+	vmovdqa	%ymm6, 864(%rsp,%rax)
+	addq	$1, %rdi
+	addq	$1, %rsi
+	cmpq	%r10, %rdi
+	jne	.LBB2_122
+# %bb.129:                              # %for_test802.preheader
+	movq	104(%rsp), %r10         # 8-byte Reload
+	testl	%r10d, %r10d
+	je	.LBB2_100
+# %bb.130:                              # %for_loop804.lr.ph
+	vpxor	%xmm0, %xmm0, %xmm0
+	cmpl	$1, %r10d
+	jne	.LBB2_134
+# %bb.131:
+	xorl	%eax, %eax
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	vpxor	%xmm1, %xmm1, %xmm1
+	vpxor	%xmm3, %xmm3, %xmm3
+	jmp	.LBB2_137
+.LBB2_100:
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	jmp	.LBB2_139
+.LBB2_60:                               # %for_loop265.lr.ph.new
+	movabsq	$8589934592, %rdx       # imm = 0x200000000
+	leaq	9088(%rsp), %rsi
+	vpxor	%xmm2, %xmm2, %xmm2
+	xorl	%edi, %edi
+	movl	%r10d, %ebx
+	xorl	%eax, %eax
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
 	vpxor	%xmm1, %xmm1, %xmm1
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB2_57:                               # %for_loop256
+.LBB2_61:                               # %for_loop265
                                         # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rdx), %ymm3, %ymm3
-	vpaddq	-384(%rdx), %ymm2, %ymm2
-	vpaddq	-352(%rdx), %ymm4, %ymm4
-	vpaddq	-320(%rdx), %ymm1, %ymm1
-	movl	%edi, %ebx
-	shlq	$7, %rbx
-	vpaddq	41664(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	41632(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	41600(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	41696(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -320(%rdx)
-	vmovdqa	%ymm7, -352(%rdx)
-	vmovdqa	%ymm6, -384(%rdx)
-	vmovdqa	%ymm5, -288(%rdx)
+	movq	%rdi, %rcx
+	sarq	$25, %rcx
+	vpaddq	9024(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	8992(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	8960(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	9056(%rsp,%rcx), %ymm3, %ymm3
+	movl	%ebx, %ecx
+	shlq	$7, %rcx
+	vpaddq	41824(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	41728(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	41760(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	41792(%rsp,%rcx), %ymm1, %ymm1
+	vpblendd	$170, %ymm2, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	vmovdqa	%ymm9, -32(%rsi)
+	vmovdqa	%ymm8, -128(%rsi)
+	vmovdqa	%ymm7, -96(%rsi)
+	vmovdqa	%ymm6, -64(%rsi)
 	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
 	vpsrlq	$32, %ymm3, %ymm3
-	vpaddq	-160(%rdx), %ymm3, %ymm3
-	vpaddq	-256(%rdx), %ymm2, %ymm2
-	vpaddq	-224(%rdx), %ymm4, %ymm4
-	vpaddq	-192(%rdx), %ymm1, %ymm1
-	leal	1(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	41664(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	41632(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	41600(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	41696(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -192(%rdx)
-	vmovdqa	%ymm7, -224(%rdx)
-	vmovdqa	%ymm6, -256(%rdx)
-	vmovdqa	%ymm5, -160(%rdx)
-	vpsrlq	$32, %ymm3, %ymm3
+	leaq	(%rdi,%r14), %rcx
+	sarq	$25, %rcx
+	vpaddq	9056(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	8960(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	8992(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	9024(%rsp,%rcx), %ymm1, %ymm1
+	leal	1(%rbx), %ecx
+	shlq	$7, %rcx
+	vpaddq	41792(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	41760(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	41728(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	41824(%rsp,%rcx), %ymm3, %ymm3
+	vpblendd	$170, %ymm2, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vmovdqa	%ymm8, 64(%rsi)
+	vmovdqa	%ymm7, 32(%rsi)
+	vmovdqa	%ymm6, (%rsi)
+	vpblendd	$170, %ymm2, %ymm3, %ymm6 # ymm6 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	vmovdqa	%ymm6, 96(%rsi)
 	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	-128(%rdx), %ymm2, %ymm2
-	vpaddq	-96(%rdx), %ymm4, %ymm4
-	vpaddq	-64(%rdx), %ymm1, %ymm1
-	vpaddq	-32(%rdx), %ymm3, %ymm3
-	leal	2(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	41696(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	41664(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	41632(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	41600(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, -32(%rdx)
-	vmovdqa	%ymm7, -64(%rdx)
-	vmovdqa	%ymm6, -96(%rdx)
-	vmovdqa	%ymm5, -128(%rdx)
 	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	(%rdx), %ymm2, %ymm2
-	vpaddq	32(%rdx), %ymm4, %ymm4
-	vpaddq	64(%rdx), %ymm1, %ymm1
-	vpaddq	96(%rdx), %ymm3, %ymm3
-	leal	3(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	41696(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	41664(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	41632(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	41600(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, 96(%rdx)
-	vmovdqa	%ymm7, 64(%rdx)
-	vmovdqa	%ymm6, 32(%rdx)
-	vmovdqa	%ymm5, (%rdx)
-	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	addq	$4, %rax
-	addq	$512, %rdx              # imm = 0x200
-	addl	$4, %edi
-	cmpl	%eax, %esi
-	jne	.LBB2_57
-.LBB2_58:                               # %for_test255.for_exit258_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	movq	8(%rsp), %rbx           # 8-byte Reload
-	je	.LBB2_61
-# %bb.59:                               # %for_loop256.epil.preheader
-	leal	(%r11,%rax), %edx
+	addq	$2, %rax
+	addl	$2, %ebx
+	addq	$256, %rsi              # imm = 0x100
+	addq	%rdx, %rdi
+	cmpl	%eax, %r11d
+	jne	.LBB2_61
+# %bb.62:                               # %for_test263.for_exit266_crit_edge.unr-lcssa
+	testl	%r8d, %r8d
+	je	.LBB2_64
+.LBB2_63:                               # %for_loop265.epil.preheader
+	movslq	%eax, %rcx
+	movq	%rcx, %rdx
+	shlq	$7, %rdx
+	vpaddq	8960(%rsp,%rdx), %ymm4, %ymm2
+	vpaddq	8992(%rsp,%rdx), %ymm5, %ymm4
+	vpaddq	9024(%rsp,%rdx), %ymm1, %ymm1
+	vpaddq	9056(%rsp,%rdx), %ymm3, %ymm3
+	addl	%r10d, %ecx
+	shlq	$7, %rcx
+	vpaddq	41824(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	41792(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	41760(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	41728(%rsp,%rcx), %ymm2, %ymm2
 	shlq	$7, %rax
-	addq	%rsp, %rax
-	addq	$8832, %rax             # imm = 0x2280
-	vpxor	%xmm0, %xmm0, %xmm0
-	.p2align	4, 0x90
-.LBB2_60:                               # %for_loop256.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rax), %ymm3, %ymm3
-	vpaddq	32(%rax), %ymm4, %ymm4
-	vpaddq	(%rax), %ymm2, %ymm2
-	vpaddq	64(%rax), %ymm1, %ymm1
-	movl	%edx, %esi
-	shlq	$7, %rsi
-	vpaddq	41664(%rsp,%rsi), %ymm1, %ymm1
-	vpaddq	41600(%rsp,%rsi), %ymm2, %ymm2
-	vpaddq	41632(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	41696(%rsp,%rsi), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, 64(%rax)
-	vmovdqa	%ymm7, (%rax)
-	vmovdqa	%ymm6, 32(%rax)
-	vmovdqa	%ymm5, 96(%rax)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
+	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm3, %ymm0 # ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vmovdqa	%ymm0, 9056(%rsp,%rax)
+	vmovdqa	%ymm7, 9024(%rsp,%rax)
+	vmovdqa	%ymm6, 8992(%rsp,%rax)
+	vmovdqa	%ymm5, 8960(%rsp,%rax)
 	vpsrlq	$32, %ymm3, %ymm3
-	incl	%edx
-	subq	$-128, %rax
-	decl	%ecx
-	jne	.LBB2_60
-.LBB2_61:                               # %for_test255.for_exit258_crit_edge
+	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm4, %ymm5
+	vpsrlq	$32, %ymm2, %ymm4
+.LBB2_64:                               # %for_test263.for_exit266_crit_edge
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	%ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm0, %ymm5, %ymm2
 	vpcmpeqd	%ymm5, %ymm5, %ymm5
-	vpxor	%ymm5, %ymm4, %ymm4
-	vextracti128	$1, %ymm4, %xmm6
-	vpackssdw	%xmm6, %xmm4, %xmm4
-	vpcmpeqq	%ymm0, %ymm2, %ymm2
 	vpxor	%ymm5, %ymm2, %ymm2
 	vextracti128	$1, %ymm2, %xmm6
 	vpackssdw	%xmm6, %xmm2, %xmm2
-	vinserti128	$1, %xmm4, %ymm2, %ymm4
+	vpcmpeqq	%ymm0, %ymm4, %ymm4
+	vpxor	%ymm5, %ymm4, %ymm4
+	vextracti128	$1, %ymm4, %xmm6
+	vpackssdw	%xmm6, %xmm4, %xmm4
+	vinserti128	$1, %xmm2, %ymm4, %ymm4
 	vpcmpeqq	%ymm0, %ymm3, %ymm2
 	vpxor	%ymm5, %ymm2, %ymm2
 	vextracti128	$1, %ymm2, %xmm3
@@ -4544,489 +4465,423 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
 	vinserti128	$1, %xmm2, %ymm0, %ymm5
-.LBB2_62:                               # %for_exit258
+.LBB2_65:                               # %for_exit266
 	vmovmskps	%ymm4, %eax
 	vmovmskps	%ymm5, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_66
-# %bb.63:                               # %for_exit258
-	testl	%r11d, %r11d
-	je	.LBB2_66
-# %bb.64:                               # %for_loop291.lr.ph
-	movl	20(%rsp), %ecx          # 4-byte Reload
+	je	.LBB2_69
+# %bb.66:                               # %for_exit266
+	testl	%r10d, %r10d
+	je	.LBB2_69
+# %bb.67:                               # %for_loop300.lr.ph
+	movq	112(%rsp), %rcx         # 8-byte Reload
 	vmovd	%ecx, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
 	movl	$32, %eax
 	subl	%ecx, %eax
 	vmovd	%eax, %xmm1
 	vpbroadcastd	%xmm1, %ymm1
-	vmovdqa	.LCPI2_3(%rip), %ymm6   # ymm6 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm4, %ymm6, %ymm2
-	vmovdqa	%ymm2, 64(%rsp)         # 32-byte Spill
-	vmovdqa	.LCPI2_4(%rip), %ymm7   # ymm7 = [4,4,5,5,6,6,7,7]
-	vpermd	%ymm4, %ymm7, %ymm2
-	vmovdqa	%ymm2, 32(%rsp)         # 32-byte Spill
+	vmovaps	.LCPI2_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm4, %ymm2, %ymm3
+	vmovaps	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovdqa	.LCPI2_4(%rip), %ymm6   # ymm6 = [4,4,5,5,6,6,7,7]
+	vpermd	%ymm4, %ymm6, %ymm3
+	vmovdqa	%ymm3, 128(%rsp)        # 32-byte Spill
+	vpermps	%ymm5, %ymm2, %ymm2
+	vmovaps	%ymm2, 224(%rsp)        # 32-byte Spill
 	vpermd	%ymm5, %ymm6, %ymm2
-	vmovdqa	%ymm2, 96(%rsp)         # 32-byte Spill
-	vpermd	%ymm5, %ymm7, %ymm5
-	movl	%r11d, %eax
-	shlq	$6, %rax
+	vmovdqa	%ymm2, 192(%rsp)        # 32-byte Spill
+	movl	%r10d, %eax
+	shlq	$7, %rax
 	vpxor	%xmm6, %xmm6, %xmm6
 	xorl	%ecx, %ecx
+	xorl	%edx, %edx
 	vpxor	%xmm12, %xmm12, %xmm12
 	vpxor	%xmm11, %xmm11, %xmm11
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm10, %xmm10, %xmm10
 	vpxor	%xmm8, %xmm8, %xmm8
 	vpxor	%xmm7, %xmm7, %xmm7
-	vxorps	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm10, %xmm10, %xmm10
 	.p2align	4, 0x90
-.LBB2_65:                               # %for_loop291
+.LBB2_68:                               # %for_loop300
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqa	8832(%rsp,%rcx,2), %ymm15
-	vmovdqa	21120(%rsp,%rcx), %ymm13
-	vmovdqa	21152(%rsp,%rcx), %ymm14
-	vpsllvd	%ymm0, %ymm13, %ymm2
-	vpor	%ymm2, %ymm12, %ymm2
+	vmovdqa	8960(%rsp,%rcx), %ymm15
+	vmovdqa	8992(%rsp,%rcx), %ymm2
+	movq	%rdx, %rsi
+	sarq	$26, %rsi
+	vmovdqa	21248(%rsp,%rsi), %ymm13
+	vmovdqa	21280(%rsp,%rsi), %ymm14
+	vpsllvd	%ymm0, %ymm13, %ymm3
+	vpor	%ymm12, %ymm3, %ymm3
 	vpsllvd	%ymm0, %ymm14, %ymm12
-	vmovdqa	8928(%rsp,%rcx,2), %ymm3
 	vpor	%ymm11, %ymm12, %ymm11
-	vextracti128	$1, %ymm11, %xmm4
+	vextracti128	$1, %ymm3, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vpsubq	%ymm4, %ymm3, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vmovdqa	8896(%rsp,%rcx,2), %ymm10
-	vpmovzxdq	%xmm11, %ymm11  # ymm11 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
-	vpsubq	%ymm11, %ymm10, %ymm11
-	vpaddq	%ymm9, %ymm11, %ymm9
-	vpmovzxdq	%xmm2, %ymm11   # ymm11 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm11, %ymm15, %ymm11
-	vpaddq	%ymm8, %ymm11, %ymm8
-	vpblendd	$170, %ymm6, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
-	vmovapd	64(%rsp), %ymm12        # 32-byte Reload
-	vblendvpd	%ymm12, %ymm11, %ymm15, %ymm11
-	vmovdqa	8864(%rsp,%rcx,2), %ymm12
-	vextracti128	$1, %ymm2, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm2, %ymm12, %ymm2
-	vpaddq	%ymm7, %ymm2, %ymm2
-	vpblendd	$170, %ymm6, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm6[1],ymm2[2],ymm6[3],ymm2[4],ymm6[5],ymm2[6],ymm6[7]
-	vmovapd	32(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm7, %ymm12, %ymm7
-	vpblendd	$170, %ymm6, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
-	vmovapd	96(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm12, %ymm10, %ymm10
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vmovdqa	9024(%rsp,%rcx), %ymm10
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpsubq	%ymm3, %ymm15, %ymm3
+	vpaddq	%ymm9, %ymm3, %ymm3
+	vpblendd	$170, %ymm6, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm6[1],ymm3[2],ymm6[3],ymm3[4],ymm6[5],ymm3[6],ymm6[7]
+	vmovapd	160(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm9, %ymm15, %ymm9
 	vpblendd	$170, %ymm6, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm6[1],ymm4[2],ymm6[3],ymm4[4],ymm6[5],ymm4[6],ymm6[7]
-	vblendvpd	%ymm5, %ymm12, %ymm3, %ymm3
-	vmovapd	%ymm10, 8896(%rsp,%rcx,2)
-	vmovapd	%ymm3, 8928(%rsp,%rcx,2)
-	vmovapd	%ymm11, 8832(%rsp,%rcx,2)
+	vmovapd	128(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm2, %ymm2
+	vpmovzxdq	%xmm11, %ymm12  # ymm12 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
+	vpsubq	%ymm12, %ymm10, %ymm12
+	vpaddq	%ymm8, %ymm12, %ymm8
+	vpblendd	$170, %ymm6, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+	vmovapd	224(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm10, %ymm10
+	vmovdqa	9056(%rsp,%rcx), %ymm12
+	vextracti128	$1, %ymm11, %xmm5
+	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
+	vpsubq	%ymm5, %ymm12, %ymm5
+	vpaddq	%ymm7, %ymm5, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+	vmovapd	192(%rsp), %ymm11       # 32-byte Reload
+	vblendvpd	%ymm11, %ymm7, %ymm12, %ymm7
+	vmovapd	%ymm7, 9056(%rsp,%rcx)
+	vmovapd	%ymm10, 9024(%rsp,%rcx)
 	vpsrlvd	%ymm1, %ymm14, %ymm11
 	vpsrlvd	%ymm1, %ymm13, %ymm12
-	vmovapd	%ymm7, 8864(%rsp,%rcx,2)
-	vpsrad	$31, %ymm4, %ymm3
-	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm9, %ymm3
-	vpshufd	$245, %ymm9, %ymm4      # ymm4 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm2, %ymm3
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vmovapd	%ymm2, 8992(%rsp,%rcx)
+	vmovapd	%ymm9, 8960(%rsp,%rcx)
+	vpsrad	$31, %ymm5, %ymm2
+	vpshufd	$245, %ymm5, %ymm5      # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
 	vpsrad	$31, %ymm8, %ymm2
-	vpshufd	$245, %ymm8, %ymm3      # ymm3 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm2, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
-	addq	$64, %rcx
+	vpshufd	$245, %ymm8, %ymm5      # ymm5 = ymm8[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpsrad	$31, %ymm4, %ymm2
+	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpsrad	$31, %ymm3, %ymm2
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	addq	%r14, %rdx
+	subq	$-128, %rcx
 	cmpq	%rcx, %rax
-	jne	.LBB2_65
-.LBB2_66:                               # %safe_if_after_true
-	leal	-1(%r11), %eax
+	jne	.LBB2_68
+.LBB2_69:                               # %safe_if_after_true
+	leal	-1(%r10), %eax
 	shlq	$7, %rax
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	8928(%rsp,%rax), %ymm0, %ymm2
-	vpcmpeqd	%ymm1, %ymm1, %ymm1
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpcmpeqq	8896(%rsp,%rax), %ymm0, %ymm4
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpxor	%ymm1, %ymm4, %ymm3
+	vpcmpeqq	9056(%rsp,%rax), %ymm0, %ymm1
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm3
+	vpcmpeqq	9024(%rsp,%rax), %ymm0, %ymm4
+	vpackssdw	%xmm3, %xmm1, %xmm1
+	vpxor	%ymm2, %ymm4, %ymm3
 	vextracti128	$1, %ymm3, %xmm4
 	vpackssdw	%xmm4, %xmm3, %xmm3
-	vinserti128	$1, %xmm2, %ymm3, %ymm11
-	vpcmpeqq	8864(%rsp,%rax), %ymm0, %ymm2
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpcmpeqq	8832(%rsp,%rax), %ymm0, %ymm0
-	vpxor	%ymm1, %ymm0, %ymm0
-	vextracti128	$1, %ymm0, %xmm3
-	vpackssdw	%xmm3, %xmm0, %xmm0
-	vinserti128	$1, %xmm2, %ymm0, %ymm10
-	vmovmskps	%ymm10, %eax
-	vmovmskps	%ymm11, %ecx
-	movl	%ecx, %edx
-	shll	$8, %edx
-	orl	%eax, %edx
-	je	.LBB2_67
-# %bb.132:                              # %for_test349.preheader
-	vpbroadcastd	.LCPI2_5(%rip), %ymm4 # ymm4 = [1,1,1,1,1,1,1,1]
-	xorl	%edx, %edx
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-	vmovdqa	.LCPI2_6(%rip), %xmm13  # xmm13 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vmovdqa	.LCPI2_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vmovdqa	%ymm4, %ymm9
-	vmovaps	%ymm10, 32(%rsp)        # 32-byte Spill
-	vmovaps	%ymm11, 64(%rsp)        # 32-byte Spill
-	.p2align	4, 0x90
-.LBB2_133:                              # %for_test349
-                                        # =>This Inner Loop Header: Depth=1
-	cmpl	%r11d, %edx
-	sbbl	%esi, %esi
-	vmovd	%esi, %xmm3
-	vpbroadcastd	%xmm3, %ymm3
-	vpshufd	$78, %xmm0, %xmm7       # xmm7 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm7, %ymm7
-	vpand	%ymm7, %ymm11, %ymm7
-	vpmovsxbd	%xmm0, %ymm11
-	vpand	%ymm11, %ymm10, %ymm10
-	vpand	%ymm3, %ymm7, %ymm11
-	vpand	%ymm3, %ymm10, %ymm10
-	vmovmskps	%ymm10, %esi
-	vmovmskps	%ymm11, %edi
-	shll	$8, %edi
-	orl	%esi, %edi
-	je	.LBB2_134
-# %bb.135:                              # %for_loop350
-                                        #   in Loop: Header=BB2_133 Depth=1
-	movl	%edx, %esi
-	movq	%rsi, %rdi
-	shlq	$6, %rdi
-	vmovdqa	21120(%rsp,%rdi), %ymm3
-	vmovdqa	21152(%rsp,%rdi), %ymm7
-	vpaddd	%ymm4, %ymm3, %ymm14
-	vpaddd	%ymm7, %ymm9, %ymm15
-	vpmaxud	%ymm7, %ymm15, %ymm7
-	vpcmpeqd	%ymm7, %ymm15, %ymm7
-	vpbroadcastd	.LCPI2_5(%rip), %ymm8 # ymm8 = [1,1,1,1,1,1,1,1]
-	vpmaxud	%ymm3, %ymm14, %ymm3
-	vpcmpeqd	%ymm3, %ymm14, %ymm3
-	vpandn	%ymm8, %ymm3, %ymm3
-	vblendvps	%ymm10, %ymm3, %ymm4, %ymm4
-	vpandn	%ymm8, %ymm7, %ymm3
-	vblendvps	%ymm11, %ymm3, %ymm9, %ymm9
-	shlq	$7, %rsi
-	vpmovzxdq	%xmm14, %ymm3   # ymm3 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vextracti128	$1, %ymm14, %xmm7
-	vpmovzxdq	%xmm7, %ymm7    # ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero
-	vpmovzxdq	%xmm15, %ymm8   # ymm8 = xmm15[0],zero,xmm15[1],zero,xmm15[2],zero,xmm15[3],zero
-	vextracti128	$1, %ymm15, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpcmpeqq	8928(%rsp,%rsi), %ymm2, %ymm2
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm5
-	vpcmpeqq	8896(%rsp,%rsi), %ymm8, %ymm8
-	vpackssdw	%xmm5, %xmm2, %xmm2
-	vpxor	%ymm1, %ymm8, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpackssdw	%xmm2, %xmm5, %xmm2
-	vpcmpeqq	8864(%rsp,%rsi), %ymm7, %ymm5
-	vpxor	%ymm1, %ymm5, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpcmpeqq	8832(%rsp,%rsi), %ymm3, %ymm3
-	vpxor	%ymm1, %ymm3, %ymm3
-	vextracti128	$1, %ymm3, %xmm6
-	vpackssdw	%xmm6, %xmm3, %xmm3
-	vpackssdw	%xmm5, %xmm3, %xmm3
-	vpacksswb	%xmm2, %xmm3, %xmm2
-	vextracti128	$1, %ymm10, %xmm3
-	vpshufb	%xmm13, %xmm3, %xmm3
-	vpshufb	%xmm13, %xmm10, %xmm5
-	vpunpckldq	%xmm3, %xmm5, %xmm3 # xmm3 = xmm5[0],xmm3[0],xmm5[1],xmm3[1]
-	vextracti128	$1, %ymm11, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm11, %xmm6
-	vpunpckldq	%xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0],xmm5[0],xmm6[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm3, %xmm3 # xmm3 = xmm3[0,1],xmm5[2,3]
-	vpand	%xmm3, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	.LCPI2_8(%rip), %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpcmpgtb	%xmm2, %xmm3, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%edx
-	jmp	.LBB2_133
-.LBB2_134:
-	vmovaps	64(%rsp), %ymm11        # 32-byte Reload
-	vmovaps	32(%rsp), %ymm10        # 32-byte Reload
-	jmp	.LBB2_68
-.LBB2_67:
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-.LBB2_68:                               # %safe_if_after_true341
-	xorl	$255, %eax
-	xorl	$255, %ecx
+	vinserti128	$1, %xmm1, %ymm3, %ymm3
+	vpcmpeqq	8992(%rsp,%rax), %ymm0, %ymm1
+	vpxor	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm4
+	vpackssdw	%xmm4, %xmm1, %xmm1
+	vpcmpeqq	8960(%rsp,%rax), %ymm0, %ymm0
+	vpxor	%ymm2, %ymm0, %ymm0
+	vextracti128	$1, %ymm0, %xmm4
+	vpackssdw	%xmm4, %xmm0, %xmm0
+	vinserti128	$1, %xmm1, %ymm0, %ymm1
+	vmovmskps	%ymm1, %eax
+	vmovmskps	%ymm3, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_69
-# %bb.136:                              # %safe_if_run_false407
-	vpxor	%ymm1, %ymm10, %ymm3
-	vpbroadcastq	.LCPI2_9(%rip), %ymm2 # ymm2 = [1,1,1,1]
-	vpcmpeqq	8928(%rsp), %ymm2, %ymm4
-	vpcmpeqq	8896(%rsp), %ymm2, %ymm5
-	vpxor	%ymm1, %ymm11, %ymm1
-	vpackssdw	%ymm4, %ymm5, %ymm4
-	vpcmpeqq	8864(%rsp), %ymm2, %ymm5
-	vpermq	$216, %ymm4, %ymm4      # ymm4 = ymm4[0,2,1,3]
-	vpcmpeqq	8832(%rsp), %ymm2, %ymm2
-	vpackssdw	%ymm5, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vpackssdw	%ymm4, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vextracti128	$1, %ymm2, %xmm4
-	vpacksswb	%xmm4, %xmm2, %xmm8
-	vextracti128	$1, %ymm3, %xmm4
-	vmovdqa	.LCPI2_6(%rip), %xmm10  # xmm10 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm6
-	vpunpckldq	%xmm4, %xmm6, %xmm6 # xmm6 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm7
-	vmovdqa	.LCPI2_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm12, %xmm7, %xmm7
-	vpshufb	%xmm12, %xmm1, %xmm5
-	vpunpckldq	%xmm7, %xmm5, %xmm5 # xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-	vpblendd	$12, %xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0,1],xmm5[2,3]
-	vpsllw	$7, %xmm5, %xmm5
-	vpblendvb	%xmm5, %xmm8, %xmm0, %xmm0
-	movl	$1, %eax
-	vpxor	%xmm13, %xmm13, %xmm13
-	vpcmpeqd	%ymm6, %ymm6, %ymm6
-	vmovdqa	.LCPI2_8(%rip), %xmm8   # xmm8 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-	vxorps	%xmm9, %xmm9, %xmm9
+	vmovaps	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovaps	%ymm1, 128(%rsp)        # 32-byte Spill
+	je	.LBB2_70
+# %bb.77:                               # %for_test357.preheader
+	movl	%r10d, %eax
+	negl	%eax
+	sbbl	%eax, %eax
+	vmovd	%eax, %xmm0
+	vpbroadcastd	%xmm0, %ymm0
+	vpand	%ymm3, %ymm0, %ymm5
+	vpand	%ymm1, %ymm0, %ymm6
+	vmovmskps	%ymm6, %eax
+	vmovmskps	%ymm5, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB2_70
+# %bb.78:                               # %for_loop359.preheader
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vbroadcastss	.LCPI2_5(%rip), %ymm11 # ymm11 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vpbroadcastd	.LCPI2_5(%rip), %ymm15 # ymm15 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	xorl	%eax, %eax
+	vpxor	%xmm8, %xmm8, %xmm8
+	vmovdqa	%ymm15, %ymm9
+	vmovdqa	%ymm15, %ymm10
+	vmovaps	%ymm11, %ymm12
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
 	.p2align	4, 0x90
-.LBB2_137:                              # %for_test417
+.LBB2_79:                               # %for_loop359
                                         # =>This Inner Loop Header: Depth=1
-	cmpl	%r11d, %eax
-	sbbl	%ecx, %ecx
-	vmovd	%ecx, %xmm7
-	vpbroadcastd	%xmm7, %ymm7
-	vpshufd	$78, %xmm0, %xmm2       # xmm2 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm2, %ymm2
-	vpand	%ymm2, %ymm1, %ymm1
-	vpmovsxbd	%xmm0, %ymm2
-	vpand	%ymm2, %ymm3, %ymm2
-	vpand	%ymm7, %ymm1, %ymm1
-	vpand	%ymm7, %ymm2, %ymm3
-	vmovmskps	%ymm3, %ecx
-	vmovmskps	%ymm1, %edx
-	shll	$8, %edx
-	orl	%ecx, %edx
-	je	.LBB2_69
-# %bb.138:                              # %for_loop418
-                                        #   in Loop: Header=BB2_137 Depth=1
 	movl	%eax, %ecx
+	cltq
+	movq	%rax, %rdx
+	shlq	$6, %rdx
+	vpaddd	21248(%rsp,%rdx), %ymm9, %ymm13
+	vpaddd	21280(%rsp,%rdx), %ymm10, %ymm14
+	movq	%rcx, %rdx
+	shlq	$6, %rdx
+	vpmaxud	21280(%rsp,%rdx), %ymm14, %ymm9
+	vpcmpeqd	%ymm9, %ymm14, %ymm9
+	vpandn	%ymm15, %ymm9, %ymm10
+	vpmaxud	21248(%rsp,%rdx), %ymm13, %ymm9
+	vpcmpeqd	%ymm9, %ymm13, %ymm9
+	vpandn	%ymm15, %ymm9, %ymm9
+	vblendvps	%ymm6, %ymm9, %ymm11, %ymm9
+	vblendvps	%ymm5, %ymm10, %ymm12, %ymm10
 	shlq	$7, %rcx
-	vpcmpeqq	8928(%rsp,%rcx), %ymm13, %ymm2
-	vpxor	%ymm6, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm7
-	vpcmpeqq	8896(%rsp,%rcx), %ymm13, %ymm11
-	vpackssdw	%xmm7, %xmm2, %xmm2
-	vpxor	%ymm6, %ymm11, %ymm7
-	vextracti128	$1, %ymm7, %xmm4
-	vpackssdw	%xmm4, %xmm7, %xmm4
-	vpackssdw	%xmm2, %xmm4, %xmm2
-	vpcmpeqq	8864(%rsp,%rcx), %ymm13, %ymm4
-	vpxor	%ymm6, %ymm4, %ymm4
+	vpmovzxdq	%xmm14, %ymm11  # ymm11 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vextracti128	$1, %ymm14, %xmm2
+	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
+	vpmovzxdq	%xmm13, %ymm12  # ymm12 = xmm13[0],zero,xmm13[1],zero,xmm13[2],zero,xmm13[3],zero
+	vextracti128	$1, %ymm13, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpcmpeqq	8992(%rsp,%rcx), %ymm3, %ymm3
+	vextracti128	$1, %ymm3, %xmm4
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vpcmpeqq	8960(%rsp,%rcx), %ymm12, %ymm4
 	vextracti128	$1, %ymm4, %xmm7
 	vpackssdw	%xmm7, %xmm4, %xmm4
-	vpcmpeqq	8832(%rsp,%rcx), %ymm13, %ymm7
-	vpxor	%ymm6, %ymm7, %ymm7
-	vextracti128	$1, %ymm7, %xmm5
-	vpackssdw	%xmm5, %xmm7, %xmm5
-	vpackssdw	%xmm4, %xmm5, %xmm4
-	vpacksswb	%xmm2, %xmm4, %xmm2
-	vextracti128	$1, %ymm3, %xmm4
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm5
-	vpunpckldq	%xmm4, %xmm5, %xmm4 # xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm1, %xmm7
-	vpunpckldq	%xmm5, %xmm7, %xmm5 # xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm4, %xmm4 # xmm4 = xmm4[0,1],xmm5[2,3]
-	vpand	%xmm4, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	%xmm2, %xmm8, %xmm2
-	vpcmpgtb	%xmm2, %xmm9, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%eax
-	jmp	.LBB2_137
-.LBB2_69:                               # %if_done340
-	vpand	.LCPI2_10(%rip), %xmm0, %xmm0
-	vpshufd	$78, %xmm0, %xmm1       # xmm1 = xmm0[2,3,0,1]
-	vpmovzxbd	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero,xmm1[4],zero,zero,zero,xmm1[5],zero,zero,zero,xmm1[6],zero,zero,zero,xmm1[7],zero,zero,zero
-	vpmovzxbd	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
-	vmovdqu	%ymm0, (%rbx)
-	vmovdqu	%ymm1, 32(%rbx)
-	jmp	.LBB2_70
-.LBB2_118:                              # %for_loop788.lr.ph.new
-	leaq	1024(%rsp), %rdx
-	movl	%r11d, %esi
-	subl	%ecx, %esi
-	vpxor	%xmm0, %xmm0, %xmm0
+	vinserti128	$1, %xmm3, %ymm4, %ymm3
+	vpcmpeqq	9056(%rsp,%rcx), %ymm2, %ymm2
+	vextracti128	$1, %ymm2, %xmm4
+	vpackssdw	%xmm4, %xmm2, %xmm2
+	vpcmpeqq	9024(%rsp,%rcx), %ymm11, %ymm4
+	vextracti128	$1, %ymm4, %xmm7
+	vpackssdw	%xmm7, %xmm4, %xmm4
+	vinserti128	$1, %xmm2, %ymm4, %ymm2
+	vpandn	%ymm5, %ymm2, %ymm2
+	vpandn	%ymm6, %ymm3, %ymm3
+	vblendvps	%ymm3, %ymm8, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm8, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r10d, %eax
+	sbbl	%ecx, %ecx
+	vmovd	%ecx, %xmm2
+	vpbroadcastd	%xmm2, %ymm2
+	vpand	%ymm2, %ymm5, %ymm3
+	vandps	%ymm3, %ymm1, %ymm5
+	vpand	%ymm2, %ymm6, %ymm2
+	vandps	%ymm2, %ymm0, %ymm6
+	vmovmskps	%ymm6, %ecx
+	vmovmskps	%ymm5, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	vmovaps	%ymm9, %ymm11
+	vmovaps	%ymm10, %ymm12
+	jne	.LBB2_79
+	jmp	.LBB2_71
+.LBB2_70:
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+.LBB2_71:                               # %safe_if_after_true349
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	128(%rsp), %ymm2, %ymm4 # 32-byte Folded Reload
+	vpxor	160(%rsp), %ymm2, %ymm2 # 32-byte Folded Reload
+	vmovmskps	%ymm4, %eax
+	vmovmskps	%ymm2, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB2_75
+# %bb.72:                               # %safe_if_run_false415
+	vpbroadcastq	.LCPI2_6(%rip), %ymm3 # ymm3 = [1,1,1,1]
+	vpcmpeqq	9056(%rsp), %ymm3, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	9024(%rsp), %ymm3, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vpcmpeqq	8992(%rsp), %ymm3, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	8960(%rsp), %ymm3, %ymm3
+	vextracti128	$1, %ymm3, %xmm7
+	vpackssdw	%xmm7, %xmm3, %xmm3
+	vinserti128	$1, %xmm6, %ymm3, %ymm3
+	vblendvps	%ymm4, %ymm3, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm5, %ymm1, %ymm1
 	xorl	%eax, %eax
-	movl	%r11d, %edi
+	cmpl	$1, %r10d
+	seta	%al
+	negl	%eax
+	vmovd	%eax, %xmm3
+	vpbroadcastd	%xmm3, %ymm3
+	vandps	%ymm0, %ymm4, %ymm4
+	vandps	%ymm1, %ymm2, %ymm2
+	vandps	%ymm3, %ymm2, %ymm2
+	vandps	%ymm3, %ymm4, %ymm3
+	vmovmskps	%ymm3, %eax
+	vmovmskps	%ymm2, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB2_75
+# %bb.73:                               # %for_loop427.preheader
+	movl	$1, %eax
+	vpxor	%xmm8, %xmm8, %xmm8
+	.p2align	4, 0x90
+.LBB2_74:                               # %for_loop427
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	shlq	$7, %rcx
+	vpcmpeqq	8992(%rsp,%rcx), %ymm8, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	8960(%rsp,%rcx), %ymm8, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vpcmpeqq	9056(%rsp,%rcx), %ymm8, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	9024(%rsp,%rcx), %ymm8, %ymm7
+	vextracti128	$1, %ymm7, %xmm4
+	vpackssdw	%xmm4, %xmm7, %xmm4
+	vinserti128	$1, %xmm6, %ymm4, %ymm4
+	vpandn	%ymm2, %ymm4, %ymm4
+	vpandn	%ymm3, %ymm5, %ymm5
+	vblendvps	%ymm5, %ymm8, %ymm0, %ymm0
+	vblendvps	%ymm4, %ymm8, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r10d, %eax
+	sbbl	%ecx, %ecx
+	vmovd	%ecx, %xmm4
+	vpbroadcastd	%xmm4, %ymm4
+	vpand	%ymm4, %ymm2, %ymm2
+	vandps	%ymm2, %ymm1, %ymm2
+	vpand	%ymm4, %ymm3, %ymm3
+	vandps	%ymm3, %ymm0, %ymm3
+	vmovmskps	%ymm3, %ecx
+	vmovmskps	%ymm2, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	jne	.LBB2_74
+.LBB2_75:                               # %if_done348
+	vbroadcastss	.LCPI2_5(%rip), %ymm2 # ymm2 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vandps	%ymm2, %ymm1, %ymm1
+	vandps	%ymm2, %ymm0, %ymm0
+	vmovups	%ymm0, (%r15)
+	vmovups	%ymm1, 32(%r15)
+	jmp	.LBB2_76
+.LBB2_134:                              # %for_loop804.lr.ph.new
+	movabsq	$8589934592, %rdx       # imm = 0x200000000
+	leaq	896(%rsp), %rsi
 	vpxor	%xmm2, %xmm2, %xmm2
+	xorl	%edi, %edi
+	movl	%r10d, %ebx
+	xorl	%eax, %eax
 	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
 	vpxor	%xmm1, %xmm1, %xmm1
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB2_119:                              # %for_loop788
+.LBB2_135:                              # %for_loop804
                                         # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rdx), %ymm3, %ymm3
-	vpaddq	-384(%rdx), %ymm2, %ymm2
-	vpaddq	-352(%rdx), %ymm4, %ymm4
-	vpaddq	-320(%rdx), %ymm1, %ymm1
-	movl	%edi, %ebx
-	shlq	$7, %rbx
-	vpaddq	25280(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	25248(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	25216(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	25312(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -320(%rdx)
-	vmovdqa	%ymm7, -352(%rdx)
-	vmovdqa	%ymm6, -384(%rdx)
-	vmovdqa	%ymm5, -288(%rdx)
+	movq	%rdi, %rcx
+	sarq	$25, %rcx
+	vpaddq	832(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	800(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	768(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	864(%rsp,%rcx), %ymm3, %ymm3
+	movl	%ebx, %ecx
+	shlq	$7, %rcx
+	vpaddq	25440(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	25344(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	25376(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	25408(%rsp,%rcx), %ymm1, %ymm1
+	vpblendd	$170, %ymm2, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	vmovdqa	%ymm9, -32(%rsi)
+	vmovdqa	%ymm8, -128(%rsi)
+	vmovdqa	%ymm7, -96(%rsi)
+	vmovdqa	%ymm6, -64(%rsi)
 	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
 	vpsrlq	$32, %ymm3, %ymm3
-	vpaddq	-160(%rdx), %ymm3, %ymm3
-	vpaddq	-256(%rdx), %ymm2, %ymm2
-	vpaddq	-224(%rdx), %ymm4, %ymm4
-	vpaddq	-192(%rdx), %ymm1, %ymm1
-	leal	1(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	25280(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	25248(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	25216(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	25312(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -192(%rdx)
-	vmovdqa	%ymm7, -224(%rdx)
-	vmovdqa	%ymm6, -256(%rdx)
-	vmovdqa	%ymm5, -160(%rdx)
-	vpsrlq	$32, %ymm3, %ymm3
+	leaq	(%rdi,%r14), %rcx
+	sarq	$25, %rcx
+	vpaddq	864(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	768(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	800(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	832(%rsp,%rcx), %ymm1, %ymm1
+	leal	1(%rbx), %ecx
+	shlq	$7, %rcx
+	vpaddq	25408(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	25376(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	25344(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	25440(%rsp,%rcx), %ymm3, %ymm3
+	vpblendd	$170, %ymm2, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpblendd	$170, %ymm2, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm2[1],ymm1[2],ymm2[3],ymm1[4],ymm2[5],ymm1[6],ymm2[7]
+	vmovdqa	%ymm8, 64(%rsi)
+	vmovdqa	%ymm7, 32(%rsi)
+	vmovdqa	%ymm6, (%rsi)
+	vpblendd	$170, %ymm2, %ymm3, %ymm6 # ymm6 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	vmovdqa	%ymm6, 96(%rsi)
 	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	-128(%rdx), %ymm2, %ymm2
-	vpaddq	-96(%rdx), %ymm4, %ymm4
-	vpaddq	-64(%rdx), %ymm1, %ymm1
-	vpaddq	-32(%rdx), %ymm3, %ymm3
-	leal	2(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	25312(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	25280(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	25248(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	25216(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, -32(%rdx)
-	vmovdqa	%ymm7, -64(%rdx)
-	vmovdqa	%ymm6, -96(%rdx)
-	vmovdqa	%ymm5, -128(%rdx)
 	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	(%rdx), %ymm2, %ymm2
-	vpaddq	32(%rdx), %ymm4, %ymm4
-	vpaddq	64(%rdx), %ymm1, %ymm1
-	vpaddq	96(%rdx), %ymm3, %ymm3
-	leal	3(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	25312(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	25280(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	25248(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	25216(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, 96(%rdx)
-	vmovdqa	%ymm7, 64(%rdx)
-	vmovdqa	%ymm6, 32(%rdx)
-	vmovdqa	%ymm5, (%rdx)
-	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	addq	$4, %rax
-	addq	$512, %rdx              # imm = 0x200
-	addl	$4, %edi
-	cmpl	%eax, %esi
-	jne	.LBB2_119
-.LBB2_120:                              # %for_test787.for_exit790_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	movq	8(%rsp), %rbx           # 8-byte Reload
-	je	.LBB2_123
-# %bb.121:                              # %for_loop788.epil.preheader
-	leal	(%r11,%rax), %edx
+	addq	$2, %rax
+	addl	$2, %ebx
+	addq	$256, %rsi              # imm = 0x100
+	addq	%rdx, %rdi
+	cmpl	%eax, %r11d
+	jne	.LBB2_135
+# %bb.136:                              # %for_test802.for_exit805_crit_edge.unr-lcssa
+	testl	%r8d, %r8d
+	je	.LBB2_138
+.LBB2_137:                              # %for_loop804.epil.preheader
+	movslq	%eax, %rcx
+	movq	%rcx, %rdx
+	shlq	$7, %rdx
+	vpaddq	768(%rsp,%rdx), %ymm4, %ymm2
+	vpaddq	800(%rsp,%rdx), %ymm5, %ymm4
+	vpaddq	832(%rsp,%rdx), %ymm1, %ymm1
+	vpaddq	864(%rsp,%rdx), %ymm3, %ymm3
+	addl	%r10d, %ecx
+	shlq	$7, %rcx
+	vpaddq	25440(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	25408(%rsp,%rcx), %ymm1, %ymm1
+	vpaddq	25376(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	25344(%rsp,%rcx), %ymm2, %ymm2
 	shlq	$7, %rax
-	addq	%rsp, %rax
-	addq	$640, %rax              # imm = 0x280
-	vpxor	%xmm0, %xmm0, %xmm0
-	.p2align	4, 0x90
-.LBB2_122:                              # %for_loop788.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rax), %ymm3, %ymm3
-	vpaddq	32(%rax), %ymm4, %ymm4
-	vpaddq	(%rax), %ymm2, %ymm2
-	vpaddq	64(%rax), %ymm1, %ymm1
-	movl	%edx, %esi
-	shlq	$7, %rsi
-	vpaddq	25280(%rsp,%rsi), %ymm1, %ymm1
-	vpaddq	25216(%rsp,%rsi), %ymm2, %ymm2
-	vpaddq	25248(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	25312(%rsp,%rsi), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, 64(%rax)
-	vmovdqa	%ymm7, (%rax)
-	vmovdqa	%ymm6, 32(%rax)
-	vmovdqa	%ymm5, 96(%rax)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
+	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm3, %ymm0 # ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vmovdqa	%ymm0, 864(%rsp,%rax)
+	vmovdqa	%ymm7, 832(%rsp,%rax)
+	vmovdqa	%ymm6, 800(%rsp,%rax)
+	vmovdqa	%ymm5, 768(%rsp,%rax)
 	vpsrlq	$32, %ymm3, %ymm3
-	incl	%edx
-	subq	$-128, %rax
-	decl	%ecx
-	jne	.LBB2_122
-.LBB2_123:                              # %for_test787.for_exit790_crit_edge
+	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm4, %ymm5
+	vpsrlq	$32, %ymm2, %ymm4
+.LBB2_138:                              # %for_test802.for_exit805_crit_edge
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	%ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm0, %ymm5, %ymm2
 	vpcmpeqd	%ymm5, %ymm5, %ymm5
-	vpxor	%ymm5, %ymm4, %ymm4
-	vextracti128	$1, %ymm4, %xmm6
-	vpackssdw	%xmm6, %xmm4, %xmm4
-	vpcmpeqq	%ymm0, %ymm2, %ymm2
 	vpxor	%ymm5, %ymm2, %ymm2
 	vextracti128	$1, %ymm2, %xmm6
 	vpackssdw	%xmm6, %xmm2, %xmm2
-	vinserti128	$1, %xmm4, %ymm2, %ymm4
+	vpcmpeqq	%ymm0, %ymm4, %ymm4
+	vpxor	%ymm5, %ymm4, %ymm4
+	vextracti128	$1, %ymm4, %xmm6
+	vpackssdw	%xmm6, %xmm4, %xmm4
+	vinserti128	$1, %xmm2, %ymm4, %ymm4
 	vpcmpeqq	%ymm0, %ymm3, %ymm2
 	vpxor	%ymm5, %ymm2, %ymm2
 	vextracti128	$1, %ymm2, %xmm3
@@ -5036,343 +4891,338 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
 	vinserti128	$1, %xmm2, %ymm0, %ymm5
-.LBB2_124:                              # %for_exit790
-	vpand	%ymm4, %ymm15, %ymm0
+.LBB2_139:                              # %for_exit805
+	vpand	%ymm15, %ymm4, %ymm0
 	vmovmskps	%ymm0, %eax
-	vpand	%ymm5, %ymm9, %ymm0
+	vpand	%ymm14, %ymm5, %ymm0
 	vmovmskps	%ymm0, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_128
-# %bb.125:                              # %for_exit790
-	testl	%r11d, %r11d
-	je	.LBB2_128
-# %bb.126:                              # %for_loop826.lr.ph
-	movl	20(%rsp), %ecx          # 4-byte Reload
+	je	.LBB2_143
+# %bb.140:                              # %for_exit805
+	testl	%r10d, %r10d
+	je	.LBB2_143
+# %bb.141:                              # %for_loop842.lr.ph
+	movq	112(%rsp), %rcx         # 8-byte Reload
 	vmovd	%ecx, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
 	movl	$32, %eax
 	subl	%ecx, %eax
 	vmovd	%eax, %xmm1
 	vpbroadcastd	%xmm1, %ymm1
-	vmovdqa	.LCPI2_3(%rip), %ymm6   # ymm6 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm4, %ymm6, %ymm2
-	vmovdqa	%ymm2, 64(%rsp)         # 32-byte Spill
-	vmovdqa	.LCPI2_4(%rip), %ymm7   # ymm7 = [4,4,5,5,6,6,7,7]
-	vpermd	%ymm4, %ymm7, %ymm2
-	vmovdqa	%ymm2, 32(%rsp)         # 32-byte Spill
+	vmovdqa	.LCPI2_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
+	vpermd	%ymm4, %ymm2, %ymm3
+	vmovdqa	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovdqa	.LCPI2_4(%rip), %ymm6   # ymm6 = [4,4,5,5,6,6,7,7]
+	vpermd	%ymm4, %ymm6, %ymm3
+	vmovdqa	%ymm3, 128(%rsp)        # 32-byte Spill
+	vpermd	%ymm5, %ymm2, %ymm2
+	vmovdqa	%ymm2, 224(%rsp)        # 32-byte Spill
 	vpermd	%ymm5, %ymm6, %ymm2
-	vmovdqa	%ymm2, 96(%rsp)         # 32-byte Spill
-	vpermd	%ymm5, %ymm7, %ymm5
-	shlq	$6, %r15
+	vmovdqa	%ymm2, 192(%rsp)        # 32-byte Spill
+	movl	%r10d, %eax
+	shlq	$7, %rax
 	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%eax, %eax
+	xorl	%ecx, %ecx
+	xorl	%edx, %edx
 	vpxor	%xmm12, %xmm12, %xmm12
 	vpxor	%xmm11, %xmm11, %xmm11
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm7, %xmm7, %xmm7
 	vpxor	%xmm9, %xmm9, %xmm9
 	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm7, %xmm7, %xmm7
 	.p2align	4, 0x90
-.LBB2_127:                              # %for_loop826
+.LBB2_142:                              # %for_loop842
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqa	640(%rsp,%rax,2), %ymm15
-	vmovdqa	17024(%rsp,%rax), %ymm13
-	vmovdqa	17056(%rsp,%rax), %ymm14
-	vpsllvd	%ymm0, %ymm13, %ymm2
-	vpor	%ymm2, %ymm12, %ymm2
+	vmovdqa	768(%rsp,%rcx), %ymm15
+	vmovdqa	800(%rsp,%rcx), %ymm2
+	movq	%rdx, %rsi
+	sarq	$26, %rsi
+	vmovdqa	17152(%rsp,%rsi), %ymm13
+	vmovdqa	17184(%rsp,%rsi), %ymm14
+	vpsllvd	%ymm0, %ymm13, %ymm3
+	vpor	%ymm12, %ymm3, %ymm3
 	vpsllvd	%ymm0, %ymm14, %ymm12
-	vmovdqa	736(%rsp,%rax,2), %ymm3
 	vpor	%ymm11, %ymm12, %ymm11
-	vextracti128	$1, %ymm11, %xmm4
+	vextracti128	$1, %ymm3, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vpsubq	%ymm4, %ymm3, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vmovdqa	704(%rsp,%rax,2), %ymm10
-	vpmovzxdq	%xmm11, %ymm11  # ymm11 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
-	vpsubq	%ymm11, %ymm10, %ymm11
-	vpaddq	%ymm9, %ymm11, %ymm9
-	vpmovzxdq	%xmm2, %ymm11   # ymm11 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm11, %ymm15, %ymm11
-	vpaddq	%ymm8, %ymm11, %ymm8
-	vpblendd	$170, %ymm6, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
-	vmovapd	64(%rsp), %ymm12        # 32-byte Reload
-	vblendvpd	%ymm12, %ymm11, %ymm15, %ymm11
-	vmovdqa	672(%rsp,%rax,2), %ymm12
-	vextracti128	$1, %ymm2, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm2, %ymm12, %ymm2
-	vpaddq	%ymm7, %ymm2, %ymm2
-	vpblendd	$170, %ymm6, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm6[1],ymm2[2],ymm6[3],ymm2[4],ymm6[5],ymm2[6],ymm6[7]
-	vmovapd	32(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm7, %ymm12, %ymm7
-	vpblendd	$170, %ymm6, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
-	vmovapd	96(%rsp), %ymm15        # 32-byte Reload
-	vblendvpd	%ymm15, %ymm12, %ymm10, %ymm10
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vmovdqa	832(%rsp,%rcx), %ymm10
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpsubq	%ymm3, %ymm15, %ymm3
+	vpaddq	%ymm9, %ymm3, %ymm3
+	vpblendd	$170, %ymm6, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm6[1],ymm3[2],ymm6[3],ymm3[4],ymm6[5],ymm3[6],ymm6[7]
+	vmovapd	160(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm9, %ymm15, %ymm9
 	vpblendd	$170, %ymm6, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm6[1],ymm4[2],ymm6[3],ymm4[4],ymm6[5],ymm4[6],ymm6[7]
-	vblendvpd	%ymm5, %ymm12, %ymm3, %ymm3
-	vmovapd	%ymm10, 704(%rsp,%rax,2)
-	vmovapd	%ymm3, 736(%rsp,%rax,2)
-	vmovapd	%ymm11, 640(%rsp,%rax,2)
+	vmovapd	128(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm2, %ymm2
+	vpmovzxdq	%xmm11, %ymm12  # ymm12 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
+	vpsubq	%ymm12, %ymm10, %ymm12
+	vpaddq	%ymm8, %ymm12, %ymm8
+	vpblendd	$170, %ymm6, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+	vmovapd	224(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm10, %ymm10
+	vmovdqa	864(%rsp,%rcx), %ymm12
+	vextracti128	$1, %ymm11, %xmm5
+	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
+	vpsubq	%ymm5, %ymm12, %ymm5
+	vpaddq	%ymm7, %ymm5, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+	vmovapd	192(%rsp), %ymm11       # 32-byte Reload
+	vblendvpd	%ymm11, %ymm7, %ymm12, %ymm7
+	vmovapd	%ymm7, 864(%rsp,%rcx)
+	vmovapd	%ymm10, 832(%rsp,%rcx)
 	vpsrlvd	%ymm1, %ymm14, %ymm11
 	vpsrlvd	%ymm1, %ymm13, %ymm12
-	vmovapd	%ymm7, 672(%rsp,%rax,2)
-	vpsrad	$31, %ymm4, %ymm3
-	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm9, %ymm3
-	vpshufd	$245, %ymm9, %ymm4      # ymm4 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm2, %ymm3
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vmovapd	%ymm2, 800(%rsp,%rcx)
+	vmovapd	%ymm9, 768(%rsp,%rcx)
+	vpsrad	$31, %ymm5, %ymm2
+	vpshufd	$245, %ymm5, %ymm5      # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
 	vpsrad	$31, %ymm8, %ymm2
-	vpshufd	$245, %ymm8, %ymm3      # ymm3 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm2, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
-	addq	$64, %rax
-	cmpq	%rax, %r15
-	jne	.LBB2_127
-.LBB2_128:                              # %safe_if_after_true816
-	leal	-1(%r11), %eax
+	vpshufd	$245, %ymm8, %ymm5      # ymm5 = ymm8[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpsrad	$31, %ymm4, %ymm2
+	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpsrad	$31, %ymm3, %ymm2
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	addq	%r14, %rdx
+	subq	$-128, %rcx
+	cmpq	%rcx, %rax
+	jne	.LBB2_142
+.LBB2_143:                              # %safe_if_after_true831
+	leal	-1(%r10), %eax
 	shlq	$7, %rax
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	736(%rsp,%rax), %ymm0, %ymm2
-	vpcmpeqd	%ymm1, %ymm1, %ymm1
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpcmpeqq	704(%rsp,%rax), %ymm0, %ymm3
-	vpxor	%ymm1, %ymm3, %ymm3
+	vpcmpeqq	864(%rsp,%rax), %ymm0, %ymm1
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm3
+	vpackssdw	%xmm3, %xmm1, %xmm1
+	vpcmpeqq	832(%rsp,%rax), %ymm0, %ymm3
+	vpxor	%ymm2, %ymm3, %ymm3
 	vextracti128	$1, %ymm3, %xmm4
 	vpackssdw	%xmm4, %xmm3, %xmm3
-	vpcmpeqq	672(%rsp,%rax), %ymm0, %ymm4
-	vinserti128	$1, %xmm2, %ymm3, %ymm11
-	vpxor	%ymm1, %ymm4, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpcmpeqq	640(%rsp,%rax), %ymm0, %ymm0
-	vpxor	%ymm1, %ymm0, %ymm0
-	vextracti128	$1, %ymm0, %xmm3
-	vpackssdw	%xmm3, %xmm0, %xmm0
-	vinserti128	$1, %xmm2, %ymm0, %ymm10
-	vmovdqa	160(%rsp), %ymm15       # 32-byte Reload
-	vpand	%ymm15, %ymm10, %ymm0
+	vpcmpeqq	800(%rsp,%rax), %ymm0, %ymm4
+	vinserti128	$1, %xmm1, %ymm3, %ymm3
+	vpxor	%ymm2, %ymm4, %ymm1
+	vextracti128	$1, %ymm1, %xmm4
+	vpackssdw	%xmm4, %xmm1, %xmm1
+	vpcmpeqq	768(%rsp,%rax), %ymm0, %ymm0
+	vpxor	%ymm2, %ymm0, %ymm0
+	vextracti128	$1, %ymm0, %xmm4
+	vpackssdw	%xmm4, %xmm0, %xmm0
+	vinserti128	$1, %xmm1, %ymm0, %ymm1
+	vmovdqa	256(%rsp), %ymm8        # 32-byte Reload
+	vpand	%ymm8, %ymm1, %ymm0
 	vmovmskps	%ymm0, %eax
-	vmovdqa	192(%rsp), %ymm14       # 32-byte Reload
-	vpand	%ymm14, %ymm11, %ymm0
+	vmovdqa	288(%rsp), %ymm14       # 32-byte Reload
+	vpand	%ymm14, %ymm3, %ymm0
 	vmovmskps	%ymm0, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB2_129
-# %bb.139:                              # %for_test888.preheader
-	vpbroadcastd	.LCPI2_5(%rip), %ymm4 # ymm4 = [1,1,1,1,1,1,1,1]
+	vmovdqa	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm1, 128(%rsp)        # 32-byte Spill
+	je	.LBB2_144
+# %bb.145:                              # %for_test903.preheader
+	movl	%r10d, %eax
+	negl	%eax
+	sbbl	%eax, %eax
+	vmovd	%eax, %xmm0
+	vpbroadcastd	%xmm0, %ymm0
+	vpand	%ymm3, %ymm0, %ymm5
+	vpand	%ymm1, %ymm0, %ymm6
+	vpand	%ymm8, %ymm6, %ymm0
+	vmovmskps	%ymm0, %eax
+	vpand	%ymm14, %ymm5, %ymm0
+	vmovmskps	%ymm0, %ecx
+	shll	$8, %ecx
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	orl	%eax, %ecx
+	je	.LBB2_146
+# %bb.149:                              # %for_loop905.preheader
+	vbroadcastss	.LCPI2_5(%rip), %ymm11 # ymm11 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vpbroadcastd	.LCPI2_5(%rip), %ymm15 # ymm15 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
 	xorl	%eax, %eax
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-	vmovdqa	.LCPI2_6(%rip), %xmm13  # xmm13 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vmovdqa	.LCPI2_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vmovdqa	%ymm4, %ymm9
-	vmovdqa	%ymm10, 32(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm11, 64(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm15, %ymm9
+	vmovdqa	%ymm15, %ymm10
+	vmovaps	%ymm11, %ymm12
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	vmovaps	256(%rsp), %ymm8        # 32-byte Reload
 	.p2align	4, 0x90
-.LBB2_140:                              # %for_test888
+.LBB2_150:                              # %for_loop905
                                         # =>This Inner Loop Header: Depth=1
-	cmpl	%r11d, %eax
-	sbbl	%ecx, %ecx
-	vmovd	%ecx, %xmm3
-	vpbroadcastd	%xmm3, %ymm3
-	vpshufd	$78, %xmm0, %xmm7       # xmm7 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm7, %ymm7
-	vpand	%ymm7, %ymm11, %ymm7
-	vpmovsxbd	%xmm0, %ymm11
-	vpand	%ymm11, %ymm10, %ymm10
-	vpand	%ymm3, %ymm7, %ymm11
-	vpand	%ymm3, %ymm10, %ymm10
-	vpand	%ymm15, %ymm10, %ymm3
-	vmovmskps	%ymm3, %ecx
-	vpand	%ymm14, %ymm11, %ymm3
-	vmovmskps	%ymm3, %edx
-	shll	$8, %edx
-	orl	%ecx, %edx
-	je	.LBB2_141
-# %bb.142:                              # %for_loop889
-                                        #   in Loop: Header=BB2_140 Depth=1
 	movl	%eax, %ecx
+	cltq
+	movq	%rax, %rdx
+	shlq	$6, %rdx
+	vpaddd	17152(%rsp,%rdx), %ymm9, %ymm13
+	vpaddd	17184(%rsp,%rdx), %ymm10, %ymm14
 	movq	%rcx, %rdx
 	shlq	$6, %rdx
-	vmovdqa	17024(%rsp,%rdx), %ymm3
-	vmovdqa	17056(%rsp,%rdx), %ymm7
-	vpaddd	%ymm4, %ymm3, %ymm14
-	vpaddd	%ymm7, %ymm9, %ymm15
-	vpmaxud	%ymm7, %ymm15, %ymm7
-	vpcmpeqd	%ymm7, %ymm15, %ymm7
-	vpbroadcastd	.LCPI2_5(%rip), %ymm8 # ymm8 = [1,1,1,1,1,1,1,1]
-	vpmaxud	%ymm3, %ymm14, %ymm3
-	vpcmpeqd	%ymm3, %ymm14, %ymm3
-	vpandn	%ymm8, %ymm3, %ymm3
-	vblendvps	%ymm10, %ymm3, %ymm4, %ymm4
-	vpandn	%ymm8, %ymm7, %ymm3
-	vblendvps	%ymm11, %ymm3, %ymm9, %ymm9
+	vpmaxud	17184(%rsp,%rdx), %ymm14, %ymm9
+	vpcmpeqd	%ymm9, %ymm14, %ymm10
+	vpmaxud	17152(%rsp,%rdx), %ymm13, %ymm9
+	vpcmpeqd	%ymm9, %ymm13, %ymm9
+	vpandn	%ymm15, %ymm9, %ymm9
+	vblendvps	%ymm6, %ymm9, %ymm11, %ymm9
+	vpandn	%ymm15, %ymm10, %ymm10
+	vblendvps	%ymm5, %ymm10, %ymm12, %ymm10
 	shlq	$7, %rcx
-	vpmovzxdq	%xmm14, %ymm3   # ymm3 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vextracti128	$1, %ymm14, %xmm7
-	vmovdqa	192(%rsp), %ymm14       # 32-byte Reload
-	vpmovzxdq	%xmm7, %ymm7    # ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero
-	vpmovzxdq	%xmm15, %ymm8   # ymm8 = xmm15[0],zero,xmm15[1],zero,xmm15[2],zero,xmm15[3],zero
-	vextracti128	$1, %ymm15, %xmm2
-	vmovdqa	160(%rsp), %ymm15       # 32-byte Reload
+	vpmovzxdq	%xmm14, %ymm11  # ymm11 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vextracti128	$1, %ymm14, %xmm2
+	vmovaps	288(%rsp), %ymm14       # 32-byte Reload
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpcmpeqq	736(%rsp,%rcx), %ymm2, %ymm2
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm5
-	vpcmpeqq	704(%rsp,%rcx), %ymm8, %ymm8
-	vpackssdw	%xmm5, %xmm2, %xmm2
-	vpxor	%ymm1, %ymm8, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpackssdw	%xmm2, %xmm5, %xmm2
-	vpcmpeqq	672(%rsp,%rcx), %ymm7, %ymm5
-	vpxor	%ymm1, %ymm5, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpcmpeqq	640(%rsp,%rcx), %ymm3, %ymm3
-	vpxor	%ymm1, %ymm3, %ymm3
-	vextracti128	$1, %ymm3, %xmm6
-	vpackssdw	%xmm6, %xmm3, %xmm3
-	vpackssdw	%xmm5, %xmm3, %xmm3
-	vpacksswb	%xmm2, %xmm3, %xmm2
-	vextracti128	$1, %ymm10, %xmm3
-	vpshufb	%xmm13, %xmm3, %xmm3
-	vpshufb	%xmm13, %xmm10, %xmm5
-	vpunpckldq	%xmm3, %xmm5, %xmm3 # xmm3 = xmm5[0],xmm3[0],xmm5[1],xmm3[1]
-	vextracti128	$1, %ymm11, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm11, %xmm6
-	vpunpckldq	%xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0],xmm5[0],xmm6[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm3, %xmm3 # xmm3 = xmm3[0,1],xmm5[2,3]
-	vpand	%xmm3, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	.LCPI2_8(%rip), %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpcmpgtb	%xmm2, %xmm3, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%eax
-	jmp	.LBB2_140
-.LBB2_141:
-	vmovdqa	64(%rsp), %ymm11        # 32-byte Reload
-	vmovdqa	32(%rsp), %ymm10        # 32-byte Reload
-	jmp	.LBB2_130
-.LBB2_129:
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-.LBB2_130:                              # %safe_if_after_true880
-	vpandn	%ymm15, %ymm10, %ymm2
-	vmovmskps	%ymm2, %eax
-	vpandn	%ymm14, %ymm11, %ymm2
-	vmovmskps	%ymm2, %ecx
-	shll	$8, %ecx
-	orl	%eax, %ecx
-	je	.LBB2_131
-# %bb.143:                              # %safe_if_run_false953
-	vpxor	%ymm1, %ymm10, %ymm3
-	vpbroadcastq	.LCPI2_9(%rip), %ymm2 # ymm2 = [1,1,1,1]
-	vpcmpeqq	736(%rsp), %ymm2, %ymm4
-	vpcmpeqq	704(%rsp), %ymm2, %ymm5
-	vpxor	%ymm1, %ymm11, %ymm1
-	vpackssdw	%ymm4, %ymm5, %ymm4
-	vpcmpeqq	672(%rsp), %ymm2, %ymm5
-	vpermq	$216, %ymm4, %ymm4      # ymm4 = ymm4[0,2,1,3]
-	vpcmpeqq	640(%rsp), %ymm2, %ymm2
-	vpackssdw	%ymm5, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vpackssdw	%ymm4, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vextracti128	$1, %ymm2, %xmm4
-	vpacksswb	%xmm4, %xmm2, %xmm8
+	vpmovzxdq	%xmm13, %ymm12  # ymm12 = xmm13[0],zero,xmm13[1],zero,xmm13[2],zero,xmm13[3],zero
+	vextracti128	$1, %ymm13, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpcmpeqq	800(%rsp,%rcx), %ymm3, %ymm3
 	vextracti128	$1, %ymm3, %xmm4
-	vmovdqa	.LCPI2_6(%rip), %xmm10  # xmm10 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm6
-	vpunpckldq	%xmm4, %xmm6, %xmm6 # xmm6 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm7
-	vmovdqa	.LCPI2_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm12, %xmm7, %xmm7
-	vpshufb	%xmm12, %xmm1, %xmm5
-	vpunpckldq	%xmm7, %xmm5, %xmm5 # xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-	vpblendd	$12, %xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0,1],xmm5[2,3]
-	vpsllw	$7, %xmm5, %xmm5
-	vpblendvb	%xmm5, %xmm8, %xmm0, %xmm0
-	movl	$1, %eax
-	vpxor	%xmm13, %xmm13, %xmm13
-	vpcmpeqd	%ymm6, %ymm6, %ymm6
-	vmovdqa	.LCPI2_8(%rip), %xmm8   # xmm8 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-	vpxor	%xmm9, %xmm9, %xmm9
-	.p2align	4, 0x90
-.LBB2_144:                              # %for_test963
-                                        # =>This Inner Loop Header: Depth=1
-	cmpl	%r11d, %eax
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vpcmpeqq	768(%rsp,%rcx), %ymm12, %ymm4
+	vextracti128	$1, %ymm4, %xmm7
+	vpackssdw	%xmm7, %xmm4, %xmm4
+	vpcmpeqq	864(%rsp,%rcx), %ymm2, %ymm2
+	vinserti128	$1, %xmm3, %ymm4, %ymm3
+	vextracti128	$1, %ymm2, %xmm4
+	vpcmpeqq	832(%rsp,%rcx), %ymm11, %ymm7
+	vpackssdw	%xmm4, %xmm2, %xmm2
+	vextracti128	$1, %ymm7, %xmm4
+	vpackssdw	%xmm4, %xmm7, %xmm4
+	vinserti128	$1, %xmm2, %ymm4, %ymm2
+	vpandn	%ymm5, %ymm2, %ymm2
+	vpandn	%ymm6, %ymm3, %ymm3
+	vpxor	%xmm4, %xmm4, %xmm4
+	vblendvps	%ymm3, %ymm4, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm4, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r10d, %eax
 	sbbl	%ecx, %ecx
-	vmovd	%ecx, %xmm7
-	vpbroadcastd	%xmm7, %ymm7
-	vpshufd	$78, %xmm0, %xmm2       # xmm2 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm2, %ymm2
-	vpand	%ymm2, %ymm1, %ymm1
-	vpmovsxbd	%xmm0, %ymm2
-	vpand	%ymm2, %ymm3, %ymm2
-	vpand	%ymm7, %ymm1, %ymm1
-	vpand	%ymm7, %ymm2, %ymm3
-	vpand	%ymm3, %ymm15, %ymm2
+	vmovd	%ecx, %xmm2
+	vpbroadcastd	%xmm2, %ymm2
+	vpand	%ymm2, %ymm5, %ymm3
+	vandps	%ymm3, %ymm1, %ymm5
+	vpand	%ymm2, %ymm6, %ymm2
+	vandps	%ymm2, %ymm0, %ymm6
+	vandps	%ymm8, %ymm6, %ymm2
 	vmovmskps	%ymm2, %ecx
-	vpand	%ymm1, %ymm14, %ymm2
+	vandps	%ymm14, %ymm5, %ymm2
 	vmovmskps	%ymm2, %edx
 	shll	$8, %edx
 	orl	%ecx, %edx
-	je	.LBB2_131
-# %bb.145:                              # %for_loop964
-                                        #   in Loop: Header=BB2_144 Depth=1
+	vmovaps	%ymm9, %ymm11
+	vmovaps	%ymm10, %ymm12
+	jne	.LBB2_150
+	jmp	.LBB2_147
+.LBB2_144:
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	jmp	.LBB2_147
+.LBB2_146:
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	vmovaps	256(%rsp), %ymm8        # 32-byte Reload
+.LBB2_147:                              # %safe_if_after_true895
+	vmovaps	128(%rsp), %ymm4        # 32-byte Reload
+	vandnps	%ymm8, %ymm4, %ymm5
+	vmovmskps	%ymm5, %eax
+	vmovdqa	160(%rsp), %ymm3        # 32-byte Reload
+	vpandn	%ymm14, %ymm3, %ymm5
+	vmovmskps	%ymm5, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	vmovaps	%ymm8, %ymm9
+	je	.LBB2_148
+# %bb.151:                              # %safe_if_run_false967
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vxorps	%ymm2, %ymm4, %ymm4
+	vpxor	%ymm2, %ymm3, %ymm2
+	vpbroadcastq	.LCPI2_6(%rip), %ymm3 # ymm3 = [1,1,1,1]
+	vpcmpeqq	864(%rsp), %ymm3, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	832(%rsp), %ymm3, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	800(%rsp), %ymm3, %ymm7
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vextracti128	$1, %ymm7, %xmm6
+	vpcmpeqq	768(%rsp), %ymm3, %ymm3
+	vpackssdw	%xmm6, %xmm7, %xmm6
+	vextracti128	$1, %ymm3, %xmm7
+	vpackssdw	%xmm7, %xmm3, %xmm3
+	vinserti128	$1, %xmm6, %ymm3, %ymm3
+	vblendvps	%ymm4, %ymm3, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm5, %ymm1, %ymm1
+	xorl	%eax, %eax
+	cmpl	$1, %r10d
+	seta	%al
+	negl	%eax
+	vmovd	%eax, %xmm3
+	vpbroadcastd	%xmm3, %ymm3
+	vandps	%ymm0, %ymm4, %ymm4
+	vandps	%ymm1, %ymm2, %ymm2
+	vandps	%ymm3, %ymm2, %ymm2
+	vandps	%ymm3, %ymm4, %ymm3
+	vandps	%ymm9, %ymm3, %ymm4
+	vmovmskps	%ymm4, %eax
+	vandps	%ymm14, %ymm2, %ymm4
+	vmovmskps	%ymm4, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB2_148
+# %bb.152:                              # %for_loop979.preheader
+	movl	$1, %eax
+	vxorps	%xmm4, %xmm4, %xmm4
+	.p2align	4, 0x90
+.LBB2_153:                              # %for_loop979
+                                        # =>This Inner Loop Header: Depth=1
 	movl	%eax, %ecx
 	shlq	$7, %rcx
-	vpcmpeqq	736(%rsp,%rcx), %ymm13, %ymm2
-	vpxor	%ymm6, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm7
-	vpcmpeqq	704(%rsp,%rcx), %ymm13, %ymm11
-	vpackssdw	%xmm7, %xmm2, %xmm2
-	vpxor	%ymm6, %ymm11, %ymm7
-	vextracti128	$1, %ymm7, %xmm4
-	vpackssdw	%xmm4, %xmm7, %xmm4
-	vpackssdw	%xmm2, %xmm4, %xmm2
-	vpcmpeqq	672(%rsp,%rcx), %ymm13, %ymm4
-	vpxor	%ymm6, %ymm4, %ymm4
-	vextracti128	$1, %ymm4, %xmm7
-	vpackssdw	%xmm7, %xmm4, %xmm4
-	vpcmpeqq	640(%rsp,%rcx), %ymm13, %ymm7
-	vpxor	%ymm6, %ymm7, %ymm7
-	vextracti128	$1, %ymm7, %xmm5
-	vpackssdw	%xmm5, %xmm7, %xmm5
-	vpackssdw	%xmm4, %xmm5, %xmm4
-	vpacksswb	%xmm2, %xmm4, %xmm2
-	vextracti128	$1, %ymm3, %xmm4
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm5
-	vpunpckldq	%xmm4, %xmm5, %xmm4 # xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm1, %xmm7
-	vpunpckldq	%xmm5, %xmm7, %xmm5 # xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm4, %xmm4 # xmm4 = xmm4[0,1],xmm5[2,3]
-	vpand	%xmm4, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	%xmm2, %xmm8, %xmm2
-	vpcmpgtb	%xmm2, %xmm9, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%eax
-	jmp	.LBB2_144
-.LBB2_131:                              # %if_done879
-	vpand	.LCPI2_10(%rip), %xmm0, %xmm0
-	vpshufd	$78, %xmm0, %xmm1       # xmm1 = xmm0[2,3,0,1]
-	vpmovzxbd	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero,xmm1[4],zero,zero,zero,xmm1[5],zero,zero,zero,xmm1[6],zero,zero,zero,xmm1[7],zero,zero,zero
-	vpmovzxbd	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
-	vmaskmovps	%ymm0, %ymm15, (%rbx)
-	vmaskmovps	%ymm1, %ymm14, 32(%rbx)
-.LBB2_70:                               # %if_done340
+	vpcmpeqq	800(%rsp,%rcx), %ymm4, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	768(%rsp,%rcx), %ymm4, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	864(%rsp,%rcx), %ymm4, %ymm7
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vextracti128	$1, %ymm7, %xmm6
+	vpcmpeqq	832(%rsp,%rcx), %ymm4, %ymm8
+	vpackssdw	%xmm6, %xmm7, %xmm6
+	vextracti128	$1, %ymm8, %xmm7
+	vpackssdw	%xmm7, %xmm8, %xmm7
+	vinserti128	$1, %xmm6, %ymm7, %ymm6
+	vpandn	%ymm2, %ymm6, %ymm6
+	vpandn	%ymm3, %ymm5, %ymm5
+	vblendvps	%ymm5, %ymm4, %ymm0, %ymm0
+	vblendvps	%ymm6, %ymm4, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r10d, %eax
+	sbbl	%ecx, %ecx
+	vmovd	%ecx, %xmm5
+	vpbroadcastd	%xmm5, %ymm5
+	vpand	%ymm5, %ymm2, %ymm2
+	vandps	%ymm2, %ymm1, %ymm2
+	vpand	%ymm5, %ymm3, %ymm3
+	vandps	%ymm3, %ymm0, %ymm3
+	vandps	%ymm9, %ymm3, %ymm5
+	vmovmskps	%ymm5, %ecx
+	vandps	%ymm14, %ymm2, %ymm5
+	vmovmskps	%ymm5, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	jne	.LBB2_153
+.LBB2_148:                              # %if_done894
+	vbroadcastss	.LCPI2_5(%rip), %ymm2 # ymm2 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vandps	%ymm2, %ymm0, %ymm0
+	vandps	%ymm2, %ymm1, %ymm1
+	vmaskmovps	%ymm0, %ymm9, (%r15)
+	vmaskmovps	%ymm1, %ymm14, 32(%r15)
+.LBB2_76:                               # %if_done348
 	leaq	-40(%rbp), %rsp
 	popq	%rbx
 	popq	%r12
@@ -5435,52 +5285,10 @@ fermat_test___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @fer
 	.section	.rodata.cst4,"aM",@progbits,4
 	.p2align	2
 .LCPI3_5:
-	.long	1                       # 0x1
-	.section	.rodata.cst16,"aM",@progbits,16
-	.p2align	4
-.LCPI3_6:
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI3_7:
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.byte	0                       # 0x0
-	.byte	4                       # 0x4
-	.byte	8                       # 0x8
-	.byte	12                      # 0xc
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-	.zero	1
-.LCPI3_8:
-	.zero	16,128
-.LCPI3_10:
-	.zero	16,1
-.LCPI3_11:
-	.zero	16
+	.long	1                       # float 1.40129846E-45
 	.section	.rodata.cst8,"aM",@progbits,8
 	.p2align	3
-.LCPI3_9:
+.LCPI3_6:
 	.quad	1                       # 0x1
 	.text
 	.globl	fermat_test
@@ -5497,36 +5305,31 @@ fermat_test:                            # @fermat_test
 	pushq	%rbx
 	andq	$-128, %rsp
 	subq	$45824, %rsp            # imm = 0xB300
-	movl	%r9d, 124(%rsp)         # 4-byte Spill
-	movl	%r8d, %r12d
-	movl	%r8d, %r11d
+                                        # kill: def $r9d killed $r9d def $r9
+	movq	%r9, 104(%rsp)          # 8-byte Spill
+                                        # kill: def $r8d killed $r8d def $r8
+	movq	%rcx, 96(%rsp)          # 8-byte Spill
 	testl	%r8d, %r8d
-	je	.LBB3_1
-# %bb.2:                                # %for_loop.lr.ph
-	vmovd	%r12d, %xmm0
+	je	.LBB3_7
+# %bb.1:                                # %for_loop.lr.ph
+	vmovd	%r8d, %xmm0
 	vpbroadcastd	%xmm0, %ymm1
 	vpmulld	.LCPI3_0(%rip), %ymm1, %ymm0
 	vpmulld	.LCPI3_1(%rip), %ymm1, %ymm1
-	cmpl	$1, %r12d
-	movq	%r11, 112(%rsp)         # 8-byte Spill
-	movq	%rcx, 128(%rsp)         # 8-byte Spill
-	jne	.LBB3_4
-# %bb.3:
+	cmpl	$1, %r8d
+	jne	.LBB3_3
+# %bb.2:
 	xorl	%eax, %eax
-	jmp	.LBB3_7
-.LBB3_1:
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	jmp	.LBB3_58
-.LBB3_4:                                # %for_loop.lr.ph.new
-	movl	%r12d, %r8d
-	andl	$1, %r8d
-	movl	%r12d, %r9d
-	subl	%r8d, %r9d
+	jmp	.LBB3_6
+.LBB3_3:                                # %for_loop.lr.ph.new
+	movl	%r8d, %r10d
+	andl	$1, %r10d
+	movl	%r8d, %r9d
+	subl	%r10d, %r9d
 	movl	$64, %ecx
 	xorl	%eax, %eax
 	.p2align	4, 0x90
-.LBB3_5:                                # %for_loop
+.LBB3_4:                                # %for_loop
                                         # =>This Inner Loop Header: Depth=1
 	vmovd	%eax, %xmm2
 	vpbroadcastd	%xmm2, %ymm2
@@ -5534,69 +5337,69 @@ fermat_test:                            # @fermat_test
 	vpaddd	%ymm0, %ymm2, %ymm2
 	vpslld	$2, %ymm2, %ymm2
 	vpslld	$2, %ymm3, %ymm3
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdi,%ymm3), %ymm5
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpgatherdd	%ymm4, (%rdi,%ymm2), %ymm6
-	vmovdqa	%ymm6, 8800(%rsp,%rcx)
-	vmovdqa	%ymm5, 8768(%rsp,%rcx)
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm4, (%rdx,%ymm3), %ymm5
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
 	vpxor	%xmm4, %xmm4, %xmm4
-	vpgatherdd	%ymm3, (%rdx,%ymm2), %ymm4
-	vpmovzxdq	%xmm5, %ymm2    # ymm2 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vextracti128	$1, %ymm5, %xmm3
-	vpmovzxdq	%xmm4, %ymm5    # ymm5 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdi,%ymm3), %ymm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	vpcmpeqd	%ymm6, %ymm6, %ymm6
+	vpgatherdd	%ymm6, (%rdi,%ymm2), %ymm5
+	vmovdqa	%ymm5, 8800(%rsp,%rcx)
+	vmovdqa	%ymm4, 8768(%rsp,%rcx)
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm3), %ymm4
+	vpxor	%xmm3, %xmm3, %xmm3
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm2), %ymm3
+	vpmovzxdq	%xmm4, %ymm2    # ymm2 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
 	vextracti128	$1, %ymm4, %xmm4
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpmovzxdq	%xmm3, %ymm5    # ymm5 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	leal	1(%rax), %ebx
+	vextracti128	$1, %ymm3, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vmovdqa	%ymm5, 576(%rsp,%rcx,2)
+	leal	1(%rax), %ebx
 	vmovd	%ebx, %xmm5
 	vpbroadcastd	%xmm5, %ymm5
 	vmovdqa	%ymm2, 512(%rsp,%rcx,2)
 	vpaddd	%ymm1, %ymm5, %ymm2
 	vpaddd	%ymm0, %ymm5, %ymm5
-	vmovdqa	%ymm4, 608(%rsp,%rcx,2)
-	vpslld	$2, %ymm5, %ymm4
+	vmovdqa	%ymm3, 608(%rsp,%rcx,2)
+	vpslld	$2, %ymm5, %ymm3
 	vpslld	$2, %ymm2, %ymm2
-	vmovdqa	%ymm3, 544(%rsp,%rcx,2)
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vmovdqa	%ymm4, 544(%rsp,%rcx,2)
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdi,%ymm2), %ymm4
 	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm3, (%rdi,%ymm2), %ymm5
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpgatherdd	%ymm3, (%rdi,%ymm4), %ymm6
-	vmovdqa	%ymm6, 8864(%rsp,%rcx)
-	vmovdqa	%ymm5, 8832(%rsp,%rcx)
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpgatherdd	%ymm3, (%rdx,%ymm2), %ymm5
-	vpcmpeqd	%ymm2, %ymm2, %ymm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpgatherdd	%ymm2, (%rdx,%ymm4), %ymm3
-	vpmovzxdq	%xmm5, %ymm2    # ymm2 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vextracti128	$1, %ymm5, %xmm4
+	vpcmpeqd	%ymm6, %ymm6, %ymm6
+	vpgatherdd	%ymm6, (%rdi,%ymm3), %ymm5
+	vmovdqa	%ymm5, 8864(%rsp,%rcx)
+	vmovdqa	%ymm4, 8832(%rsp,%rcx)
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm2), %ymm4
+	vpxor	%xmm2, %xmm2, %xmm2
+	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpgatherdd	%ymm5, (%rdx,%ymm3), %ymm2
+	vpmovzxdq	%xmm4, %ymm3    # ymm3 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vextracti128	$1, %ymm4, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vpmovzxdq	%xmm3, %ymm5    # ymm5 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vextracti128	$1, %ymm3, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpmovzxdq	%xmm2, %ymm5    # ymm5 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
+	vextracti128	$1, %ymm2, %xmm2
+	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vmovdqa	%ymm5, 704(%rsp,%rcx,2)
-	vmovdqa	%ymm3, 736(%rsp,%rcx,2)
-	vmovdqa	%ymm2, 640(%rsp,%rcx,2)
+	vmovdqa	%ymm2, 736(%rsp,%rcx,2)
+	vmovdqa	%ymm3, 640(%rsp,%rcx,2)
 	vmovdqa	%ymm4, 672(%rsp,%rcx,2)
 	addq	$2, %rax
 	subq	$-128, %rcx
 	cmpl	%eax, %r9d
-	jne	.LBB3_5
-# %bb.6:                                # %for_test.for_exit_crit_edge.unr-lcssa
-	testl	%r8d, %r8d
-	je	.LBB3_8
-.LBB3_7:                                # %for_loop.epil.preheader
+	jne	.LBB3_4
+# %bb.5:                                # %for_test.for_exit_crit_edge.unr-lcssa
+	testl	%r10d, %r10d
+	je	.LBB3_7
+.LBB3_6:                                # %for_loop.epil.preheader
 	movq	%rax, %rcx
 	shlq	$6, %rcx
 	vmovd	%eax, %xmm2
@@ -5605,289 +5408,299 @@ fermat_test:                            # @fermat_test
 	vpaddd	%ymm0, %ymm2, %ymm0
 	vpslld	$2, %ymm0, %ymm0
 	vpslld	$2, %ymm1, %ymm1
-	vpcmpeqd	%ymm2, %ymm2, %ymm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpgatherdd	%ymm2, (%rdi,%ymm1), %ymm3
-	vpcmpeqd	%ymm2, %ymm2, %ymm2
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpgatherdd	%ymm2, (%rdi,%ymm0), %ymm4
-	vmovdqa	%ymm4, 8864(%rsp,%rcx)
-	vmovdqa	%ymm3, 8832(%rsp,%rcx)
-	vpcmpeqd	%ymm2, %ymm2, %ymm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpgatherdd	%ymm2, (%rdx,%ymm1), %ymm3
-	vpcmpeqd	%ymm1, %ymm1, %ymm1
 	vpxor	%xmm2, %xmm2, %xmm2
-	vpgatherdd	%ymm1, (%rdx,%ymm0), %ymm2
+	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vpgatherdd	%ymm3, (%rdi,%ymm1), %ymm2
+	vpxor	%xmm3, %xmm3, %xmm3
+	vpcmpeqd	%ymm4, %ymm4, %ymm4
+	vpgatherdd	%ymm4, (%rdi,%ymm0), %ymm3
+	vmovdqa	%ymm3, 8864(%rsp,%rcx)
+	vmovdqa	%ymm2, 8832(%rsp,%rcx)
+	vpxor	%xmm2, %xmm2, %xmm2
+	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vpgatherdd	%ymm3, (%rdx,%ymm1), %ymm2
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	vpxor	%xmm3, %xmm3, %xmm3
+	vpgatherdd	%ymm1, (%rdx,%ymm0), %ymm3
 	shlq	$7, %rax
-	vpmovzxdq	%xmm3, %ymm0    # ymm0 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vextracti128	$1, %ymm3, %xmm1
+	vpmovzxdq	%xmm2, %ymm0    # ymm0 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
+	vextracti128	$1, %ymm2, %xmm1
 	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
-	vpmovzxdq	%xmm2, %ymm3    # ymm3 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vextracti128	$1, %ymm2, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vmovdqa	%ymm2, 736(%rsp,%rax)
-	vmovdqa	%ymm3, 704(%rsp,%rax)
+	vpmovzxdq	%xmm3, %ymm2    # ymm2 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vextracti128	$1, %ymm3, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vmovdqa	%ymm3, 736(%rsp,%rax)
+	vmovdqa	%ymm2, 704(%rsp,%rax)
 	vmovdqa	%ymm1, 672(%rsp,%rax)
 	vmovdqa	%ymm0, 640(%rsp,%rax)
-.LBB3_8:                                # %for_exit
-	vmovups	(%rsi), %ymm0
-	vmovaps	%ymm0, 288(%rsp)        # 32-byte Spill
-	vmovdqu	32(%rsi), %ymm0
-	vmovdqa	%ymm0, 256(%rsp)        # 32-byte Spill
-	testl	%r12d, %r12d
-	jle	.LBB3_14
-# %bb.9:                                # %for_loop33.lr.ph
-	movl	$-2147483648, %eax      # imm = 0x80000000
-	movl	124(%rsp), %ecx         # 4-byte Reload
-	shrxl	%ecx, %eax, %esi
-	vmovd	%ecx, %xmm0
-	vpbroadcastd	%xmm0, %ymm2
-	movl	$32, %eax
+.LBB3_7:                                # %for_exit
+	movabsq	$4294967296, %r14       # imm = 0x100000000
+	xorl	%ecx, %ecx
+	cmpl	$23, 104(%rsp)          # 4-byte Folded Reload
+	seta	%cl
+	movl	%r8d, %eax
 	subl	%ecx, %eax
-	vmovd	%eax, %xmm0
-	vpbroadcastd	%xmm0, %ymm7
-	leaq	8896(%rsp), %r9
-	movl	%r12d, %r13d
-	andl	$-2, %r13d
-	movq	112(%rsp), %rax         # 8-byte Reload
-	movq	%rax, %r14
-	shlq	$7, %r14
-	movq	%rax, %r15
-	shlq	$6, %r15
-	vmovdqa	%ymm2, 352(%rsp)        # 32-byte Spill
-	vmovdqa	%ymm7, 320(%rsp)        # 32-byte Spill
-	jmp	.LBB3_10
+	vmovups	(%rsi), %ymm0
+	vmovaps	%ymm0, 352(%rsp)        # 32-byte Spill
+	vmovdqu	32(%rsi), %ymm0
+	vmovdqa	%ymm0, 320(%rsp)        # 32-byte Spill
+	testl	%eax, %eax
+	jle	.LBB3_15
+# %bb.8:                                # %for_loop38.lr.ph
+	movq	104(%rsp), %rsi         # 8-byte Reload
+	cmpl	$24, %esi
+	setb	%cl
+	shlb	$5, %cl
+	movzbl	%cl, %ecx
+	leal	(%rcx,%rsi), %ecx
+	addl	$-24, %ecx
+	movl	$-2147483648, %edx      # imm = 0x80000000
+	shrxl	%ecx, %edx, %r10d
+	vmovd	%esi, %xmm0
+	vpbroadcastd	%xmm0, %ymm10
+	movl	$32, %ecx
+	subl	%esi, %ecx
+	vmovd	%ecx, %xmm0
+	vpbroadcastd	%xmm0, %ymm11
+	movl	%r8d, %r9d
+	movslq	%eax, %rcx
+	movl	%r8d, %eax
+	andl	$1, %eax
+	movl	%r8d, %r13d
+	subl	%eax, %r13d
+	movq	%r9, %r12
+	shlq	$7, %r12
+	vmovdqa	%ymm10, 288(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm11, 256(%rsp)       # 32-byte Spill
+	movq	%r9, 120(%rsp)          # 8-byte Spill
 	.p2align	4, 0x90
-.LBB3_13:                               # %for_test32.loopexit
-                                        #   in Loop: Header=BB3_10 Depth=1
-	movl	$-2147483648, %esi      # imm = 0x80000000
-	cmpq	$1, 152(%rsp)           # 8-byte Folded Reload
-	movq	144(%rsp), %rax         # 8-byte Reload
-	jle	.LBB3_14
-.LBB3_10:                               # %for_loop33
+.LBB3_9:                                # %for_loop38
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB3_36 Depth 2
+                                        #     Child Loop BB3_12 Depth 2
+                                        #       Child Loop BB3_27 Depth 3
+                                        #         Child Loop BB3_30 Depth 4
+                                        #       Child Loop BB3_40 Depth 3
                                         #       Child Loop BB3_37 Depth 3
-                                        #         Child Loop BB3_24 Depth 4
-                                        #       Child Loop BB3_29 Depth 3
-                                        #       Child Loop BB3_31 Depth 3
-                                        #         Child Loop BB3_33 Depth 4
-	movq	%rax, 152(%rsp)         # 8-byte Spill
-	leaq	-1(%rax), %rcx
+                                        #         Child Loop BB3_42 Depth 4
+	addq	$-1, %rcx
 	movq	%rcx, %rax
 	shlq	$6, %rax
 	vpcmpeqd	%ymm0, %ymm0, %ymm0
-	movq	%rcx, 144(%rsp)         # 8-byte Spill
+	movq	%rcx, 112(%rsp)         # 8-byte Spill
 	testq	%rcx, %rcx
-	je	.LBB3_12
-# %bb.11:                               # %for_loop33
-                                        #   in Loop: Header=BB3_10 Depth=1
+	je	.LBB3_11
+# %bb.10:                               # %for_loop38
+                                        #   in Loop: Header=BB3_9 Depth=1
 	vpxor	%xmm0, %xmm0, %xmm0
-.LBB3_12:                               # %for_loop33
-                                        #   in Loop: Header=BB3_10 Depth=1
+.LBB3_11:                               # %for_loop38
+                                        #   in Loop: Header=BB3_9 Depth=1
 	vpaddd	8864(%rsp,%rax), %ymm0, %ymm1
-	vmovdqa	%ymm1, 416(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm1, 448(%rsp)        # 32-byte Spill
 	vpaddd	8832(%rsp,%rax), %ymm0, %ymm0
-	vmovdqa	%ymm0, 384(%rsp)        # 32-byte Spill
-	jmp	.LBB3_36
+	vmovdqa	%ymm0, 416(%rsp)        # 32-byte Spill
 	.p2align	4, 0x90
-.LBB3_35:                               # %for_exit129
-                                        #   in Loop: Header=BB3_36 Depth=2
-	shrl	%esi
-	je	.LBB3_13
-.LBB3_36:                               # %for_loop50.lr.ph.split.us
-                                        #   Parent Loop BB3_10 Depth=1
+.LBB3_12:                               # %do_loop
+                                        #   Parent Loop BB3_9 Depth=1
                                         # =>  This Loop Header: Depth=2
+                                        #       Child Loop BB3_27 Depth 3
+                                        #         Child Loop BB3_30 Depth 4
+                                        #       Child Loop BB3_40 Depth 3
                                         #       Child Loop BB3_37 Depth 3
-                                        #         Child Loop BB3_24 Depth 4
-                                        #       Child Loop BB3_29 Depth 3
-                                        #       Child Loop BB3_31 Depth 3
-                                        #         Child Loop BB3_33 Depth 4
-	movl	%esi, 140(%rsp)         # 4-byte Spill
+                                        #         Child Loop BB3_42 Depth 4
+	movq	%r8, %r15
+	movl	%r10d, %ebx
 	leaq	29312(%rsp), %rdi
 	leaq	640(%rsp), %rsi
-	movl	%r12d, %edx
-	movq	%r9, %rbx
+	movl	%r15d, %edx
 	vzeroupper
 	callq	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	vpxor	%xmm15, %xmm15, %xmm15
-	movq	%rbx, %r9
+	movq	%r15, %r8
+	testl	%r15d, %r15d
+	je	.LBB3_13
+# %bb.26:                               # %for_loop70.lr.ph.us.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
 	movl	$1, %eax
 	xorl	%ecx, %ecx
-	movq	112(%rsp), %r8          # 8-byte Reload
-	vmovdqa	288(%rsp), %ymm12       # 32-byte Reload
-	vmovdqa	256(%rsp), %ymm13       # 32-byte Reload
-	vmovdqa	.LCPI3_2(%rip), %ymm14  # ymm14 = [0,2,4,6,4,6,6,7]
-	jmp	.LBB3_37
+	movl	%ebx, %r10d
+	movq	120(%rsp), %r9          # 8-byte Reload
+	leaq	8896(%rsp), %r11
+	vpxor	%xmm12, %xmm12, %xmm12
 	.p2align	4, 0x90
-.LBB3_38:                               #   in Loop: Header=BB3_37 Depth=3
-	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%esi, %esi
-.LBB3_26:                               # %for_loop61.us.epil.preheader
-                                        #   in Loop: Header=BB3_37 Depth=3
-	movq	%rsi, %rdi
-	shlq	$6, %rdi
-	vpmovzxdq	8864(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8880(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8832(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8848(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	vpmuludq	%ymm0, %ymm9, %ymm0
-	vpmuludq	%ymm1, %ymm8, %ymm1
-	addl	%ecx, %esi
-	shlq	$7, %rsi
-	vpaddq	29344(%rsp,%rsi), %ymm7, %ymm7
-	vpaddq	29312(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	%ymm3, %ymm4, %ymm3
-	vpaddq	29408(%rsp,%rsi), %ymm6, %ymm4
-	vpaddq	%ymm0, %ymm4, %ymm0
-	vpaddq	29376(%rsp,%rsi), %ymm5, %ymm4
-	vpaddq	%ymm1, %ymm4, %ymm1
-	vpblendd	$170, %ymm15, %ymm2, %ymm4 # ymm4 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm0, %ymm6 # ymm6 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm15[1],ymm1[2],ymm15[3],ymm1[4],ymm15[5],ymm1[6],ymm15[7]
-	vmovdqa	%ymm7, 29376(%rsp,%rsi)
-	vmovdqa	%ymm6, 29408(%rsp,%rsi)
-	vmovdqa	%ymm5, 29312(%rsp,%rsi)
-	vmovdqa	%ymm4, 29344(%rsp,%rsi)
-	vpsrlq	$32, %ymm0, %ymm6
-	vpsrlq	$32, %ymm1, %ymm5
-	vpsrlq	$32, %ymm2, %ymm7
-	vpsrlq	$32, %ymm3, %ymm4
-.LBB3_27:                               # %for_exit63.us
-                                        #   in Loop: Header=BB3_37 Depth=3
-	vmovdqa	%ymm7, 672(%rsp,%rdx)
-	vmovdqa	%ymm4, 640(%rsp,%rdx)
-	vmovdqa	%ymm5, 704(%rsp,%rdx)
-	vmovdqa	%ymm6, 736(%rsp,%rdx)
-	incq	%rcx
-	incq	%rax
-	cmpq	%r8, %rcx
-	je	.LBB3_28
-.LBB3_37:                               # %for_loop61.lr.ph.us
-                                        #   Parent Loop BB3_10 Depth=1
-                                        #     Parent Loop BB3_36 Depth=2
+.LBB3_27:                               # %for_loop70.lr.ph.us
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
                                         # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB3_24 Depth 4
+                                        #         Child Loop BB3_30 Depth 4
 	movq	%rcx, %rdx
 	shlq	$7, %rdx
-	vpermd	29376(%rsp,%rdx), %ymm14, %ymm0
-	vpermd	29408(%rsp,%rdx), %ymm14, %ymm1
-	vpermd	29312(%rsp,%rdx), %ymm14, %ymm2
+	vmovdqa	.LCPI3_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
+	vmovdqa	%ymm0, %ymm3
+	vpermd	29376(%rsp,%rdx), %ymm0, %ymm0
+	vpermd	29408(%rsp,%rdx), %ymm3, %ymm1
+	vpermd	29312(%rsp,%rdx), %ymm3, %ymm2
 	vinserti128	$1, %xmm1, %ymm0, %ymm0
-	vpermd	29344(%rsp,%rdx), %ymm14, %ymm1
+	vpermd	29344(%rsp,%rdx), %ymm3, %ymm1
 	vinserti128	$1, %xmm1, %ymm2, %ymm1
-	vpmulld	%ymm1, %ymm12, %ymm3
-	vpmulld	%ymm0, %ymm13, %ymm1
+	vpmulld	352(%rsp), %ymm1, %ymm3 # 32-byte Folded Reload
+	vpmulld	320(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
 	vextracti128	$1, %ymm1, %xmm0
 	vpmovzxdq	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,xmm0[1],zero,xmm0[2],zero,xmm0[3],zero
 	vpmovzxdq	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,xmm1[1],zero,xmm1[2],zero,xmm1[3],zero
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpxor	%xmm5, %xmm5, %xmm5
+	cmpl	$1, %r8d
+	jne	.LBB3_29
+# %bb.28:                               #   in Loop: Header=BB3_27 Depth=3
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm4, %xmm4, %xmm4
-	cmpl	$1, %r12d
-	je	.LBB3_38
-# %bb.23:                               # %for_loop61.lr.ph.us.new
-                                        #   in Loop: Header=BB3_37 Depth=3
-	movq	%r9, %rdi
+	xorl	%esi, %esi
+	jmp	.LBB3_32
+	.p2align	4, 0x90
+.LBB3_29:                               # %for_loop70.lr.ph.us.new
+                                        #   in Loop: Header=BB3_27 Depth=3
+	movq	%r11, %rdi
 	xorl	%esi, %esi
 	vpxor	%xmm7, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm5, %xmm5
 	vpxor	%xmm6, %xmm6, %xmm6
+	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB3_24:                               # %for_loop61.us
-                                        #   Parent Loop BB3_10 Depth=1
-                                        #     Parent Loop BB3_36 Depth=2
-                                        #       Parent Loop BB3_37 Depth=3
+.LBB3_30:                               # %for_loop70.us
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
+                                        #       Parent Loop BB3_27 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vpmovzxdq	-32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm0, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm2, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmovzxdq	-16(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm0, %ymm8, %ymm8
 	leal	(%rcx,%rsi), %ebx
 	shlq	$7, %rbx
-	vpaddq	29408(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm11, %ymm6
-	vpaddq	29312(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
+	vpaddq	29312(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm11, %ymm5, %ymm5
 	vpaddq	29344(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	29376(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm7, %ymm9, %ymm7
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm6, %ymm8 # ymm8 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm7, %ymm10 # ymm10 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 29376(%rsp,%rbx)
-	vmovdqa	%ymm10, 29344(%rsp,%rbx)
-	vmovdqa	%ymm9, 29312(%rsp,%rbx)
-	vmovdqa	%ymm8, 29408(%rsp,%rbx)
+	vpaddq	%ymm10, %ymm7, %ymm7
+	vpaddq	29376(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	29408(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	%ymm8, %ymm4, %ymm4
+	vpblendd	$170, %ymm12, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm7, %ymm9 # ymm9 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+	vmovdqa	%ymm11, 29408(%rsp,%rbx)
+	vmovdqa	%ymm10, 29376(%rsp,%rbx)
+	vmovdqa	%ymm9, 29344(%rsp,%rbx)
+	vmovdqa	%ymm8, 29312(%rsp,%rbx)
 	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm6, %ymm6
 	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm7, %ymm7
-	vpmovzxdq	32(%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rdi), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	(%rdi), %ymm8   # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmovzxdq	16(%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
 	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	vpmuludq	%ymm0, %ymm9, %ymm9
-	vpmuludq	%ymm1, %ymm8, %ymm8
+	vpmuludq	%ymm0, %ymm10, %ymm10
+	vpmuludq	%ymm1, %ymm9, %ymm9
+	vpmuludq	%ymm3, %ymm8, %ymm8
 	leal	(%rax,%rsi), %ebx
 	shlq	$7, %rbx
 	vpaddq	29344(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	29312(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	%ymm7, %ymm11, %ymm7
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vpaddq	29408(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm9, %ymm6
-	vpaddq	29376(%rsp,%rbx), %ymm5, %ymm5
-	vpaddq	%ymm5, %ymm8, %ymm5
-	vpblendd	$170, %ymm15, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm15[1],ymm7[2],ymm15[3],ymm7[4],ymm15[5],ymm7[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm15[1],ymm4[2],ymm15[3],ymm4[4],ymm15[5],ymm4[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm15[1],ymm6[2],ymm15[3],ymm6[4],ymm15[5],ymm6[6],ymm15[7]
-	vpblendd	$170, %ymm15, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm15[1],ymm5[2],ymm15[3],ymm5[4],ymm15[5],ymm5[6],ymm15[7]
-	vmovdqa	%ymm11, 29376(%rsp,%rbx)
-	vmovdqa	%ymm10, 29408(%rsp,%rbx)
-	vmovdqa	%ymm9, 29312(%rsp,%rbx)
+	vpaddq	29408(%rsp,%rbx), %ymm4, %ymm4
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vpaddq	29376(%rsp,%rbx), %ymm6, %ymm6
+	vpaddq	%ymm9, %ymm6, %ymm6
+	vpaddq	29312(%rsp,%rbx), %ymm5, %ymm5
+	vpaddq	%ymm8, %ymm5, %ymm5
+	vpblendd	$170, %ymm12, %ymm7, %ymm8 # ymm8 = ymm7[0],ymm12[1],ymm7[2],ymm12[3],ymm7[4],ymm12[5],ymm7[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm12[1],ymm4[2],ymm12[3],ymm4[4],ymm12[5],ymm4[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm12[1],ymm6[2],ymm12[3],ymm6[4],ymm12[5],ymm6[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm12[1],ymm5[2],ymm12[3],ymm5[4],ymm12[5],ymm5[6],ymm12[7]
+	vmovdqa	%ymm11, 29312(%rsp,%rbx)
+	vmovdqa	%ymm10, 29376(%rsp,%rbx)
+	vmovdqa	%ymm9, 29408(%rsp,%rbx)
 	vmovdqa	%ymm8, 29344(%rsp,%rbx)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm5, %ymm5
-	vpsrlq	$32, %ymm7, %ymm7
 	vpsrlq	$32, %ymm4, %ymm4
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm5, %ymm5
 	addq	$2, %rsi
 	subq	$-128, %rdi
 	cmpl	%esi, %r13d
-	jne	.LBB3_24
-# %bb.25:                               # %for_test60.for_exit63_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB3_37 Depth=3
-	testb	$1, %r12b
-	jne	.LBB3_26
-	jmp	.LBB3_27
-	.p2align	4, 0x90
-.LBB3_28:                               # %for_loop91.lr.ph
-                                        #   in Loop: Header=BB3_36 Depth=2
-	movl	140(%rsp), %esi         # 4-byte Reload
-	vmovd	%esi, %xmm0
+	jne	.LBB3_30
+# %bb.31:                               # %for_test68.for_exit71_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB3_27 Depth=3
+	testb	$1, %r8b
+	je	.LBB3_33
+.LBB3_32:                               # %for_loop70.us.epil.preheader
+                                        #   in Loop: Header=BB3_27 Depth=3
+	movq	%rsi, %rdi
+	shlq	$6, %rdi
+	vpmovzxdq	8880(%rsp,%rdi), %ymm8 # ymm8 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8864(%rsp,%rdi), %ymm9 # ymm9 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8848(%rsp,%rdi), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8832(%rsp,%rdi), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	vpmuludq	%ymm1, %ymm9, %ymm1
+	vpmuludq	%ymm0, %ymm8, %ymm0
+	addl	%ecx, %esi
+	shlq	$7, %rsi
+	vpaddq	29312(%rsp,%rsi), %ymm5, %ymm5
+	vpaddq	29344(%rsp,%rsi), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm5, %ymm3
+	vpaddq	%ymm2, %ymm7, %ymm2
+	vpaddq	29376(%rsp,%rsi), %ymm6, %ymm5
+	vpaddq	%ymm1, %ymm5, %ymm1
+	vpaddq	29408(%rsp,%rsi), %ymm4, %ymm4
+	vpaddq	%ymm0, %ymm4, %ymm0
+	vpblendd	$170, %ymm12, %ymm3, %ymm4 # ymm4 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm12[1],ymm2[2],ymm12[3],ymm2[4],ymm12[5],ymm2[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm1, %ymm6 # ymm6 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vpblendd	$170, %ymm12, %ymm0, %ymm7 # ymm7 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vmovdqa	%ymm7, 29408(%rsp,%rsi)
+	vmovdqa	%ymm6, 29376(%rsp,%rsi)
+	vmovdqa	%ymm5, 29344(%rsp,%rsi)
+	vmovdqa	%ymm4, 29312(%rsp,%rsi)
+	vpsrlq	$32, %ymm0, %ymm4
+	vpsrlq	$32, %ymm1, %ymm6
+	vpsrlq	$32, %ymm2, %ymm7
+	vpsrlq	$32, %ymm3, %ymm5
+.LBB3_33:                               # %for_exit71.us
+                                        #   in Loop: Header=BB3_27 Depth=3
+	vmovdqa	%ymm7, 672(%rsp,%rdx)
+	vmovdqa	%ymm5, 640(%rsp,%rdx)
+	vmovdqa	%ymm6, 704(%rsp,%rdx)
+	vmovdqa	%ymm4, 736(%rsp,%rdx)
+	addq	$1, %rcx
+	addq	$1, %rax
+	cmpq	%r9, %rcx
+	jne	.LBB3_27
+# %bb.34:                               # %for_test98.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
+	testl	%r8d, %r8d
+	vmovdqa	288(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	256(%rsp), %ymm11       # 32-byte Reload
+	je	.LBB3_35
+# %bb.39:                               # %for_loop100.lr.ph
+                                        #   in Loop: Header=BB3_12 Depth=2
+	vmovd	%r10d, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
-	vpand	384(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
-	vpand	416(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
-	vpcmpeqd	%ymm0, %ymm15, %ymm0
+	vpand	416(%rsp), %ymm0, %ymm1 # 32-byte Folded Reload
+	vpand	448(%rsp), %ymm0, %ymm0 # 32-byte Folded Reload
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpcmpeqd	%ymm13, %ymm0, %ymm0
 	vpcmpeqd	%ymm2, %ymm2, %ymm2
 	vpxor	%ymm2, %ymm0, %ymm0
-	vpcmpeqd	%ymm1, %ymm15, %ymm1
+	vpcmpeqd	%ymm13, %ymm1, %ymm1
 	vpxor	%ymm2, %ymm1, %ymm1
 	vmovdqa	.LCPI3_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
 	vpermd	%ymm1, %ymm2, %ymm4
@@ -5895,994 +5708,993 @@ fermat_test:                            # @fermat_test
 	vpermd	%ymm1, %ymm3, %ymm5
 	vpermd	%ymm0, %ymm2, %ymm6
 	vpermd	%ymm0, %ymm3, %ymm7
-	vpxor	%xmm11, %xmm11, %xmm11
-	movl	%r12d, %eax
-	xorl	%ecx, %ecx
-	vpxor	%xmm12, %xmm12, %xmm12
+	xorl	%eax, %eax
+	leaq	640(%rsp), %rcx
 	vpxor	%xmm14, %xmm14, %xmm14
-	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
 	.p2align	4, 0x90
-.LBB3_29:                               # %for_loop91
-                                        #   Parent Loop BB3_10 Depth=1
-                                        #     Parent Loop BB3_36 Depth=2
+.LBB3_40:                               # %for_loop100
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	movl	%eax, %edx
+	cltq
+	movq	%rax, %rdx
 	shlq	$7, %rdx
-	vmovdqa	29312(%rsp,%rdx), %ymm0
-	vmovdqa	29344(%rsp,%rdx), %ymm1
-	vmovdqa	29376(%rsp,%rdx), %ymm8
-	vmovdqa	29408(%rsp,%rdx), %ymm9
-	vpaddq	640(%rsp,%rcx), %ymm0, %ymm0
-	vpaddq	672(%rsp,%rcx), %ymm1, %ymm1
-	vpaddq	704(%rsp,%rcx), %ymm8, %ymm8
-	vpaddq	736(%rsp,%rcx), %ymm9, %ymm9
-	vpaddq	%ymm0, %ymm0, %ymm10
-	vblendvpd	%ymm4, %ymm10, %ymm0, %ymm0
-	vpaddq	%ymm1, %ymm1, %ymm10
-	vblendvpd	%ymm5, %ymm10, %ymm1, %ymm1
-	vpaddq	%ymm8, %ymm8, %ymm10
-	vblendvpd	%ymm6, %ymm10, %ymm8, %ymm8
-	vpaddq	%ymm9, %ymm9, %ymm10
-	vblendvpd	%ymm7, %ymm10, %ymm9, %ymm9
-	vpaddq	%ymm8, %ymm14, %ymm3
-	vpblendd	$170, %ymm15, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm15[1],ymm3[2],ymm15[3],ymm3[4],ymm15[5],ymm3[6],ymm15[7]
-	vmovdqa	%ymm8, 704(%rsp,%rcx)
-	vpaddq	%ymm9, %ymm13, %ymm2
-	vpblendd	$170, %ymm15, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm15[1],ymm2[2],ymm15[3],ymm2[4],ymm15[5],ymm2[6],ymm15[7]
-	vmovdqa	%ymm8, 736(%rsp,%rcx)
-	vpaddq	%ymm0, %ymm11, %ymm0
-	vpblendd	$170, %ymm15, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm15[1],ymm0[2],ymm15[3],ymm0[4],ymm15[5],ymm0[6],ymm15[7]
-	vmovdqa	%ymm8, 640(%rsp,%rcx)
-	vpaddq	%ymm1, %ymm12, %ymm1
-	vpblendd	$170, %ymm15, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm15[1],ymm1[2],ymm15[3],ymm1[4],ymm15[5],ymm1[6],ymm15[7]
-	vmovdqa	%ymm8, 672(%rsp,%rcx)
-	vpsrlq	$32, %ymm2, %ymm13
-	vpsrlq	$32, %ymm3, %ymm14
-	vpsrlq	$32, %ymm1, %ymm12
-	vpsrlq	$32, %ymm0, %ymm11
+	leal	(%r8,%rax), %esi
+	movslq	%esi, %rsi
+	shlq	$7, %rsi
+	vmovdqa	29312(%rsp,%rsi), %ymm0
+	vmovdqa	29344(%rsp,%rsi), %ymm1
+	vmovdqa	29376(%rsp,%rsi), %ymm2
+	vmovdqa	29408(%rsp,%rsi), %ymm3
+	vpaddq	640(%rsp,%rdx), %ymm0, %ymm0
+	vpaddq	672(%rsp,%rdx), %ymm1, %ymm1
+	vpaddq	704(%rsp,%rdx), %ymm2, %ymm2
+	vpaddq	736(%rsp,%rdx), %ymm3, %ymm3
+	vpaddq	%ymm0, %ymm0, %ymm8
+	vblendvpd	%ymm4, %ymm8, %ymm0, %ymm0
+	vpaddq	%ymm1, %ymm1, %ymm8
+	vblendvpd	%ymm5, %ymm8, %ymm1, %ymm1
+	vpaddq	%ymm2, %ymm2, %ymm8
+	vblendvpd	%ymm6, %ymm8, %ymm2, %ymm2
+	vpaddq	%ymm3, %ymm3, %ymm8
+	vblendvpd	%ymm7, %ymm8, %ymm3, %ymm3
+	vpaddq	%ymm3, %ymm9, %ymm3
+	vpblendd	$170, %ymm12, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm12[1],ymm3[2],ymm12[3],ymm3[4],ymm12[5],ymm3[6],ymm12[7]
+	vmovdqa	%ymm8, 96(%rcx)
+	vpaddq	%ymm2, %ymm15, %ymm2
+	vpblendd	$170, %ymm12, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm12[1],ymm2[2],ymm12[3],ymm2[4],ymm12[5],ymm2[6],ymm12[7]
+	vmovdqa	%ymm8, 64(%rcx)
+	vpaddq	%ymm1, %ymm14, %ymm1
+	vpblendd	$170, %ymm12, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm12[1],ymm1[2],ymm12[3],ymm1[4],ymm12[5],ymm1[6],ymm12[7]
+	vmovdqa	%ymm8, 32(%rcx)
+	vpaddq	%ymm0, %ymm13, %ymm0
+	vpblendd	$170, %ymm12, %ymm0, %ymm8 # ymm8 = ymm0[0],ymm12[1],ymm0[2],ymm12[3],ymm0[4],ymm12[5],ymm0[6],ymm12[7]
+	vmovdqa	%ymm8, (%rcx)
+	vpsrlq	$32, %ymm3, %ymm9
+	vpsrlq	$32, %ymm2, %ymm15
+	vpsrlq	$32, %ymm1, %ymm14
+	vpsrlq	$32, %ymm0, %ymm13
+	addl	$1, %eax
 	subq	$-128, %rcx
-	incl	%eax
-	cmpq	%rcx, %r14
-	jne	.LBB3_29
-# %bb.30:                               # %for_test126.preheader
-                                        #   in Loop: Header=BB3_36 Depth=2
-	vpcmpeqd	%ymm3, %ymm3, %ymm3
-	vpcmpeqd	%ymm4, %ymm4, %ymm4
-	vmovdqa	352(%rsp), %ymm2        # 32-byte Reload
-	vmovdqa	320(%rsp), %ymm7        # 32-byte Reload
+	cmpl	%eax, %r8d
+	jne	.LBB3_40
+	jmp	.LBB3_36
 	.p2align	4, 0x90
-.LBB3_31:                               # %for_test126
-                                        #   Parent Loop BB3_10 Depth=1
-                                        #     Parent Loop BB3_36 Depth=2
-                                        # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB3_33 Depth 4
-	vpcmpeqq	%ymm15, %ymm12, %ymm0
+.LBB3_13:                               #   in Loop: Header=BB3_12 Depth=2
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
+	movl	%ebx, %r10d
+	vmovdqa	288(%rsp), %ymm10       # 32-byte Reload
+	vmovdqa	256(%rsp), %ymm11       # 32-byte Reload
+	vpxor	%xmm12, %xmm12, %xmm12
+	jmp	.LBB3_36
+	.p2align	4, 0x90
+.LBB3_35:                               #   in Loop: Header=BB3_12 Depth=2
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm14, %xmm14, %xmm14
+	vpxor	%xmm15, %xmm15, %xmm15
+	vpxor	%xmm9, %xmm9, %xmm9
+.LBB3_36:                               # %for_test134.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
+	vmovdqa	%ymm9, 384(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm12, %ymm9, %ymm0
+	vpcmpeqd	%ymm3, %ymm3, %ymm3
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm15, %ymm11, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm3, %ymm0, %ymm3
-	vpcmpeqq	%ymm15, %ymm13, %ymm0
+	vpcmpeqq	%ymm12, %ymm15, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm4
+	vpcmpeqq	%ymm12, %ymm14, %ymm0
+	vpxor	%ymm3, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpackssdw	%xmm1, %xmm0, %xmm0
-	vpcmpeqq	%ymm15, %ymm14, %ymm1
-	vextracti128	$1, %ymm1, %xmm6
-	vpackssdw	%xmm6, %xmm1, %xmm1
-	vinserti128	$1, %xmm0, %ymm1, %ymm0
-	vpandn	%ymm4, %ymm0, %ymm4
-	vmovmskps	%ymm3, %eax
+	vpcmpeqq	%ymm12, %ymm13, %ymm1
+	vpxor	%ymm3, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm2
+	vmovmskps	%ymm2, %eax
 	vmovmskps	%ymm4, %ecx
 	shll	$8, %ecx
 	orl	%eax, %ecx
-	je	.LBB3_35
-# %bb.32:                               # %for_loop141.lr.ph
-                                        #   in Loop: Header=BB3_31 Depth=3
-	vmovdqa	%ymm14, 512(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm13, 544(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm12, 576(%rsp)       # 32-byte Spill
-	vmovdqa	%ymm11, 608(%rsp)       # 32-byte Spill
-	vmovaps	.LCPI3_3(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
-	vpermps	%ymm3, %ymm0, %ymm1
-	vmovaps	%ymm1, 192(%rsp)        # 32-byte Spill
-	vmovaps	.LCPI3_4(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
-	vmovaps	%ymm3, 480(%rsp)        # 32-byte Spill
-	vpermps	%ymm3, %ymm1, %ymm3
-	vmovaps	%ymm3, 160(%rsp)        # 32-byte Spill
-	vpermps	%ymm4, %ymm0, %ymm0
-	vmovaps	%ymm0, 224(%rsp)        # 32-byte Spill
-	vmovaps	%ymm4, 448(%rsp)        # 32-byte Spill
-	vpermps	%ymm4, %ymm1, %ymm9
-	vmovdqa	%ymm2, %ymm6
+	je	.LBB3_44
+	.p2align	4, 0x90
+.LBB3_37:                               # %for_test148.preheader
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
+                                        # =>    This Loop Header: Depth=3
+                                        #         Child Loop BB3_42 Depth 4
+	vmovdqa	.LCPI3_3(%rip), %ymm0   # ymm0 = [0,0,1,1,2,2,3,3]
+	vpermd	%ymm2, %ymm0, %ymm3
+	vmovdqa	.LCPI3_4(%rip), %ymm1   # ymm1 = [4,4,5,5,6,6,7,7]
+	vpermd	%ymm2, %ymm1, %ymm5
+	vpermd	%ymm4, %ymm0, %ymm0
+	vpermd	%ymm4, %ymm1, %ymm1
+	testl	%r8d, %r8d
+	vmovdqa	%ymm13, 608(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm14, 576(%rsp)       # 32-byte Spill
+	vmovdqa	%ymm15, 544(%rsp)       # 32-byte Spill
+	vmovaps	%ymm4, 512(%rsp)        # 32-byte Spill
+	vmovaps	%ymm2, 480(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm1, 160(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm0, 128(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm5, 224(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm3, 192(%rsp)        # 32-byte Spill
+	vmovdqa	%ymm11, %ymm8
 	vpxor	%xmm11, %xmm11, %xmm11
-	movl	$0, %eax
-	vpxor	%xmm10, %xmm10, %xmm10
-	vpxor	%xmm12, %xmm12, %xmm12
+	je	.LBB3_38
+# %bb.41:                               # %for_loop150.preheader
+                                        #   in Loop: Header=BB3_37 Depth=3
+	xorl	%eax, %eax
+	xorl	%ecx, %ecx
 	vpxor	%xmm13, %xmm13, %xmm13
-	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vmovdqa	%ymm10, %ymm7
+	vpxor	%xmm10, %xmm10, %xmm10
 	vpxor	%xmm15, %xmm15, %xmm15
 	vpxor	%xmm14, %xmm14, %xmm14
 	.p2align	4, 0x90
-.LBB3_33:                               # %for_loop141
-                                        #   Parent Loop BB3_10 Depth=1
-                                        #     Parent Loop BB3_36 Depth=2
-                                        #       Parent Loop BB3_31 Depth=3
+.LBB3_42:                               # %for_loop150
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
+                                        #       Parent Loop BB3_37 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	vmovdqa	640(%rsp,%rax,2), %ymm2
-	vmovdqa	8832(%rsp,%rax), %ymm0
-	vmovdqa	8864(%rsp,%rax), %ymm1
-	vpsllvd	%ymm6, %ymm0, %ymm3
-	vpor	%ymm3, %ymm15, %ymm3
-	vpsllvd	%ymm6, %ymm1, %ymm15
-	vmovdqa	736(%rsp,%rax,2), %ymm4
+	vmovdqa	640(%rsp,%rax), %ymm2
+	vmovdqa	672(%rsp,%rax), %ymm3
+	movq	%rcx, %rdx
+	sarq	$26, %rdx
+	vmovdqa	8832(%rsp,%rdx), %ymm0
+	vmovdqa	8864(%rsp,%rdx), %ymm1
+	vpsllvd	%ymm7, %ymm0, %ymm4
+	vpor	%ymm15, %ymm4, %ymm4
+	vpsllvd	%ymm7, %ymm1, %ymm15
 	vpor	%ymm14, %ymm15, %ymm14
-	vextracti128	$1, %ymm14, %xmm5
+	vextracti128	$1, %ymm4, %xmm5
 	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpsubq	%ymm5, %ymm4, %ymm5
-	vpaddq	%ymm5, %ymm13, %ymm5
-	vmovdqa	704(%rsp,%rax,2), %ymm13
-	vpmovzxdq	%xmm14, %ymm14  # ymm14 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vpsubq	%ymm14, %ymm13, %ymm14
-	vpaddq	%ymm12, %ymm14, %ymm12
-	vpmovzxdq	%xmm3, %ymm14   # ymm14 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm14, %ymm2, %ymm14
-	vpaddq	%ymm11, %ymm14, %ymm11
-	vpblendd	$170, %ymm8, %ymm11, %ymm14 # ymm14 = ymm11[0],ymm8[1],ymm11[2],ymm8[3],ymm11[4],ymm8[5],ymm11[6],ymm8[7]
-	vmovapd	192(%rsp), %ymm15       # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm2, %ymm2
-	vmovdqa	672(%rsp,%rax,2), %ymm14
-	vextracti128	$1, %ymm3, %xmm3
-	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
-	vpsubq	%ymm3, %ymm14, %ymm3
-	vpaddq	%ymm3, %ymm10, %ymm3
-	vpblendd	$170, %ymm8, %ymm3, %ymm10 # ymm10 = ymm3[0],ymm8[1],ymm3[2],ymm8[3],ymm3[4],ymm8[5],ymm3[6],ymm8[7]
-	vmovapd	160(%rsp), %ymm15       # 32-byte Reload
-	vblendvpd	%ymm15, %ymm10, %ymm14, %ymm10
-	vpblendd	$170, %ymm8, %ymm12, %ymm14 # ymm14 = ymm12[0],ymm8[1],ymm12[2],ymm8[3],ymm12[4],ymm8[5],ymm12[6],ymm8[7]
-	vmovapd	224(%rsp), %ymm15       # 32-byte Reload
-	vblendvpd	%ymm15, %ymm14, %ymm13, %ymm13
-	vpblendd	$170, %ymm8, %ymm5, %ymm14 # ymm14 = ymm5[0],ymm8[1],ymm5[2],ymm8[3],ymm5[4],ymm8[5],ymm5[6],ymm8[7]
-	vblendvpd	%ymm9, %ymm14, %ymm4, %ymm4
-	vmovapd	%ymm13, 704(%rsp,%rax,2)
-	vmovapd	%ymm4, 736(%rsp,%rax,2)
-	vmovapd	%ymm2, 640(%rsp,%rax,2)
-	vpsrlvd	%ymm7, %ymm1, %ymm14
-	vpsrlvd	%ymm7, %ymm0, %ymm15
-	vmovapd	%ymm10, 672(%rsp,%rax,2)
-	vpsrad	$31, %ymm5, %ymm0
-	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm12, %ymm0
-	vpshufd	$245, %ymm12, %ymm1     # ymm1 = ymm12[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpsrad	$31, %ymm3, %ymm0
-	vpshufd	$245, %ymm3, %ymm1      # ymm1 = ymm3[1,1,3,3,5,5,7,7]
+	vpsubq	%ymm5, %ymm3, %ymm5
+	vpaddq	%ymm13, %ymm5, %ymm5
+	vmovdqa	704(%rsp,%rax), %ymm13
+	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm11, %ymm4, %ymm4
+	vpblendd	$170, %ymm9, %ymm4, %ymm11 # ymm11 = ymm4[0],ymm9[1],ymm4[2],ymm9[3],ymm4[4],ymm9[5],ymm4[6],ymm9[7]
+	vmovapd	192(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm11, %ymm2, %ymm2
+	vpblendd	$170, %ymm9, %ymm5, %ymm11 # ymm11 = ymm5[0],ymm9[1],ymm5[2],ymm9[3],ymm5[4],ymm9[5],ymm5[6],ymm9[7]
+	vmovapd	224(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm11, %ymm3, %ymm3
+	vpmovzxdq	%xmm14, %ymm11  # ymm11 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vpsubq	%ymm11, %ymm13, %ymm11
+	vpaddq	%ymm12, %ymm11, %ymm11
+	vpblendd	$170, %ymm9, %ymm11, %ymm12 # ymm12 = ymm11[0],ymm9[1],ymm11[2],ymm9[3],ymm11[4],ymm9[5],ymm11[6],ymm9[7]
+	vmovapd	128(%rsp), %ymm6        # 32-byte Reload
+	vblendvpd	%ymm6, %ymm12, %ymm13, %ymm12
+	vmovdqa	736(%rsp,%rax), %ymm13
+	vextracti128	$1, %ymm14, %xmm6
+	vpmovzxdq	%xmm6, %ymm6    # ymm6 = xmm6[0],zero,xmm6[1],zero,xmm6[2],zero,xmm6[3],zero
+	vpsubq	%ymm6, %ymm13, %ymm6
+	vpaddq	%ymm10, %ymm6, %ymm6
+	vpblendd	$170, %ymm9, %ymm6, %ymm10 # ymm10 = ymm6[0],ymm9[1],ymm6[2],ymm9[3],ymm6[4],ymm9[5],ymm6[6],ymm9[7]
+	vmovapd	160(%rsp), %ymm14       # 32-byte Reload
+	vblendvpd	%ymm14, %ymm10, %ymm13, %ymm10
+	vmovapd	%ymm10, 736(%rsp,%rax)
+	vmovapd	%ymm12, 704(%rsp,%rax)
+	vpsrlvd	%ymm8, %ymm1, %ymm14
+	vpsrlvd	%ymm8, %ymm0, %ymm15
+	vmovapd	%ymm3, 672(%rsp,%rax)
+	vmovapd	%ymm2, 640(%rsp,%rax)
+	vpsrad	$31, %ymm6, %ymm0
+	vpshufd	$245, %ymm6, %ymm1      # ymm1 = ymm6[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm10 # ymm10 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
 	vpsrad	$31, %ymm11, %ymm0
 	vpshufd	$245, %ymm11, %ymm1     # ymm1 = ymm11[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm12 # ymm12 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpsrad	$31, %ymm5, %ymm0
+	vpshufd	$245, %ymm5, %ymm1      # ymm1 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm13 # ymm13 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
+	vpsrad	$31, %ymm4, %ymm0
+	vpshufd	$245, %ymm4, %ymm1      # ymm1 = ymm4[1,1,3,3,5,5,7,7]
 	vpblendd	$170, %ymm0, %ymm1, %ymm11 # ymm11 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	addq	$64, %rax
-	cmpq	%rax, %r15
-	jne	.LBB3_33
-# %bb.34:                               # %for_exit143
-                                        #   in Loop: Header=BB3_31 Depth=3
-	vmovdqa	544(%rsp), %ymm1        # 32-byte Reload
-	vpaddq	%ymm1, %ymm13, %ymm0
-	vmovdqa	%ymm1, %ymm13
-	vmovdqa	512(%rsp), %ymm14       # 32-byte Reload
-	vpaddq	%ymm14, %ymm12, %ymm1
-	vmovdqa	576(%rsp), %ymm12       # 32-byte Reload
-	vpaddq	%ymm12, %ymm10, %ymm2
-	vmovdqa	608(%rsp), %ymm4        # 32-byte Reload
-	vpaddq	%ymm4, %ymm11, %ymm3
-	vmovdqa	%ymm4, %ymm11
-	vmovapd	192(%rsp), %ymm4        # 32-byte Reload
-	vblendvpd	%ymm4, %ymm3, %ymm11, %ymm11
-	vmovapd	160(%rsp), %ymm3        # 32-byte Reload
-	vblendvpd	%ymm3, %ymm2, %ymm12, %ymm12
-	vmovapd	224(%rsp), %ymm2        # 32-byte Reload
-	vblendvpd	%ymm2, %ymm1, %ymm14, %ymm14
-	vblendvpd	%ymm9, %ymm0, %ymm13, %ymm13
-	vmovdqa	%ymm6, %ymm2
-	vpxor	%xmm15, %xmm15, %xmm15
-	vmovaps	480(%rsp), %ymm3        # 32-byte Reload
-	vmovaps	448(%rsp), %ymm4        # 32-byte Reload
-	jmp	.LBB3_31
-.LBB3_14:                               # %for_test188.preheader
-	testl	%r12d, %r12d
-	je	.LBB3_15
-# %bb.16:                               # %for_loop189.lr.ph
-	leal	-1(%r12), %r8d
-	movl	%r12d, %ecx
-	andl	$3, %ecx
-	cmpl	$3, %r8d
-	jae	.LBB3_50
-# %bb.17:
-	xorl	%eax, %eax
-	movq	112(%rsp), %r11         # 8-byte Reload
-	jmp	.LBB3_18
-.LBB3_15:
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm5, %xmm5, %xmm5
-	movq	128(%rsp), %rcx         # 8-byte Reload
-	movq	112(%rsp), %r11         # 8-byte Reload
-	jmp	.LBB3_58
-.LBB3_50:                               # %for_loop189.lr.ph.new
-	movl	%r12d, %edx
-	subl	%ecx, %edx
-	movl	$384, %esi              # imm = 0x180
-	xorl	%eax, %eax
-	vpxor	%xmm0, %xmm0, %xmm0
-	movq	112(%rsp), %r11         # 8-byte Reload
+	addq	%r14, %rcx
+	subq	$-128, %rax
+	cmpq	%rax, %r12
+	jne	.LBB3_42
+	jmp	.LBB3_43
 	.p2align	4, 0x90
-.LBB3_51:                               # %for_loop189
-                                        # =>This Inner Loop Header: Depth=1
-	vmovaps	256(%rsp,%rsi), %ymm1
-	vmovaps	320(%rsp,%rsi), %ymm2
-	vmovaps	352(%rsp,%rsi), %ymm3
-	vmovaps	%ymm1, 12544(%rsp,%rsi)
-	vmovaps	%ymm3, 12640(%rsp,%rsi)
-	vmovaps	%ymm2, 12608(%rsp,%rsi)
-	vmovaps	288(%rsp,%rsi), %ymm1
-	vmovaps	%ymm1, 12576(%rsp,%rsi)
-	leaq	(%r11,%rax), %rdi
-	movl	%edi, %ebx
-	shlq	$7, %rbx
-	vmovdqa	%ymm0, 12928(%rsp,%rbx)
-	vmovdqa	%ymm0, 13024(%rsp,%rbx)
-	vmovdqa	%ymm0, 12992(%rsp,%rbx)
-	vmovdqa	%ymm0, 12960(%rsp,%rbx)
-	vmovaps	416(%rsp,%rsi), %ymm1
-	vmovaps	448(%rsp,%rsi), %ymm2
-	vmovaps	480(%rsp,%rsi), %ymm3
-	vmovaps	384(%rsp,%rsi), %ymm4
-	vmovaps	%ymm4, 12672(%rsp,%rsi)
-	vmovaps	%ymm3, 12768(%rsp,%rsi)
-	vmovaps	%ymm2, 12736(%rsp,%rsi)
-	vmovaps	%ymm1, 12704(%rsp,%rsi)
-	leal	1(%rdi), %ebx
-	shlq	$7, %rbx
-	vmovdqa	%ymm0, 12928(%rsp,%rbx)
-	vmovdqa	%ymm0, 13024(%rsp,%rbx)
-	vmovdqa	%ymm0, 12992(%rsp,%rbx)
-	vmovdqa	%ymm0, 12960(%rsp,%rbx)
-	vmovaps	544(%rsp,%rsi), %ymm1
-	vmovaps	576(%rsp,%rsi), %ymm2
-	vmovaps	608(%rsp,%rsi), %ymm3
-	vmovaps	512(%rsp,%rsi), %ymm4
-	vmovaps	%ymm4, 12800(%rsp,%rsi)
-	vmovaps	%ymm3, 12896(%rsp,%rsi)
-	vmovaps	%ymm2, 12864(%rsp,%rsi)
-	vmovaps	%ymm1, 12832(%rsp,%rsi)
-	leal	2(%rdi), %ebx
-	shlq	$7, %rbx
-	vmovdqa	%ymm0, 12928(%rsp,%rbx)
-	vmovdqa	%ymm0, 13024(%rsp,%rbx)
-	vmovdqa	%ymm0, 12992(%rsp,%rbx)
-	vmovdqa	%ymm0, 12960(%rsp,%rbx)
-	vmovdqa	640(%rsp,%rsi), %ymm1
-	vmovdqa	672(%rsp,%rsi), %ymm2
-	vmovdqa	704(%rsp,%rsi), %ymm3
-	vmovdqa	736(%rsp,%rsi), %ymm4
-	vmovdqa	%ymm4, 13024(%rsp,%rsi)
-	vmovdqa	%ymm3, 12992(%rsp,%rsi)
-	vmovdqa	%ymm2, 12960(%rsp,%rsi)
-	vmovdqa	%ymm1, 12928(%rsp,%rsi)
-	addl	$3, %edi
-	shlq	$7, %rdi
-	vmovdqa	%ymm0, 13024(%rsp,%rdi)
-	vmovdqa	%ymm0, 12992(%rsp,%rdi)
-	vmovdqa	%ymm0, 12960(%rsp,%rdi)
-	vmovdqa	%ymm0, 12928(%rsp,%rdi)
-	addq	$4, %rax
-	addq	$512, %rsi              # imm = 0x200
-	cmpl	%eax, %edx
-	jne	.LBB3_51
-.LBB3_18:                               # %for_test188.for_test206.preheader_crit_edge.unr-lcssa
-	testl	%ecx, %ecx
-	vmovdqa	288(%rsp), %ymm14       # 32-byte Reload
-	vmovdqa	256(%rsp), %ymm15       # 32-byte Reload
-	je	.LBB3_21
-# %bb.19:                               # %for_loop189.epil.preheader
-	leal	(%r12,%rax), %edx
-	shlq	$7, %rax
+.LBB3_38:                               #   in Loop: Header=BB3_37 Depth=3
+	vpxor	%xmm13, %xmm13, %xmm13
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm12, %xmm12, %xmm12
+	vmovdqa	%ymm10, %ymm7
+	vpxor	%xmm10, %xmm10, %xmm10
+.LBB3_43:                               # %for_exit151
+                                        #   in Loop: Header=BB3_37 Depth=3
+	vmovdqa	384(%rsp), %ymm4        # 32-byte Reload
+	vpaddq	%ymm4, %ymm10, %ymm0
+	vmovdqa	544(%rsp), %ymm15       # 32-byte Reload
+	vpaddq	%ymm15, %ymm12, %ymm1
+	vmovdqa	576(%rsp), %ymm14       # 32-byte Reload
+	vpaddq	%ymm14, %ymm13, %ymm2
+	vmovdqa	608(%rsp), %ymm13       # 32-byte Reload
+	vpaddq	%ymm13, %ymm11, %ymm3
+	vmovapd	192(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm3, %ymm13, %ymm13
+	vmovapd	224(%rsp), %ymm3        # 32-byte Reload
+	vblendvpd	%ymm3, %ymm2, %ymm14, %ymm14
+	vmovapd	128(%rsp), %ymm2        # 32-byte Reload
+	vblendvpd	%ymm2, %ymm1, %ymm15, %ymm15
+	vmovapd	160(%rsp), %ymm1        # 32-byte Reload
+	vblendvpd	%ymm1, %ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm9, %ymm14, %ymm0
+	vextracti128	$1, %ymm0, %xmm1
+	vpackssdw	%xmm1, %xmm0, %xmm0
+	vpcmpeqq	%ymm9, %ymm13, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vinserti128	$1, %xmm0, %ymm1, %ymm0
+	vmovapd	%ymm4, 384(%rsp)        # 32-byte Spill
+	vpcmpeqq	%ymm9, %ymm4, %ymm1
+	vextracti128	$1, %ymm1, %xmm2
+	vpackssdw	%xmm2, %xmm1, %xmm1
+	vpcmpeqq	%ymm9, %ymm15, %ymm2
+	vextracti128	$1, %ymm2, %xmm3
+	vpackssdw	%xmm3, %xmm2, %xmm2
+	vinserti128	$1, %xmm1, %ymm2, %ymm1
+	vmovdqa	512(%rsp), %ymm4        # 32-byte Reload
+	vpandn	%ymm4, %ymm1, %ymm4
+	vmovdqa	480(%rsp), %ymm2        # 32-byte Reload
+	vpandn	%ymm2, %ymm0, %ymm2
+	vmovmskps	%ymm2, %eax
+	vmovmskps	%ymm4, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	vmovdqa	%ymm7, %ymm10
+	vmovdqa	%ymm8, %ymm11
+	jne	.LBB3_37
+.LBB3_44:                               # %for_exit137
+                                        #   in Loop: Header=BB3_12 Depth=2
+	shrl	%r10d
+	jne	.LBB3_12
+# %bb.14:                               # %for_test36.loopexit
+                                        #   in Loop: Header=BB3_9 Depth=1
+	movl	$-2147483648, %r10d     # imm = 0x80000000
+	movq	112(%rsp), %rcx         # 8-byte Reload
+	testq	%rcx, %rcx
+	jg	.LBB3_9
+.LBB3_15:                               # %for_test196.preheader
+	testl	%r8d, %r8d
+	je	.LBB3_16
+# %bb.17:                               # %for_loop198.lr.ph
+	leal	-1(%r8), %ecx
+	movl	%r8d, %eax
+	andl	$3, %eax
+	cmpl	$3, %ecx
+	jae	.LBB3_53
+# %bb.18:
+	xorl	%ecx, %ecx
+	testl	%eax, %eax
+	jne	.LBB3_20
+	jmp	.LBB3_22
+.LBB3_53:                               # %for_loop198.lr.ph.new
+	movl	%r8d, %edx
+	subl	%eax, %edx
+	movl	%r8d, %r9d
+	movl	$384, %edi              # imm = 0x180
+	xorl	%ecx, %ecx
 	vpxor	%xmm0, %xmm0, %xmm0
 	.p2align	4, 0x90
-.LBB3_20:                               # %for_loop189.epil
+.LBB3_54:                               # %for_loop198
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqa	640(%rsp,%rax), %ymm1
-	vmovdqa	672(%rsp,%rax), %ymm2
-	vmovdqa	704(%rsp,%rax), %ymm3
-	vmovdqa	736(%rsp,%rax), %ymm4
-	vmovdqa	%ymm3, 12992(%rsp,%rax)
-	vmovdqa	%ymm4, 13024(%rsp,%rax)
-	vmovdqa	%ymm1, 12928(%rsp,%rax)
-	vmovdqa	%ymm2, 12960(%rsp,%rax)
-	movl	%edx, %esi
+	vmovaps	288(%rsp,%rdi), %ymm1
+	vmovaps	320(%rsp,%rdi), %ymm2
+	vmovaps	352(%rsp,%rdi), %ymm3
+	vmovaps	%ymm3, 12640(%rsp,%rdi)
+	vmovaps	%ymm2, 12608(%rsp,%rdi)
+	vmovaps	%ymm1, 12576(%rsp,%rdi)
+	vmovaps	256(%rsp,%rdi), %ymm1
+	vmovaps	%ymm1, 12544(%rsp,%rdi)
+	leaq	(%r9,%rcx), %rbx
+	movl	%ebx, %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 13024(%rsp,%rsi)
+	vmovdqa	%ymm0, 12992(%rsp,%rsi)
+	vmovdqa	%ymm0, 12960(%rsp,%rsi)
+	vmovdqa	%ymm0, 12928(%rsp,%rsi)
+	vmovaps	384(%rsp,%rdi), %ymm1
+	vmovaps	416(%rsp,%rdi), %ymm2
+	vmovaps	448(%rsp,%rdi), %ymm3
+	vmovaps	480(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 12768(%rsp,%rdi)
+	vmovaps	%ymm3, 12736(%rsp,%rdi)
+	vmovaps	%ymm2, 12704(%rsp,%rdi)
+	vmovaps	%ymm1, 12672(%rsp,%rdi)
+	leal	1(%rbx), %esi
 	shlq	$7, %rsi
 	vmovdqa	%ymm0, 12992(%rsp,%rsi)
-	vmovdqa	%ymm0, 13024(%rsp,%rsi)
 	vmovdqa	%ymm0, 12928(%rsp,%rsi)
+	vmovdqa	%ymm0, 13024(%rsp,%rsi)
 	vmovdqa	%ymm0, 12960(%rsp,%rsi)
-	incl	%edx
-	subq	$-128, %rax
-	decl	%ecx
-	jne	.LBB3_20
-.LBB3_21:                               # %for_test206.preheader
-	testl	%r12d, %r12d
+	vmovaps	512(%rsp,%rdi), %ymm1
+	vmovaps	544(%rsp,%rdi), %ymm2
+	vmovaps	576(%rsp,%rdi), %ymm3
+	vmovaps	608(%rsp,%rdi), %ymm4
+	vmovaps	%ymm4, 12896(%rsp,%rdi)
+	vmovaps	%ymm3, 12864(%rsp,%rdi)
+	vmovaps	%ymm2, 12832(%rsp,%rdi)
+	vmovaps	%ymm1, 12800(%rsp,%rdi)
+	leal	2(%rbx), %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 13024(%rsp,%rsi)
+	vmovdqa	%ymm0, 12992(%rsp,%rsi)
+	vmovdqa	%ymm0, 12960(%rsp,%rsi)
+	vmovdqa	%ymm0, 12928(%rsp,%rsi)
+	vmovdqa	640(%rsp,%rdi), %ymm1
+	vmovdqa	672(%rsp,%rdi), %ymm2
+	vmovdqa	704(%rsp,%rdi), %ymm3
+	vmovdqa	736(%rsp,%rdi), %ymm4
+	vmovdqa	%ymm4, 13024(%rsp,%rdi)
+	vmovdqa	%ymm3, 12992(%rsp,%rdi)
+	vmovdqa	%ymm2, 12960(%rsp,%rdi)
+	vmovdqa	%ymm1, 12928(%rsp,%rdi)
+	addl	$3, %ebx
+	shlq	$7, %rbx
+	vmovdqa	%ymm0, 13024(%rsp,%rbx)
+	vmovdqa	%ymm0, 12992(%rsp,%rbx)
+	vmovdqa	%ymm0, 12960(%rsp,%rbx)
+	vmovdqa	%ymm0, 12928(%rsp,%rbx)
+	addq	$4, %rcx
+	addq	$512, %rdi              # imm = 0x200
+	cmpl	%ecx, %edx
+	jne	.LBB3_54
+# %bb.19:                               # %for_test196.for_test214.preheader_crit_edge.unr-lcssa
+	testl	%eax, %eax
 	je	.LBB3_22
-# %bb.39:                               # %for_loop207.lr.ph.split.us
+.LBB3_20:                               # %for_loop198.epil.preheader
+	leal	(%r8,%rcx), %edx
+	shlq	$7, %rcx
+	negl	%eax
+	vpxor	%xmm0, %xmm0, %xmm0
+	.p2align	4, 0x90
+.LBB3_21:                               # %for_loop198.epil
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqa	640(%rsp,%rcx), %ymm1
+	vmovdqa	672(%rsp,%rcx), %ymm2
+	vmovdqa	704(%rsp,%rcx), %ymm3
+	vmovdqa	736(%rsp,%rcx), %ymm4
+	vmovdqa	%ymm4, 13024(%rsp,%rcx)
+	vmovdqa	%ymm3, 12992(%rsp,%rcx)
+	vmovdqa	%ymm2, 12960(%rsp,%rcx)
+	vmovdqa	%ymm1, 12928(%rsp,%rcx)
+	movl	%edx, %esi
+	shlq	$7, %rsi
+	vmovdqa	%ymm0, 13024(%rsp,%rsi)
+	vmovdqa	%ymm0, 12992(%rsp,%rsi)
+	vmovdqa	%ymm0, 12960(%rsp,%rsi)
+	vmovdqa	%ymm0, 12928(%rsp,%rsi)
+	addl	$1, %edx
+	subq	$-128, %rcx
+	addl	$1, %eax
+	jne	.LBB3_21
+.LBB3_22:                               # %for_test214.preheader
+	testl	%r8d, %r8d
+	je	.LBB3_16
+# %bb.23:                               # %for_loop232.lr.ph.us.preheader
 	leaq	8896(%rsp), %r9
-	movl	%r12d, %edx
-	andl	$-2, %edx
+	movl	%r8d, %r15d
+	andl	$1, %r15d
+	movl	%r8d, %r11d
+	subl	%r15d, %r11d
 	movl	$1, %esi
 	xorl	%edi, %edi
 	vmovdqa	.LCPI3_2(%rip), %ymm0   # ymm0 = [0,2,4,6,4,6,6,7]
 	vpxor	%xmm1, %xmm1, %xmm1
-	jmp	.LBB3_40
+	movl	%r8d, %r10d
 	.p2align	4, 0x90
-.LBB3_41:                               #   in Loop: Header=BB3_40 Depth=1
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
-	vpxor	%xmm8, %xmm8, %xmm8
-	xorl	%eax, %eax
-.LBB3_45:                               # %for_loop223.us.epil.preheader
-                                        #   in Loop: Header=BB3_40 Depth=1
-	movq	%rax, %rcx
-	shlq	$6, %rcx
-	vpmovzxdq	8864(%rsp,%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8880(%rsp,%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8832(%rsp,%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	8848(%rsp,%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm4, %ymm13, %ymm4
-	vpmuludq	%ymm5, %ymm12, %ymm5
-	vpmuludq	%ymm2, %ymm11, %ymm2
-	vpmuludq	%ymm3, %ymm10, %ymm3
-	addl	%edi, %eax
-	shlq	$7, %rax
-	vpaddq	12960(%rsp,%rax), %ymm9, %ymm9
-	vpaddq	12928(%rsp,%rax), %ymm7, %ymm7
-	vpaddq	%ymm4, %ymm9, %ymm4
-	vpaddq	%ymm5, %ymm7, %ymm5
-	vpaddq	13024(%rsp,%rax), %ymm8, %ymm7
-	vpaddq	%ymm2, %ymm7, %ymm2
-	vpaddq	12992(%rsp,%rax), %ymm6, %ymm6
-	vpaddq	%ymm3, %ymm6, %ymm3
-	vpblendd	$170, %ymm1, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
-	vmovdqa	%ymm9, 12992(%rsp,%rax)
-	vmovdqa	%ymm8, 13024(%rsp,%rax)
-	vmovdqa	%ymm7, 12928(%rsp,%rax)
-	vmovdqa	%ymm6, 12960(%rsp,%rax)
-	vpsrlq	$32, %ymm2, %ymm8
-	vpsrlq	$32, %ymm3, %ymm6
-	vpsrlq	$32, %ymm4, %ymm9
-	vpsrlq	$32, %ymm5, %ymm7
-.LBB3_46:                               # %for_exit225.us
-                                        #   in Loop: Header=BB3_40 Depth=1
-	vmovdqa	%ymm9, 672(%rsp,%r10)
-	vmovdqa	%ymm7, 640(%rsp,%r10)
-	vmovdqa	%ymm6, 704(%rsp,%r10)
-	vmovdqa	%ymm8, 736(%rsp,%r10)
-	incq	%rdi
-	incq	%rsi
-	cmpq	%r11, %rdi
-	je	.LBB3_47
-.LBB3_40:                               # %for_loop223.lr.ph.us
+.LBB3_24:                               # %for_loop232.lr.ph.us
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB3_43 Depth 2
-	movq	%rdi, %r10
-	shlq	$7, %r10
-	vpermd	12992(%rsp,%r10), %ymm0, %ymm2
-	vpermd	13024(%rsp,%r10), %ymm0, %ymm3
-	vpermd	12928(%rsp,%r10), %ymm0, %ymm4
+                                        #     Child Loop BB3_46 Depth 2
+	movq	%rdi, %rax
+	shlq	$7, %rax
+	vpermd	12992(%rsp,%rax), %ymm0, %ymm2
+	vpermd	13024(%rsp,%rax), %ymm0, %ymm3
+	vpermd	12928(%rsp,%rax), %ymm0, %ymm4
 	vinserti128	$1, %xmm3, %ymm2, %ymm2
-	vpermd	12960(%rsp,%r10), %ymm0, %ymm3
+	vpermd	12960(%rsp,%rax), %ymm0, %ymm3
 	vinserti128	$1, %xmm3, %ymm4, %ymm3
-	vpmulld	%ymm3, %ymm14, %ymm5
-	vpmulld	%ymm2, %ymm15, %ymm3
+	vpmulld	352(%rsp), %ymm3, %ymm5 # 32-byte Folded Reload
+	vpmulld	320(%rsp), %ymm2, %ymm3 # 32-byte Folded Reload
 	vextracti128	$1, %ymm3, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
 	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
 	vextracti128	$1, %ymm5, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
 	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
-	vpxor	%xmm7, %xmm7, %xmm7
-	cmpl	$1, %r12d
-	je	.LBB3_41
-# %bb.42:                               # %for_loop223.lr.ph.us.new
-                                        #   in Loop: Header=BB3_40 Depth=1
-	movq	%r9, %rcx
-	xorl	%eax, %eax
-	vpxor	%xmm9, %xmm9, %xmm9
-	vpxor	%xmm6, %xmm6, %xmm6
 	vpxor	%xmm8, %xmm8, %xmm8
-	.p2align	4, 0x90
-.LBB3_43:                               # %for_loop223.us
-                                        #   Parent Loop BB3_40 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	vpmovzxdq	-32(%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-48(%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-64(%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	-16(%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm2, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm4, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rdi,%rax), %ebx
-	shlq	$7, %rbx
-	vpaddq	13024(%rsp,%rbx), %ymm8, %ymm8
-	vpaddq	%ymm13, %ymm8, %ymm8
-	vpaddq	12928(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	12960(%rsp,%rbx), %ymm9, %ymm9
-	vpaddq	12992(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm11, %ymm9, %ymm9
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 12992(%rsp,%rbx)
-	vmovdqa	%ymm12, 12960(%rsp,%rbx)
-	vmovdqa	%ymm11, 12928(%rsp,%rbx)
-	vmovdqa	%ymm10, 13024(%rsp,%rbx)
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm7, %ymm7
-	vpsrlq	$32, %ymm9, %ymm9
-	vpmovzxdq	32(%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	48(%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	(%rcx), %ymm12  # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmovzxdq	16(%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
-	vpmuludq	%ymm4, %ymm13, %ymm13
-	vpmuludq	%ymm5, %ymm12, %ymm12
-	vpmuludq	%ymm2, %ymm11, %ymm11
-	vpmuludq	%ymm3, %ymm10, %ymm10
-	leal	(%rsi,%rax), %ebx
-	shlq	$7, %rbx
-	vpaddq	12960(%rsp,%rbx), %ymm9, %ymm9
-	vpaddq	12928(%rsp,%rbx), %ymm7, %ymm7
-	vpaddq	%ymm13, %ymm9, %ymm9
-	vpaddq	%ymm7, %ymm12, %ymm7
-	vpaddq	13024(%rsp,%rbx), %ymm8, %ymm8
-	vpaddq	%ymm11, %ymm8, %ymm8
-	vpaddq	12992(%rsp,%rbx), %ymm6, %ymm6
-	vpaddq	%ymm6, %ymm10, %ymm6
-	vpblendd	$170, %ymm1, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm7, %ymm11 # ymm11 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
-	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
-	vmovdqa	%ymm13, 12992(%rsp,%rbx)
-	vmovdqa	%ymm12, 13024(%rsp,%rbx)
-	vmovdqa	%ymm11, 12928(%rsp,%rbx)
-	vmovdqa	%ymm10, 12960(%rsp,%rbx)
-	vpsrlq	$32, %ymm8, %ymm8
-	vpsrlq	$32, %ymm6, %ymm6
-	vpsrlq	$32, %ymm9, %ymm9
-	vpsrlq	$32, %ymm7, %ymm7
-	addq	$2, %rax
-	subq	$-128, %rcx
-	cmpl	%eax, %edx
-	jne	.LBB3_43
-# %bb.44:                               # %for_test222.for_exit225_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB3_40 Depth=1
-	testb	$1, %r12b
+	cmpl	$1, %r8d
 	jne	.LBB3_45
-	jmp	.LBB3_46
-.LBB3_47:                               # %for_test255.preheader
-	testl	%r12d, %r12d
-	je	.LBB3_22
-# %bb.48:                               # %for_loop256.lr.ph
-	movl	%r12d, %r9d
-	andl	$3, %r9d
-	cmpl	$3, %r8d
-	jae	.LBB3_52
-# %bb.49:
-	vpxor	%xmm2, %xmm2, %xmm2
+# %bb.25:                               #   in Loop: Header=BB3_24 Depth=1
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	xorl	%edx, %edx
+	jmp	.LBB3_48
+	.p2align	4, 0x90
+.LBB3_45:                               # %for_loop232.lr.ph.us.new
+                                        #   in Loop: Header=BB3_24 Depth=1
+	movq	%r9, %rbx
+	xorl	%edx, %edx
+	vpxor	%xmm9, %xmm9, %xmm9
+	vpxor	%xmm7, %xmm7, %xmm7
+	vpxor	%xmm6, %xmm6, %xmm6
+	.p2align	4, 0x90
+.LBB3_46:                               # %for_loop232.us
+                                        #   Parent Loop BB3_24 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	vpmovzxdq	-16(%rbx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	-64(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm13
+	vpmuludq	%ymm4, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm2, %ymm10, %ymm10
+	leal	(%rdi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	12928(%rsp,%rcx), %ymm8, %ymm8
+	vpaddq	%ymm13, %ymm8, %ymm8
+	vpaddq	12960(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	%ymm12, %ymm9, %ymm9
+	vpaddq	12992(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	13024(%rsp,%rcx), %ymm6, %ymm6
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	%ymm10, %ymm6, %ymm6
+	vpblendd	$170, %ymm1, %ymm8, %ymm10 # ymm10 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm9, %ymm11 # ymm11 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm6, %ymm13 # ymm13 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
+	vmovdqa	%ymm13, 13024(%rsp,%rcx)
+	vmovdqa	%ymm12, 12992(%rsp,%rcx)
+	vmovdqa	%ymm11, 12960(%rsp,%rcx)
+	vmovdqa	%ymm10, 12928(%rsp,%rcx)
+	vpsrlq	$32, %ymm8, %ymm8
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm9, %ymm9
+	vpmovzxdq	(%rbx), %ymm10  # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	32(%rbx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	48(%rbx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	16(%rbx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm4, %ymm13, %ymm13
+	vpmuludq	%ymm2, %ymm12, %ymm12
+	vpmuludq	%ymm3, %ymm11, %ymm11
+	vpmuludq	%ymm5, %ymm10, %ymm10
+	leal	(%rsi,%rdx), %ecx
+	shlq	$7, %rcx
+	vpaddq	12960(%rsp,%rcx), %ymm9, %ymm9
+	vpaddq	13024(%rsp,%rcx), %ymm6, %ymm6
+	vpaddq	%ymm13, %ymm9, %ymm9
+	vpaddq	%ymm12, %ymm6, %ymm6
+	vpaddq	12992(%rsp,%rcx), %ymm7, %ymm7
+	vpaddq	%ymm11, %ymm7, %ymm7
+	vpaddq	12928(%rsp,%rcx), %ymm8, %ymm8
+	vpaddq	%ymm10, %ymm8, %ymm8
+	vpblendd	$170, %ymm1, %ymm9, %ymm10 # ymm10 = ymm9[0],ymm1[1],ymm9[2],ymm1[3],ymm9[4],ymm1[5],ymm9[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm6, %ymm11 # ymm11 = ymm6[0],ymm1[1],ymm6[2],ymm1[3],ymm6[4],ymm1[5],ymm6[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm7, %ymm12 # ymm12 = ymm7[0],ymm1[1],ymm7[2],ymm1[3],ymm7[4],ymm1[5],ymm7[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm8, %ymm13 # ymm13 = ymm8[0],ymm1[1],ymm8[2],ymm1[3],ymm8[4],ymm1[5],ymm8[6],ymm1[7]
+	vmovdqa	%ymm13, 12928(%rsp,%rcx)
+	vmovdqa	%ymm12, 12992(%rsp,%rcx)
+	vmovdqa	%ymm11, 13024(%rsp,%rcx)
+	vmovdqa	%ymm10, 12960(%rsp,%rcx)
+	vpsrlq	$32, %ymm6, %ymm6
+	vpsrlq	$32, %ymm7, %ymm7
+	vpsrlq	$32, %ymm9, %ymm9
+	vpsrlq	$32, %ymm8, %ymm8
+	addq	$2, %rdx
+	subq	$-128, %rbx
+	cmpl	%edx, %r11d
+	jne	.LBB3_46
+# %bb.47:                               # %for_test230.for_exit233_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB3_24 Depth=1
+	testb	$1, %r8b
+	je	.LBB3_49
+.LBB3_48:                               # %for_loop232.us.epil.preheader
+                                        #   in Loop: Header=BB3_24 Depth=1
+	movq	%rdx, %rcx
+	shlq	$6, %rcx
+	vpmovzxdq	8880(%rsp,%rcx), %ymm10 # ymm10 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8864(%rsp,%rcx), %ymm11 # ymm11 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8848(%rsp,%rcx), %ymm12 # ymm12 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmovzxdq	8832(%rsp,%rcx), %ymm13 # ymm13 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero
+	vpmuludq	%ymm5, %ymm13, %ymm5
+	vpmuludq	%ymm4, %ymm12, %ymm4
+	vpmuludq	%ymm3, %ymm11, %ymm3
+	vpmuludq	%ymm2, %ymm10, %ymm2
+	addl	%edi, %edx
+	shlq	$7, %rdx
+	vpaddq	12928(%rsp,%rdx), %ymm8, %ymm8
+	vpaddq	12960(%rsp,%rdx), %ymm9, %ymm9
+	vpaddq	%ymm5, %ymm8, %ymm5
+	vpaddq	%ymm4, %ymm9, %ymm4
+	vpaddq	12992(%rsp,%rdx), %ymm7, %ymm7
+	vpaddq	%ymm3, %ymm7, %ymm3
+	vpaddq	13024(%rsp,%rdx), %ymm6, %ymm6
+	vpaddq	%ymm2, %ymm6, %ymm2
+	vpblendd	$170, %ymm1, %ymm5, %ymm6 # ymm6 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm2, %ymm9 # ymm9 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
+	vmovdqa	%ymm9, 13024(%rsp,%rdx)
+	vmovdqa	%ymm8, 12992(%rsp,%rdx)
+	vmovdqa	%ymm7, 12960(%rsp,%rdx)
+	vmovdqa	%ymm6, 12928(%rsp,%rdx)
+	vpsrlq	$32, %ymm2, %ymm6
+	vpsrlq	$32, %ymm3, %ymm7
+	vpsrlq	$32, %ymm4, %ymm9
+	vpsrlq	$32, %ymm5, %ymm8
+.LBB3_49:                               # %for_exit233.us
+                                        #   in Loop: Header=BB3_24 Depth=1
+	vmovdqa	%ymm9, 672(%rsp,%rax)
+	vmovdqa	%ymm8, 640(%rsp,%rax)
+	vmovdqa	%ymm7, 704(%rsp,%rax)
+	vmovdqa	%ymm6, 736(%rsp,%rax)
+	addq	$1, %rdi
+	addq	$1, %rsi
+	cmpq	%r10, %rdi
+	jne	.LBB3_24
+# %bb.50:                               # %for_test263.preheader
+	testl	%r8d, %r8d
+	je	.LBB3_16
+# %bb.51:                               # %for_loop265.lr.ph
+	vpxor	%xmm0, %xmm0, %xmm0
+	cmpl	$1, %r8d
+	jne	.LBB3_55
+# %bb.52:
 	xorl	%eax, %eax
-	vpxor	%xmm4, %xmm4, %xmm4
-	vpxor	%xmm1, %xmm1, %xmm1
-	vpxor	%xmm3, %xmm3, %xmm3
-	jmp	.LBB3_54
-.LBB3_22:
 	vpxor	%xmm4, %xmm4, %xmm4
 	vpxor	%xmm5, %xmm5, %xmm5
-	movq	128(%rsp), %rcx         # 8-byte Reload
-	jmp	.LBB3_58
-.LBB3_52:                               # %for_loop256.lr.ph.new
-	leaq	1024(%rsp), %rdx
-	movl	%r12d, %esi
-	subl	%r9d, %esi
-	vpxor	%xmm0, %xmm0, %xmm0
-	xorl	%eax, %eax
-	movl	%r12d, %edi
 	vpxor	%xmm2, %xmm2, %xmm2
+	vpxor	%xmm3, %xmm3, %xmm3
+	jmp	.LBB3_58
+.LBB3_16:
 	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	jmp	.LBB3_60
+.LBB3_55:                               # %for_loop265.lr.ph.new
+	leaq	768(%rsp), %rdx
 	vpxor	%xmm1, %xmm1, %xmm1
+	xorl	%esi, %esi
+	movabsq	$8589934592, %rdi       # imm = 0x200000000
+	movl	%r8d, %ebx
+	xorl	%eax, %eax
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm5, %xmm5, %xmm5
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB3_53:                               # %for_loop256
+.LBB3_56:                               # %for_loop265
                                         # =>This Inner Loop Header: Depth=1
-	vpaddq	-288(%rdx), %ymm3, %ymm3
-	vpaddq	-384(%rdx), %ymm2, %ymm2
-	vpaddq	-352(%rdx), %ymm4, %ymm4
-	vpaddq	-320(%rdx), %ymm1, %ymm1
-	movl	%edi, %ebx
-	shlq	$7, %rbx
-	vpaddq	12992(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	12960(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	12928(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	13024(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -320(%rdx)
-	vmovdqa	%ymm7, -352(%rdx)
-	vmovdqa	%ymm6, -384(%rdx)
-	vmovdqa	%ymm5, -288(%rdx)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
+	movq	%rsi, %rcx
+	sarq	$25, %rcx
+	vpaddq	704(%rsp,%rcx), %ymm2, %ymm2
+	vpaddq	672(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	640(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	736(%rsp,%rcx), %ymm3, %ymm3
+	movl	%ebx, %ecx
+	shlq	$7, %rcx
+	vpaddq	13024(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	12928(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	12960(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	12992(%rsp,%rcx), %ymm2, %ymm2
+	vpblendd	$170, %ymm1, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm4, %ymm8 # ymm8 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
+	vmovdqa	%ymm9, -32(%rdx)
+	vmovdqa	%ymm8, -128(%rdx)
+	vmovdqa	%ymm7, -96(%rdx)
+	vmovdqa	%ymm6, -64(%rdx)
 	vpsrlq	$32, %ymm2, %ymm2
-	vpsrlq	$32, %ymm3, %ymm3
-	vpaddq	-160(%rdx), %ymm3, %ymm3
-	vpaddq	-256(%rdx), %ymm2, %ymm2
-	vpaddq	-224(%rdx), %ymm4, %ymm4
-	vpaddq	-192(%rdx), %ymm1, %ymm1
-	leal	1(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	12992(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	12960(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	12928(%rsp,%rbx), %ymm2, %ymm2
-	vpaddq	13024(%rsp,%rbx), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm2, %ymm6 # ymm6 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm7 # ymm7 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, -192(%rdx)
-	vmovdqa	%ymm7, -224(%rdx)
-	vmovdqa	%ymm6, -256(%rdx)
-	vmovdqa	%ymm5, -160(%rdx)
-	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
+	vpsrlq	$32, %ymm5, %ymm5
 	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	-128(%rdx), %ymm2, %ymm2
-	vpaddq	-96(%rdx), %ymm4, %ymm4
-	vpaddq	-64(%rdx), %ymm1, %ymm1
-	vpaddq	-32(%rdx), %ymm3, %ymm3
-	leal	2(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	13024(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	12992(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	12960(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	12928(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, -32(%rdx)
-	vmovdqa	%ymm7, -64(%rdx)
-	vmovdqa	%ymm6, -96(%rdx)
-	vmovdqa	%ymm5, -128(%rdx)
 	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
+	leaq	(%rsi,%r14), %rcx
+	sarq	$25, %rcx
+	vpaddq	736(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	640(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	672(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	704(%rsp,%rcx), %ymm2, %ymm2
+	leal	1(%rbx), %ecx
+	shlq	$7, %rcx
+	vpaddq	12992(%rsp,%rcx), %ymm2, %ymm2
+	vpaddq	12960(%rsp,%rcx), %ymm5, %ymm5
+	vpaddq	12928(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	13024(%rsp,%rcx), %ymm3, %ymm3
+	vpblendd	$170, %ymm1, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm1[1],ymm4[2],ymm1[3],ymm4[4],ymm1[5],ymm4[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm1[1],ymm5[2],ymm1[3],ymm5[4],ymm1[5],ymm5[6],ymm1[7]
+	vpblendd	$170, %ymm1, %ymm2, %ymm8 # ymm8 = ymm2[0],ymm1[1],ymm2[2],ymm1[3],ymm2[4],ymm1[5],ymm2[6],ymm1[7]
+	vmovdqa	%ymm8, 64(%rdx)
+	vmovdqa	%ymm7, 32(%rdx)
+	vmovdqa	%ymm6, (%rdx)
+	vpblendd	$170, %ymm1, %ymm3, %ymm6 # ymm6 = ymm3[0],ymm1[1],ymm3[2],ymm1[3],ymm3[4],ymm1[5],ymm3[6],ymm1[7]
+	vmovdqa	%ymm6, 96(%rdx)
 	vpsrlq	$32, %ymm2, %ymm2
-	vpaddq	(%rdx), %ymm2, %ymm2
-	vpaddq	32(%rdx), %ymm4, %ymm4
-	vpaddq	64(%rdx), %ymm1, %ymm1
-	vpaddq	96(%rdx), %ymm3, %ymm3
-	leal	3(%rdi), %ebx
-	shlq	$7, %rbx
-	vpaddq	13024(%rsp,%rbx), %ymm3, %ymm3
-	vpaddq	12992(%rsp,%rbx), %ymm1, %ymm1
-	vpaddq	12960(%rsp,%rbx), %ymm4, %ymm4
-	vpaddq	12928(%rsp,%rbx), %ymm2, %ymm2
-	vpblendd	$170, %ymm0, %ymm2, %ymm5 # ymm5 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm7 # ymm7 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
-	vmovdqa	%ymm8, 96(%rdx)
-	vmovdqa	%ymm7, 64(%rdx)
-	vmovdqa	%ymm6, 32(%rdx)
-	vmovdqa	%ymm5, (%rdx)
+	vpsrlq	$32, %ymm5, %ymm5
+	vpsrlq	$32, %ymm4, %ymm4
 	vpsrlq	$32, %ymm3, %ymm3
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
-	addq	$4, %rax
-	addq	$512, %rdx              # imm = 0x200
-	addl	$4, %edi
-	cmpl	%eax, %esi
-	jne	.LBB3_53
-.LBB3_54:                               # %for_test255.for_exit258_crit_edge.unr-lcssa
-	testl	%r9d, %r9d
-	movq	128(%rsp), %rcx         # 8-byte Reload
-	je	.LBB3_57
-# %bb.55:                               # %for_loop256.epil.preheader
-	leal	(%r12,%rax), %edx
+	addq	$2, %rax
+	addl	$2, %ebx
+	addq	$256, %rdx              # imm = 0x100
+	addq	%rdi, %rsi
+	cmpl	%eax, %r11d
+	jne	.LBB3_56
+# %bb.57:                               # %for_test263.for_exit266_crit_edge.unr-lcssa
+	testl	%r15d, %r15d
+	je	.LBB3_59
+.LBB3_58:                               # %for_loop265.epil.preheader
+	movslq	%eax, %rcx
+	movq	%rcx, %rdx
+	shlq	$7, %rdx
+	vpaddq	640(%rsp,%rdx), %ymm4, %ymm1
+	vpaddq	672(%rsp,%rdx), %ymm5, %ymm4
+	vpaddq	704(%rsp,%rdx), %ymm2, %ymm2
+	vpaddq	736(%rsp,%rdx), %ymm3, %ymm3
+	addl	%r8d, %ecx
+	shlq	$7, %rcx
+	vpaddq	13024(%rsp,%rcx), %ymm3, %ymm3
+	vpaddq	12992(%rsp,%rcx), %ymm2, %ymm2
+	vpaddq	12960(%rsp,%rcx), %ymm4, %ymm4
+	vpaddq	12928(%rsp,%rcx), %ymm1, %ymm1
 	shlq	$7, %rax
-	addq	%rsp, %rax
-	addq	$640, %rax              # imm = 0x280
-	vpxor	%xmm0, %xmm0, %xmm0
-	.p2align	4, 0x90
-.LBB3_56:                               # %for_loop256.epil
-                                        # =>This Inner Loop Header: Depth=1
-	vpaddq	96(%rax), %ymm3, %ymm3
-	vpaddq	32(%rax), %ymm4, %ymm4
-	vpaddq	(%rax), %ymm2, %ymm2
-	vpaddq	64(%rax), %ymm1, %ymm1
-	movl	%edx, %esi
-	shlq	$7, %rsi
-	vpaddq	12992(%rsp,%rsi), %ymm1, %ymm1
-	vpaddq	12928(%rsp,%rsi), %ymm2, %ymm2
-	vpaddq	12960(%rsp,%rsi), %ymm4, %ymm4
-	vpaddq	13024(%rsp,%rsi), %ymm3, %ymm3
-	vpblendd	$170, %ymm0, %ymm3, %ymm5 # ymm5 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vpblendd	$170, %ymm0, %ymm1, %ymm5 # ymm5 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm4, %ymm6 # ymm6 = ymm4[0],ymm0[1],ymm4[2],ymm0[3],ymm4[4],ymm0[5],ymm4[6],ymm0[7]
 	vpblendd	$170, %ymm0, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm0[1],ymm2[2],ymm0[3],ymm2[4],ymm0[5],ymm2[6],ymm0[7]
-	vpblendd	$170, %ymm0, %ymm1, %ymm8 # ymm8 = ymm1[0],ymm0[1],ymm1[2],ymm0[3],ymm1[4],ymm0[5],ymm1[6],ymm0[7]
-	vmovdqa	%ymm8, 64(%rax)
-	vmovdqa	%ymm7, (%rax)
-	vmovdqa	%ymm6, 32(%rax)
-	vmovdqa	%ymm5, 96(%rax)
-	vpsrlq	$32, %ymm1, %ymm1
-	vpsrlq	$32, %ymm4, %ymm4
-	vpsrlq	$32, %ymm2, %ymm2
+	vpblendd	$170, %ymm0, %ymm3, %ymm0 # ymm0 = ymm3[0],ymm0[1],ymm3[2],ymm0[3],ymm3[4],ymm0[5],ymm3[6],ymm0[7]
+	vmovdqa	%ymm0, 736(%rsp,%rax)
+	vmovdqa	%ymm7, 704(%rsp,%rax)
+	vmovdqa	%ymm6, 672(%rsp,%rax)
+	vmovdqa	%ymm5, 640(%rsp,%rax)
 	vpsrlq	$32, %ymm3, %ymm3
-	incl	%edx
-	subq	$-128, %rax
-	decl	%r9d
-	jne	.LBB3_56
-.LBB3_57:                               # %for_test255.for_exit258_crit_edge
+	vpsrlq	$32, %ymm2, %ymm2
+	vpsrlq	$32, %ymm4, %ymm5
+	vpsrlq	$32, %ymm1, %ymm4
+.LBB3_59:                               # %for_test263.for_exit266_crit_edge
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	%ymm0, %ymm4, %ymm4
+	vpcmpeqq	%ymm0, %ymm5, %ymm1
 	vpcmpeqd	%ymm5, %ymm5, %ymm5
+	vpxor	%ymm5, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm6
+	vpackssdw	%xmm6, %xmm1, %xmm1
+	vpcmpeqq	%ymm0, %ymm4, %ymm4
 	vpxor	%ymm5, %ymm4, %ymm4
 	vextracti128	$1, %ymm4, %xmm6
 	vpackssdw	%xmm6, %xmm4, %xmm4
-	vpcmpeqq	%ymm0, %ymm2, %ymm2
-	vpxor	%ymm5, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm6
-	vpackssdw	%xmm6, %xmm2, %xmm2
-	vinserti128	$1, %xmm4, %ymm2, %ymm4
-	vpcmpeqq	%ymm0, %ymm3, %ymm2
-	vpxor	%ymm5, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpcmpeqq	%ymm0, %ymm1, %ymm0
+	vinserti128	$1, %xmm1, %ymm4, %ymm4
+	vpcmpeqq	%ymm0, %ymm3, %ymm1
+	vpxor	%ymm5, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm3
+	vpackssdw	%xmm3, %xmm1, %xmm1
+	vpcmpeqq	%ymm0, %ymm2, %ymm0
 	vpxor	%ymm5, %ymm0, %ymm0
-	vextracti128	$1, %ymm0, %xmm1
-	vpackssdw	%xmm1, %xmm0, %xmm0
-	vinserti128	$1, %xmm2, %ymm0, %ymm5
-.LBB3_58:                               # %for_exit258
+	vextracti128	$1, %ymm0, %xmm2
+	vpackssdw	%xmm2, %xmm0, %xmm0
+	vinserti128	$1, %xmm1, %ymm0, %ymm5
+.LBB3_60:                               # %for_exit266
 	vmovmskps	%ymm4, %eax
-	vmovmskps	%ymm5, %edx
-	shll	$8, %edx
-	orl	%eax, %edx
-	je	.LBB3_62
-# %bb.59:                               # %for_exit258
-	testl	%r12d, %r12d
-	je	.LBB3_62
-# %bb.60:                               # %for_loop291.lr.ph
-	movl	124(%rsp), %edx         # 4-byte Reload
-	vmovd	%edx, %xmm0
+	vmovmskps	%ymm5, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB3_64
+# %bb.61:                               # %for_exit266
+	testl	%r8d, %r8d
+	je	.LBB3_64
+# %bb.62:                               # %for_loop300.lr.ph
+	movq	104(%rsp), %rcx         # 8-byte Reload
+	vmovd	%ecx, %xmm0
 	vpbroadcastd	%xmm0, %ymm0
 	movl	$32, %eax
-	subl	%edx, %eax
+	subl	%ecx, %eax
 	vmovd	%eax, %xmm1
 	vpbroadcastd	%xmm1, %ymm1
-	vmovdqa	.LCPI3_3(%rip), %ymm6   # ymm6 = [0,0,1,1,2,2,3,3]
-	vpermd	%ymm4, %ymm6, %ymm2
-	vmovdqa	%ymm2, 192(%rsp)        # 32-byte Spill
-	vmovdqa	.LCPI3_4(%rip), %ymm7   # ymm7 = [4,4,5,5,6,6,7,7]
-	vpermd	%ymm4, %ymm7, %ymm2
-	vmovdqa	%ymm2, 160(%rsp)        # 32-byte Spill
+	vmovaps	.LCPI3_3(%rip), %ymm2   # ymm2 = [0,0,1,1,2,2,3,3]
+	vpermps	%ymm4, %ymm2, %ymm3
+	vmovaps	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovdqa	.LCPI3_4(%rip), %ymm6   # ymm6 = [4,4,5,5,6,6,7,7]
+	vpermd	%ymm4, %ymm6, %ymm3
+	vmovdqa	%ymm3, 128(%rsp)        # 32-byte Spill
+	vpermps	%ymm5, %ymm2, %ymm2
+	vmovaps	%ymm2, 224(%rsp)        # 32-byte Spill
 	vpermd	%ymm5, %ymm6, %ymm2
-	vmovdqa	%ymm2, 224(%rsp)        # 32-byte Spill
-	vpermd	%ymm5, %ymm7, %ymm5
-	shlq	$6, %r11
+	vmovdqa	%ymm2, 192(%rsp)        # 32-byte Spill
+	movl	%r8d, %eax
+	shlq	$7, %rax
 	vpxor	%xmm6, %xmm6, %xmm6
-	xorl	%eax, %eax
+	xorl	%ecx, %ecx
+	xorl	%edx, %edx
 	vpxor	%xmm12, %xmm12, %xmm12
 	vpxor	%xmm11, %xmm11, %xmm11
-	vpxor	%xmm8, %xmm8, %xmm8
-	vpxor	%xmm7, %xmm7, %xmm7
 	vpxor	%xmm9, %xmm9, %xmm9
 	vpxor	%xmm10, %xmm10, %xmm10
+	vpxor	%xmm8, %xmm8, %xmm8
+	vpxor	%xmm7, %xmm7, %xmm7
 	.p2align	4, 0x90
-.LBB3_61:                               # %for_loop291
+.LBB3_63:                               # %for_loop300
                                         # =>This Inner Loop Header: Depth=1
-	vmovdqa	640(%rsp,%rax,2), %ymm15
-	vmovdqa	8832(%rsp,%rax), %ymm13
-	vmovdqa	8864(%rsp,%rax), %ymm14
-	vpsllvd	%ymm0, %ymm13, %ymm2
-	vpor	%ymm2, %ymm12, %ymm2
+	vmovdqa	640(%rsp,%rcx), %ymm15
+	vmovdqa	672(%rsp,%rcx), %ymm2
+	movq	%rdx, %rsi
+	sarq	$26, %rsi
+	vmovdqa	8832(%rsp,%rsi), %ymm13
+	vmovdqa	8864(%rsp,%rsi), %ymm14
+	vpsllvd	%ymm0, %ymm13, %ymm3
+	vpor	%ymm12, %ymm3, %ymm3
 	vpsllvd	%ymm0, %ymm14, %ymm12
-	vmovdqa	736(%rsp,%rax,2), %ymm3
 	vpor	%ymm11, %ymm12, %ymm11
-	vextracti128	$1, %ymm11, %xmm4
+	vextracti128	$1, %ymm3, %xmm4
 	vpmovzxdq	%xmm4, %ymm4    # ymm4 = xmm4[0],zero,xmm4[1],zero,xmm4[2],zero,xmm4[3],zero
-	vpsubq	%ymm4, %ymm3, %ymm4
-	vpaddq	%ymm4, %ymm10, %ymm4
-	vmovdqa	704(%rsp,%rax,2), %ymm10
-	vpmovzxdq	%xmm11, %ymm11  # ymm11 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
-	vpsubq	%ymm11, %ymm10, %ymm11
-	vpaddq	%ymm9, %ymm11, %ymm9
-	vpmovzxdq	%xmm2, %ymm11   # ymm11 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm11, %ymm15, %ymm11
-	vpaddq	%ymm8, %ymm11, %ymm8
-	vpblendd	$170, %ymm6, %ymm8, %ymm11 # ymm11 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
-	vmovapd	192(%rsp), %ymm12       # 32-byte Reload
-	vblendvpd	%ymm12, %ymm11, %ymm15, %ymm11
-	vmovdqa	672(%rsp,%rax,2), %ymm12
-	vextracti128	$1, %ymm2, %xmm2
-	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpsubq	%ymm2, %ymm12, %ymm2
-	vpaddq	%ymm7, %ymm2, %ymm2
-	vpblendd	$170, %ymm6, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm6[1],ymm2[2],ymm6[3],ymm2[4],ymm6[5],ymm2[6],ymm6[7]
-	vmovapd	160(%rsp), %ymm15       # 32-byte Reload
-	vblendvpd	%ymm15, %ymm7, %ymm12, %ymm7
-	vpblendd	$170, %ymm6, %ymm9, %ymm12 # ymm12 = ymm9[0],ymm6[1],ymm9[2],ymm6[3],ymm9[4],ymm6[5],ymm9[6],ymm6[7]
-	vmovapd	224(%rsp), %ymm15       # 32-byte Reload
-	vblendvpd	%ymm15, %ymm12, %ymm10, %ymm10
+	vpsubq	%ymm4, %ymm2, %ymm4
+	vpaddq	%ymm10, %ymm4, %ymm4
+	vmovdqa	704(%rsp,%rcx), %ymm10
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpsubq	%ymm3, %ymm15, %ymm3
+	vpaddq	%ymm9, %ymm3, %ymm3
+	vpblendd	$170, %ymm6, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm6[1],ymm3[2],ymm6[3],ymm3[4],ymm6[5],ymm3[6],ymm6[7]
+	vmovapd	160(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm9, %ymm15, %ymm9
 	vpblendd	$170, %ymm6, %ymm4, %ymm12 # ymm12 = ymm4[0],ymm6[1],ymm4[2],ymm6[3],ymm4[4],ymm6[5],ymm4[6],ymm6[7]
-	vblendvpd	%ymm5, %ymm12, %ymm3, %ymm3
-	vmovapd	%ymm10, 704(%rsp,%rax,2)
-	vmovapd	%ymm3, 736(%rsp,%rax,2)
-	vmovapd	%ymm11, 640(%rsp,%rax,2)
+	vmovapd	128(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm2, %ymm2
+	vpmovzxdq	%xmm11, %ymm12  # ymm12 = xmm11[0],zero,xmm11[1],zero,xmm11[2],zero,xmm11[3],zero
+	vpsubq	%ymm12, %ymm10, %ymm12
+	vpaddq	%ymm8, %ymm12, %ymm8
+	vpblendd	$170, %ymm6, %ymm8, %ymm12 # ymm12 = ymm8[0],ymm6[1],ymm8[2],ymm6[3],ymm8[4],ymm6[5],ymm8[6],ymm6[7]
+	vmovapd	224(%rsp), %ymm5        # 32-byte Reload
+	vblendvpd	%ymm5, %ymm12, %ymm10, %ymm10
+	vmovdqa	736(%rsp,%rcx), %ymm12
+	vextracti128	$1, %ymm11, %xmm5
+	vpmovzxdq	%xmm5, %ymm5    # ymm5 = xmm5[0],zero,xmm5[1],zero,xmm5[2],zero,xmm5[3],zero
+	vpsubq	%ymm5, %ymm12, %ymm5
+	vpaddq	%ymm7, %ymm5, %ymm5
+	vpblendd	$170, %ymm6, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm6[1],ymm5[2],ymm6[3],ymm5[4],ymm6[5],ymm5[6],ymm6[7]
+	vmovapd	192(%rsp), %ymm11       # 32-byte Reload
+	vblendvpd	%ymm11, %ymm7, %ymm12, %ymm7
+	vmovapd	%ymm7, 736(%rsp,%rcx)
+	vmovapd	%ymm10, 704(%rsp,%rcx)
 	vpsrlvd	%ymm1, %ymm14, %ymm11
 	vpsrlvd	%ymm1, %ymm13, %ymm12
-	vmovapd	%ymm7, 672(%rsp,%rax,2)
-	vpsrad	$31, %ymm4, %ymm3
-	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm9, %ymm3
-	vpshufd	$245, %ymm9, %ymm4      # ymm4 = ymm9[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm4, %ymm9 # ymm9 = ymm4[0],ymm3[1],ymm4[2],ymm3[3],ymm4[4],ymm3[5],ymm4[6],ymm3[7]
-	vpsrad	$31, %ymm2, %ymm3
-	vpshufd	$245, %ymm2, %ymm2      # ymm2 = ymm2[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm3, %ymm2, %ymm7 # ymm7 = ymm2[0],ymm3[1],ymm2[2],ymm3[3],ymm2[4],ymm3[5],ymm2[6],ymm3[7]
+	vmovapd	%ymm2, 672(%rsp,%rcx)
+	vmovapd	%ymm9, 640(%rsp,%rcx)
+	vpsrad	$31, %ymm5, %ymm2
+	vpshufd	$245, %ymm5, %ymm5      # ymm5 = ymm5[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm7 # ymm7 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
 	vpsrad	$31, %ymm8, %ymm2
-	vpshufd	$245, %ymm8, %ymm3      # ymm3 = ymm8[1,1,3,3,5,5,7,7]
-	vpblendd	$170, %ymm2, %ymm3, %ymm8 # ymm8 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
-	addq	$64, %rax
-	cmpq	%rax, %r11
-	jne	.LBB3_61
-.LBB3_62:                               # %safe_if_after_true
-	leal	-1(%r12), %eax
+	vpshufd	$245, %ymm8, %ymm5      # ymm5 = ymm8[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm5, %ymm8 # ymm8 = ymm5[0],ymm2[1],ymm5[2],ymm2[3],ymm5[4],ymm2[5],ymm5[6],ymm2[7]
+	vpsrad	$31, %ymm4, %ymm2
+	vpshufd	$245, %ymm4, %ymm4      # ymm4 = ymm4[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm4, %ymm10 # ymm10 = ymm4[0],ymm2[1],ymm4[2],ymm2[3],ymm4[4],ymm2[5],ymm4[6],ymm2[7]
+	vpsrad	$31, %ymm3, %ymm2
+	vpshufd	$245, %ymm3, %ymm3      # ymm3 = ymm3[1,1,3,3,5,5,7,7]
+	vpblendd	$170, %ymm2, %ymm3, %ymm9 # ymm9 = ymm3[0],ymm2[1],ymm3[2],ymm2[3],ymm3[4],ymm2[5],ymm3[6],ymm2[7]
+	addq	%r14, %rdx
+	subq	$-128, %rcx
+	cmpq	%rcx, %rax
+	jne	.LBB3_63
+.LBB3_64:                               # %safe_if_after_true
+	leal	-1(%r8), %eax
 	shlq	$7, %rax
 	vpxor	%xmm0, %xmm0, %xmm0
-	vpcmpeqq	736(%rsp,%rax), %ymm0, %ymm2
-	vpcmpeqd	%ymm1, %ymm1, %ymm1
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
+	vpcmpeqq	736(%rsp,%rax), %ymm0, %ymm1
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm3
 	vpcmpeqq	704(%rsp,%rax), %ymm0, %ymm4
-	vpackssdw	%xmm3, %xmm2, %xmm2
-	vpxor	%ymm1, %ymm4, %ymm3
+	vpackssdw	%xmm3, %xmm1, %xmm1
+	vpxor	%ymm2, %ymm4, %ymm3
 	vextracti128	$1, %ymm3, %xmm4
 	vpackssdw	%xmm4, %xmm3, %xmm3
-	vinserti128	$1, %xmm2, %ymm3, %ymm11
-	vpcmpeqq	672(%rsp,%rax), %ymm0, %ymm2
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm3
-	vpackssdw	%xmm3, %xmm2, %xmm2
+	vinserti128	$1, %xmm1, %ymm3, %ymm3
+	vpcmpeqq	672(%rsp,%rax), %ymm0, %ymm1
+	vpxor	%ymm2, %ymm1, %ymm1
+	vextracti128	$1, %ymm1, %xmm4
+	vpackssdw	%xmm4, %xmm1, %xmm1
 	vpcmpeqq	640(%rsp,%rax), %ymm0, %ymm0
-	vpxor	%ymm1, %ymm0, %ymm0
-	vextracti128	$1, %ymm0, %xmm3
-	vpackssdw	%xmm3, %xmm0, %xmm0
-	vinserti128	$1, %xmm2, %ymm0, %ymm10
-	vmovmskps	%ymm10, %eax
-	vmovmskps	%ymm11, %ebx
-	movl	%ebx, %edx
-	shll	$8, %edx
-	orl	%eax, %edx
-	je	.LBB3_63
-# %bb.66:                               # %for_test349.preheader
-	vpbroadcastd	.LCPI3_5(%rip), %ymm4 # ymm4 = [1,1,1,1,1,1,1,1]
-	xorl	%edx, %edx
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-	vmovdqa	.LCPI3_6(%rip), %xmm13  # xmm13 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vmovdqa	.LCPI3_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vmovdqa	%ymm4, %ymm9
-	vmovaps	%ymm10, 160(%rsp)       # 32-byte Spill
-	vmovaps	%ymm11, 192(%rsp)       # 32-byte Spill
+	vpxor	%ymm2, %ymm0, %ymm0
+	vextracti128	$1, %ymm0, %xmm4
+	vpackssdw	%xmm4, %xmm0, %xmm0
+	vinserti128	$1, %xmm1, %ymm0, %ymm1
+	vmovmskps	%ymm1, %eax
+	vmovmskps	%ymm3, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	vmovaps	%ymm3, 160(%rsp)        # 32-byte Spill
+	vmovaps	%ymm1, 128(%rsp)        # 32-byte Spill
+	je	.LBB3_65
+# %bb.68:                               # %for_test357.preheader
+	movl	%r8d, %eax
+	negl	%eax
+	sbbl	%eax, %eax
+	vmovd	%eax, %xmm0
+	vpbroadcastd	%xmm0, %ymm0
+	vpand	%ymm3, %ymm0, %ymm5
+	vpand	%ymm1, %ymm0, %ymm6
+	vmovmskps	%ymm6, %eax
+	vmovmskps	%ymm5, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB3_65
+# %bb.69:                               # %for_loop359.preheader
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vbroadcastss	.LCPI3_5(%rip), %ymm11 # ymm11 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vpbroadcastd	.LCPI3_5(%rip), %ymm15 # ymm15 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	xorl	%eax, %eax
+	vpxor	%xmm8, %xmm8, %xmm8
+	vmovdqa	%ymm15, %ymm9
+	vmovdqa	%ymm15, %ymm10
+	vmovaps	%ymm11, %ymm12
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	movq	96(%rsp), %rsi          # 8-byte Reload
 	.p2align	4, 0x90
-.LBB3_67:                               # %for_test349
+.LBB3_70:                               # %for_loop359
                                         # =>This Inner Loop Header: Depth=1
-	cmpl	%r12d, %edx
-	sbbl	%esi, %esi
-	vmovd	%esi, %xmm3
-	vpbroadcastd	%xmm3, %ymm3
-	vpshufd	$78, %xmm0, %xmm7       # xmm7 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm7, %ymm7
-	vpand	%ymm7, %ymm11, %ymm7
-	vpmovsxbd	%xmm0, %ymm11
-	vpand	%ymm11, %ymm10, %ymm10
-	vpand	%ymm3, %ymm7, %ymm11
-	vpand	%ymm3, %ymm10, %ymm10
-	vmovmskps	%ymm10, %esi
-	vmovmskps	%ymm11, %edi
-	shll	$8, %edi
-	orl	%esi, %edi
-	je	.LBB3_68
-# %bb.69:                               # %for_loop350
-                                        #   in Loop: Header=BB3_67 Depth=1
-	movl	%edx, %esi
-	movq	%rsi, %rdi
-	shlq	$6, %rdi
-	vmovdqa	8832(%rsp,%rdi), %ymm3
-	vmovdqa	8864(%rsp,%rdi), %ymm7
-	vpaddd	%ymm4, %ymm3, %ymm14
-	vpaddd	%ymm7, %ymm9, %ymm15
-	vpmaxud	%ymm7, %ymm15, %ymm7
-	vpcmpeqd	%ymm7, %ymm15, %ymm7
-	vpbroadcastd	.LCPI3_5(%rip), %ymm8 # ymm8 = [1,1,1,1,1,1,1,1]
-	vpmaxud	%ymm3, %ymm14, %ymm3
-	vpcmpeqd	%ymm3, %ymm14, %ymm3
-	vpandn	%ymm8, %ymm3, %ymm3
-	vblendvps	%ymm10, %ymm3, %ymm4, %ymm4
-	vpandn	%ymm8, %ymm7, %ymm3
-	vblendvps	%ymm11, %ymm3, %ymm9, %ymm9
-	shlq	$7, %rsi
-	vpmovzxdq	%xmm14, %ymm3   # ymm3 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
-	vextracti128	$1, %ymm14, %xmm7
-	vpmovzxdq	%xmm7, %ymm7    # ymm7 = xmm7[0],zero,xmm7[1],zero,xmm7[2],zero,xmm7[3],zero
-	vpmovzxdq	%xmm15, %ymm8   # ymm8 = xmm15[0],zero,xmm15[1],zero,xmm15[2],zero,xmm15[3],zero
-	vextracti128	$1, %ymm15, %xmm2
+	movl	%eax, %ecx
+	cltq
+	movq	%rax, %rdx
+	shlq	$6, %rdx
+	vpaddd	8832(%rsp,%rdx), %ymm9, %ymm13
+	vpaddd	8864(%rsp,%rdx), %ymm10, %ymm14
+	movq	%rcx, %rdx
+	shlq	$6, %rdx
+	vpmaxud	8864(%rsp,%rdx), %ymm14, %ymm9
+	vpcmpeqd	%ymm9, %ymm14, %ymm9
+	vpandn	%ymm15, %ymm9, %ymm10
+	vpmaxud	8832(%rsp,%rdx), %ymm13, %ymm9
+	vpcmpeqd	%ymm9, %ymm13, %ymm9
+	vpandn	%ymm15, %ymm9, %ymm9
+	vblendvps	%ymm6, %ymm9, %ymm11, %ymm9
+	vblendvps	%ymm5, %ymm10, %ymm12, %ymm10
+	shlq	$7, %rcx
+	vpmovzxdq	%xmm14, %ymm11  # ymm11 = xmm14[0],zero,xmm14[1],zero,xmm14[2],zero,xmm14[3],zero
+	vextracti128	$1, %ymm14, %xmm2
 	vpmovzxdq	%xmm2, %ymm2    # ymm2 = xmm2[0],zero,xmm2[1],zero,xmm2[2],zero,xmm2[3],zero
-	vpcmpeqq	736(%rsp,%rsi), %ymm2, %ymm2
-	vpxor	%ymm1, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm5
-	vpcmpeqq	704(%rsp,%rsi), %ymm8, %ymm8
-	vpackssdw	%xmm5, %xmm2, %xmm2
-	vpxor	%ymm1, %ymm8, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpackssdw	%xmm2, %xmm5, %xmm2
-	vpcmpeqq	672(%rsp,%rsi), %ymm7, %ymm5
-	vpxor	%ymm1, %ymm5, %ymm5
-	vextracti128	$1, %ymm5, %xmm6
-	vpackssdw	%xmm6, %xmm5, %xmm5
-	vpcmpeqq	640(%rsp,%rsi), %ymm3, %ymm3
-	vpxor	%ymm1, %ymm3, %ymm3
-	vextracti128	$1, %ymm3, %xmm6
-	vpackssdw	%xmm6, %xmm3, %xmm3
-	vpackssdw	%xmm5, %xmm3, %xmm3
-	vpacksswb	%xmm2, %xmm3, %xmm2
-	vextracti128	$1, %ymm10, %xmm3
-	vpshufb	%xmm13, %xmm3, %xmm3
-	vpshufb	%xmm13, %xmm10, %xmm5
-	vpunpckldq	%xmm3, %xmm5, %xmm3 # xmm3 = xmm5[0],xmm3[0],xmm5[1],xmm3[1]
-	vextracti128	$1, %ymm11, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm11, %xmm6
-	vpunpckldq	%xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0],xmm5[0],xmm6[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm3, %xmm3 # xmm3 = xmm3[0,1],xmm5[2,3]
-	vpand	%xmm3, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	.LCPI3_8(%rip), %xmm2, %xmm2
-	vpxor	%xmm3, %xmm3, %xmm3
-	vpcmpgtb	%xmm2, %xmm3, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%edx
-	jmp	.LBB3_67
-.LBB3_68:
-	vmovaps	192(%rsp), %ymm11       # 32-byte Reload
-	vmovaps	160(%rsp), %ymm10       # 32-byte Reload
-	jmp	.LBB3_64
-.LBB3_63:
-	vpcmpeqd	%xmm0, %xmm0, %xmm0
-.LBB3_64:                               # %safe_if_after_true341
-	xorl	$255, %eax
-	xorl	$255, %ebx
-	shll	$8, %ebx
-	orl	%eax, %ebx
-	je	.LBB3_65
-# %bb.70:                               # %safe_if_run_false407
-	vpxor	%ymm1, %ymm10, %ymm3
-	vpbroadcastq	.LCPI3_9(%rip), %ymm2 # ymm2 = [1,1,1,1]
-	vpcmpeqq	736(%rsp), %ymm2, %ymm4
-	vpcmpeqq	704(%rsp), %ymm2, %ymm5
-	vpxor	%ymm1, %ymm11, %ymm1
-	vpackssdw	%ymm4, %ymm5, %ymm4
-	vpcmpeqq	672(%rsp), %ymm2, %ymm5
-	vpermq	$216, %ymm4, %ymm4      # ymm4 = ymm4[0,2,1,3]
-	vpcmpeqq	640(%rsp), %ymm2, %ymm2
-	vpackssdw	%ymm5, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vpackssdw	%ymm4, %ymm2, %ymm2
-	vpermq	$216, %ymm2, %ymm2      # ymm2 = ymm2[0,2,1,3]
-	vextracti128	$1, %ymm2, %xmm4
-	vpacksswb	%xmm4, %xmm2, %xmm8
+	vpmovzxdq	%xmm13, %ymm12  # ymm12 = xmm13[0],zero,xmm13[1],zero,xmm13[2],zero,xmm13[3],zero
+	vextracti128	$1, %ymm13, %xmm3
+	vpmovzxdq	%xmm3, %ymm3    # ymm3 = xmm3[0],zero,xmm3[1],zero,xmm3[2],zero,xmm3[3],zero
+	vpcmpeqq	672(%rsp,%rcx), %ymm3, %ymm3
 	vextracti128	$1, %ymm3, %xmm4
-	vmovdqa	.LCPI3_6(%rip), %xmm10  # xmm10 = <0,4,8,12,u,u,u,u,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm6
-	vpunpckldq	%xmm4, %xmm6, %xmm6 # xmm6 = xmm6[0],xmm4[0],xmm6[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm7
-	vmovdqa	.LCPI3_7(%rip), %xmm12  # xmm12 = <u,u,u,u,0,4,8,12,u,u,u,u,u,u,u,u>
-	vpshufb	%xmm12, %xmm7, %xmm7
-	vpshufb	%xmm12, %xmm1, %xmm5
-	vpunpckldq	%xmm7, %xmm5, %xmm5 # xmm5 = xmm5[0],xmm7[0],xmm5[1],xmm7[1]
-	vpblendd	$12, %xmm5, %xmm6, %xmm5 # xmm5 = xmm6[0,1],xmm5[2,3]
-	vpsllw	$7, %xmm5, %xmm5
-	vpblendvb	%xmm5, %xmm8, %xmm0, %xmm0
-	movl	$1, %eax
-	vpxor	%xmm13, %xmm13, %xmm13
-	vpcmpeqd	%ymm6, %ymm6, %ymm6
-	vmovdqa	.LCPI3_8(%rip), %xmm8   # xmm8 = [128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128]
-	vpxor	%xmm9, %xmm9, %xmm9
-	.p2align	4, 0x90
-.LBB3_71:                               # %for_test417
-                                        # =>This Inner Loop Header: Depth=1
-	cmpl	%r12d, %eax
-	sbbl	%edx, %edx
-	vmovd	%edx, %xmm7
-	vpbroadcastd	%xmm7, %ymm7
-	vpshufd	$78, %xmm0, %xmm2       # xmm2 = xmm0[2,3,0,1]
-	vpmovsxbd	%xmm2, %ymm2
-	vpand	%ymm2, %ymm1, %ymm1
-	vpmovsxbd	%xmm0, %ymm2
-	vpand	%ymm2, %ymm3, %ymm2
-	vpand	%ymm7, %ymm1, %ymm1
-	vpand	%ymm7, %ymm2, %ymm3
-	vmovmskps	%ymm3, %esi
-	vmovmskps	%ymm1, %edx
-	shll	$8, %edx
-	orl	%esi, %edx
-	je	.LBB3_65
-# %bb.72:                               # %for_loop418
-                                        #   in Loop: Header=BB3_71 Depth=1
-	movl	%eax, %edx
-	shlq	$7, %rdx
-	vpcmpeqq	736(%rsp,%rdx), %ymm13, %ymm2
-	vpxor	%ymm6, %ymm2, %ymm2
-	vextracti128	$1, %ymm2, %xmm7
-	vpcmpeqq	704(%rsp,%rdx), %ymm13, %ymm11
-	vpackssdw	%xmm7, %xmm2, %xmm2
-	vpxor	%ymm6, %ymm11, %ymm7
-	vextracti128	$1, %ymm7, %xmm4
-	vpackssdw	%xmm4, %xmm7, %xmm4
-	vpackssdw	%xmm2, %xmm4, %xmm2
-	vpcmpeqq	672(%rsp,%rdx), %ymm13, %ymm4
-	vpxor	%ymm6, %ymm4, %ymm4
+	vpackssdw	%xmm4, %xmm3, %xmm3
+	vpcmpeqq	640(%rsp,%rcx), %ymm12, %ymm4
 	vextracti128	$1, %ymm4, %xmm7
 	vpackssdw	%xmm7, %xmm4, %xmm4
-	vpcmpeqq	640(%rsp,%rdx), %ymm13, %ymm7
-	vpxor	%ymm6, %ymm7, %ymm7
-	vextracti128	$1, %ymm7, %xmm5
-	vpackssdw	%xmm5, %xmm7, %xmm5
-	vpackssdw	%xmm4, %xmm5, %xmm4
-	vpacksswb	%xmm2, %xmm4, %xmm2
-	vextracti128	$1, %ymm3, %xmm4
-	vpshufb	%xmm10, %xmm4, %xmm4
-	vpshufb	%xmm10, %xmm3, %xmm5
-	vpunpckldq	%xmm4, %xmm5, %xmm4 # xmm4 = xmm5[0],xmm4[0],xmm5[1],xmm4[1]
-	vextracti128	$1, %ymm1, %xmm5
-	vpshufb	%xmm12, %xmm5, %xmm5
-	vpshufb	%xmm12, %xmm1, %xmm7
-	vpunpckldq	%xmm5, %xmm7, %xmm5 # xmm5 = xmm7[0],xmm5[0],xmm7[1],xmm5[1]
-	vpblendd	$12, %xmm5, %xmm4, %xmm4 # xmm4 = xmm4[0,1],xmm5[2,3]
-	vpand	%xmm4, %xmm2, %xmm2
-	vpsllw	$7, %xmm2, %xmm2
-	vpand	%xmm2, %xmm8, %xmm2
-	vpcmpgtb	%xmm2, %xmm9, %xmm2
-	vpandn	%xmm0, %xmm2, %xmm0
-	incl	%eax
-	jmp	.LBB3_71
-.LBB3_65:                               # %if_done340
-	vpand	.LCPI3_10(%rip), %xmm0, %xmm0
-	vpshufd	$78, %xmm0, %xmm1       # xmm1 = xmm0[2,3,0,1]
-	vpmovzxbd	%xmm1, %ymm1    # ymm1 = xmm1[0],zero,zero,zero,xmm1[1],zero,zero,zero,xmm1[2],zero,zero,zero,xmm1[3],zero,zero,zero,xmm1[4],zero,zero,zero,xmm1[5],zero,zero,zero,xmm1[6],zero,zero,zero,xmm1[7],zero,zero,zero
-	vpmovzxbd	%xmm0, %ymm0    # ymm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero
-	vmovdqu	%ymm0, (%rcx)
-	vmovdqu	%ymm1, 32(%rcx)
+	vinserti128	$1, %xmm3, %ymm4, %ymm3
+	vpcmpeqq	736(%rsp,%rcx), %ymm2, %ymm2
+	vextracti128	$1, %ymm2, %xmm4
+	vpackssdw	%xmm4, %xmm2, %xmm2
+	vpcmpeqq	704(%rsp,%rcx), %ymm11, %ymm4
+	vextracti128	$1, %ymm4, %xmm7
+	vpackssdw	%xmm7, %xmm4, %xmm4
+	vinserti128	$1, %xmm2, %ymm4, %ymm2
+	vpandn	%ymm5, %ymm2, %ymm2
+	vpandn	%ymm6, %ymm3, %ymm3
+	vblendvps	%ymm3, %ymm8, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm8, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r8d, %eax
+	sbbl	%ecx, %ecx
+	vmovd	%ecx, %xmm2
+	vpbroadcastd	%xmm2, %ymm2
+	vpand	%ymm2, %ymm5, %ymm3
+	vandps	%ymm3, %ymm1, %ymm5
+	vpand	%ymm2, %ymm6, %ymm2
+	vandps	%ymm2, %ymm0, %ymm6
+	vmovmskps	%ymm6, %ecx
+	vmovmskps	%ymm5, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	vmovaps	%ymm9, %ymm11
+	vmovaps	%ymm10, %ymm12
+	jne	.LBB3_70
+	jmp	.LBB3_66
+.LBB3_65:
+	vpcmpeqd	%ymm0, %ymm0, %ymm0
+	vpcmpeqd	%ymm1, %ymm1, %ymm1
+	movq	96(%rsp), %rsi          # 8-byte Reload
+.LBB3_66:                               # %safe_if_after_true349
+	vpcmpeqd	%ymm2, %ymm2, %ymm2
+	vpxor	128(%rsp), %ymm2, %ymm4 # 32-byte Folded Reload
+	vpxor	160(%rsp), %ymm2, %ymm2 # 32-byte Folded Reload
+	vmovmskps	%ymm4, %eax
+	vmovmskps	%ymm2, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB3_67
+# %bb.71:                               # %safe_if_run_false415
+	vpbroadcastq	.LCPI3_6(%rip), %ymm3 # ymm3 = [1,1,1,1]
+	vpcmpeqq	736(%rsp), %ymm3, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	704(%rsp), %ymm3, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vpcmpeqq	672(%rsp), %ymm3, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	640(%rsp), %ymm3, %ymm3
+	vextracti128	$1, %ymm3, %xmm7
+	vpackssdw	%xmm7, %xmm3, %xmm3
+	vinserti128	$1, %xmm6, %ymm3, %ymm3
+	vblendvps	%ymm4, %ymm3, %ymm0, %ymm0
+	vblendvps	%ymm2, %ymm5, %ymm1, %ymm1
+	xorl	%eax, %eax
+	cmpl	$1, %r8d
+	seta	%al
+	negl	%eax
+	vmovd	%eax, %xmm3
+	vpbroadcastd	%xmm3, %ymm3
+	vandps	%ymm0, %ymm4, %ymm4
+	vandps	%ymm1, %ymm2, %ymm2
+	vandps	%ymm3, %ymm2, %ymm2
+	vandps	%ymm3, %ymm4, %ymm3
+	vmovmskps	%ymm3, %eax
+	vmovmskps	%ymm2, %ecx
+	shll	$8, %ecx
+	orl	%eax, %ecx
+	je	.LBB3_67
+# %bb.72:                               # %for_loop427.preheader
+	movl	$1, %eax
+	vpxor	%xmm8, %xmm8, %xmm8
+	.p2align	4, 0x90
+.LBB3_73:                               # %for_loop427
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	shlq	$7, %rcx
+	vpcmpeqq	672(%rsp,%rcx), %ymm8, %ymm5
+	vextracti128	$1, %ymm5, %xmm6
+	vpackssdw	%xmm6, %xmm5, %xmm5
+	vpcmpeqq	640(%rsp,%rcx), %ymm8, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vinserti128	$1, %xmm5, %ymm6, %ymm5
+	vpcmpeqq	736(%rsp,%rcx), %ymm8, %ymm6
+	vextracti128	$1, %ymm6, %xmm7
+	vpackssdw	%xmm7, %xmm6, %xmm6
+	vpcmpeqq	704(%rsp,%rcx), %ymm8, %ymm7
+	vextracti128	$1, %ymm7, %xmm4
+	vpackssdw	%xmm4, %xmm7, %xmm4
+	vinserti128	$1, %xmm6, %ymm4, %ymm4
+	vpandn	%ymm2, %ymm4, %ymm4
+	vpandn	%ymm3, %ymm5, %ymm5
+	vblendvps	%ymm5, %ymm8, %ymm0, %ymm0
+	vblendvps	%ymm4, %ymm8, %ymm1, %ymm1
+	addl	$1, %eax
+	cmpl	%r8d, %eax
+	sbbl	%ecx, %ecx
+	vmovd	%ecx, %xmm4
+	vpbroadcastd	%xmm4, %ymm4
+	vpand	%ymm4, %ymm2, %ymm2
+	vandps	%ymm2, %ymm1, %ymm2
+	vpand	%ymm4, %ymm3, %ymm3
+	vandps	%ymm3, %ymm0, %ymm3
+	vmovmskps	%ymm3, %ecx
+	vmovmskps	%ymm2, %edx
+	shll	$8, %edx
+	orl	%ecx, %edx
+	jne	.LBB3_73
+.LBB3_67:                               # %if_done348
+	vbroadcastss	.LCPI3_5(%rip), %ymm2 # ymm2 = [1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45,1.40129846E-45]
+	vandps	%ymm2, %ymm1, %ymm1
+	vandps	%ymm2, %ymm0, %ymm0
+	vmovups	%ymm0, (%rsi)
+	vmovups	%ymm1, 32(%rsi)
 	leaq	-40(%rbp), %rsp
 	popq	%rbx
 	popq	%r12
@@ -6895,5 +6707,6 @@ fermat_test:                            # @fermat_test
 .Lfunc_end3:
 	.size	fermat_test, .Lfunc_end3-fermat_test
                                         # -- End function
-	.ident	"clang version 10.0.1 (/usr/local/src/llvm/llvm-10.0/clang ef32c611aa214dea855364efd7ba451ec5ec3f74)"
+
+	.ident	"clang version 8.0.0 (http://llvm.org/git/clang.git 2d5099826365b50ff253e48c0832255600e68202) (http://llvm.org/git/llvm.git 498b7f9b57123ce661e075ae584876be72852506)"
 	.section	".note.GNU-stack","",@progbits

--- a/ispc/primetest512.s
+++ b/ispc/primetest512.s
@@ -1470,28 +1470,27 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	pushq	%rbx
 	andq	$-128, %rsp
 	subq	$45568, %rsp            # imm = 0xB200
-	movl	%r8d, %r15d
+	movl	%r9d, 32(%rsp)          # 4-byte Spill
+	movl	%r8d, %r13d
+	movq	%rcx, 40(%rsp)          # 8-byte Spill
 	vpmovsxbd	%xmm0, %zmm0
 	vpslld	$31, %zmm0, %zmm0
 	vptestmd	%zmm0, %zmm0, %k5
-	kxorw	%k0, %k0, %k2
 	testl	%r8d, %r8d
-	je	.LBB2_65
+	je	.LBB2_7
 # %bb.1:                                # %for_loop.lr.ph
-	vpbroadcastd	%r15d, %zmm0
+	vpbroadcastd	%r13d, %zmm0
 	vpmulld	.LCPI2_0(%rip), %zmm0, %zmm0
-	kmovw	%k5, %r11d
-	cmpl	$1, %r15d
-	movq	%rcx, 32(%rsp)          # 8-byte Spill
-	movl	%r9d, 24(%rsp)          # 4-byte Spill
+	kmovw	%k5, %r9d
+	cmpl	$1, %r13d
 	jne	.LBB2_3
 # %bb.2:
 	xorl	%eax, %eax
 	jmp	.LBB2_6
 .LBB2_3:                                # %for_loop.lr.ph.new
-	movl	%r15d, %r8d
+	movl	%r13d, %r8d
 	andl	$1, %r8d
-	movl	%r15d, %r10d
+	movl	%r13d, %r10d
 	subl	%r8d, %r10d
 	movl	$64, %ecx
 	xorl	%eax, %eax
@@ -1501,13 +1500,13 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpbroadcastd	%eax, %zmm1
 	vpaddd	%zmm0, %zmm1, %zmm1
 	vpslld	$2, %zmm1, %zmm1
-	kmovw	%r11d, %k1
-	vpxor	%xmm2, %xmm2, %xmm2
+	kmovw	%r9d, %k1
 	kmovw	%k1, %k2
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdi,%zmm1), %zmm2 {%k2}
 	vmovdqa64	%zmm2, 8512(%rsp,%rcx)
-	vpxor	%xmm2, %xmm2, %xmm2
 	kmovw	%k1, %k2
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdx,%zmm1), %zmm2 {%k2}
 	vextracti64x4	$1, %zmm2, %ymm1
 	vpmovzxdq	%ymm1, %zmm1    # zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero
@@ -1518,8 +1517,8 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpbroadcastd	%ebx, %zmm1
 	vpaddd	%zmm0, %zmm1, %zmm1
 	vpslld	$2, %zmm1, %zmm1
-	vpxor	%xmm2, %xmm2, %xmm2
 	kmovw	%k1, %k2
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdi,%zmm1), %zmm2 {%k2}
 	vmovdqa64	%zmm2, 8576(%rsp,%rcx)
 	vpxor	%xmm2, %xmm2, %xmm2
@@ -1542,10 +1541,10 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpbroadcastd	%eax, %zmm1
 	vpaddd	%zmm0, %zmm1, %zmm0
 	vpslld	$2, %zmm0, %zmm0
-	kmovw	%r11d, %k1
+	kmovw	%r9d, %k1
 	vpxor	%xmm1, %xmm1, %xmm1
-	vpxor	%xmm2, %xmm2, %xmm2
 	kmovw	%k1, %k2
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdi,%zmm0), %zmm2 {%k2}
 	vmovdqa64	%zmm2, 8576(%rsp,%rcx)
 	shlq	$7, %rax
@@ -1556,45 +1555,58 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vmovdqa64	%zmm1, 448(%rsp,%rax)
 	vmovdqa64	%zmm0, 384(%rsp,%rax)
 .LBB2_7:                                # %for_exit
-	vmovdqu32	(%rsi), %zmm0 {%k5}{z}
-	vmovdqa64	%zmm0, 64(%rsp) # 64-byte Spill
-	testl	%r15d, %r15d
-	movl	%r15d, %r14d
-	jle	.LBB2_13
-# %bb.8:                                # %for_loop31.lr.ph
-	movl	$-2147483648, %eax      # imm = 0x80000000
-	movl	24(%rsp), %ecx          # 4-byte Reload
-	shrxl	%ecx, %eax, %edi
-	vpbroadcastd	%ecx, %zmm11
-	movl	$32, %eax
+	xorl	%ecx, %ecx
+	movl	32(%rsp), %edx          # 4-byte Reload
+	cmpl	$23, %edx
+	seta	%cl
+	movl	%r13d, %eax
 	subl	%ecx, %eax
-	vpbroadcastd	%eax, %zmm12
-	leal	-1(%r15), %r12d
-	leaq	8640(%rsp), %r13
-	movl	%r15d, %ebx
+	vmovdqu32	(%rsi), %zmm12 {%k5}{z}
+	testl	%eax, %eax
+	vpbroadcastd	%edx, %zmm11
+	movl	%r13d, %r14d
+	jle	.LBB2_15
+# %bb.8:                                # %for_loop35.lr.ph
+	xorl	%ecx, %ecx
+	movl	32(%rsp), %esi          # 4-byte Reload
+	cmpl	$24, %esi
+	setb	%cl
+	shll	$5, %ecx
+	addl	%esi, %ecx
+	addb	$-24, %cl
+	movl	$-2147483648, %edx      # imm = 0x80000000
+	shrxl	%ecx, %edx, %edi
+	movl	$32, %ecx
+	subl	%esi, %ecx
+	vpbroadcastd	%ecx, %zmm13
+	leal	-1(%r13), %r12d
+	movl	%eax, %eax
+	leaq	8640(%rsp), %r15
+	movl	%r13d, %ebx
 	andl	$-2, %ebx
-	vpbroadcastq	.LCPI2_1(%rip), %zmm13 # zmm13 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	movq	%r14, %rax
+	vpbroadcastq	.LCPI2_1(%rip), %zmm14 # zmm14 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
 	kmovw	%k5, 30(%rsp)           # 2-byte Spill
 	vmovdqa64	%zmm11, 256(%rsp) # 64-byte Spill
 	vmovdqa64	%zmm12, 192(%rsp) # 64-byte Spill
 	vmovdqa64	%zmm13, 128(%rsp) # 64-byte Spill
+	vmovdqa64	%zmm14, 64(%rsp) # 64-byte Spill
 	jmp	.LBB2_9
 	.p2align	4, 0x90
-.LBB2_12:                               # %for_test30.loopexit
+.LBB2_14:                               # %for_test34.loopexit
                                         #   in Loop: Header=BB2_9 Depth=1
 	movl	$-2147483648, %edi      # imm = 0x80000000
 	cmpq	$1, 56(%rsp)            # 8-byte Folded Reload
 	movq	48(%rsp), %rax          # 8-byte Reload
-	jle	.LBB2_13
-.LBB2_9:                                # %for_loop31
+	jle	.LBB2_15
+.LBB2_9:                                # %for_loop35
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_43 Depth 2
-                                        #       Child Loop BB2_44 Depth 3
-                                        #         Child Loop BB2_23 Depth 4
+                                        #     Child Loop BB2_12 Depth 2
+                                        #       Child Loop BB2_26 Depth 3
+                                        #         Child Loop BB2_29 Depth 4
+                                        #       Child Loop BB2_49 Depth 3
                                         #       Child Loop BB2_41 Depth 3
-                                        #       Child Loop BB2_32 Depth 3
-                                        #         Child Loop BB2_36 Depth 4
+                                        #         Child Loop BB2_44 Depth 4
+                                        #       Child Loop BB2_50 Depth 3
 	movq	%rax, 56(%rsp)          # 8-byte Spill
 	leaq	-1(%rax), %rcx
 	movq	%rcx, %rax
@@ -1603,43 +1615,50 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	testq	%rcx, %rcx
 	vpternlogd	$255, %zmm0, %zmm0, %zmm0
 	je	.LBB2_11
-# %bb.10:                               # %for_loop31
+# %bb.10:                               # %for_loop35
                                         #   in Loop: Header=BB2_9 Depth=1
 	vpxor	%xmm0, %xmm0, %xmm0
-.LBB2_11:                               # %for_loop31
+.LBB2_11:                               # %for_loop35
                                         #   in Loop: Header=BB2_9 Depth=1
 	vpaddd	8576(%rsp,%rax), %zmm0, %zmm0
 	vmovdqa64	%zmm0, 320(%rsp) # 64-byte Spill
-	jmp	.LBB2_43
+	jmp	.LBB2_12
 	.p2align	4, 0x90
-.LBB2_42:                               # %for_exit127
-                                        #   in Loop: Header=BB2_43 Depth=2
+.LBB2_51:                               # %for_exit135
+                                        #   in Loop: Header=BB2_12 Depth=2
 	shrl	%edi
-	je	.LBB2_12
-.LBB2_43:                               # %for_loop48.lr.ph.split.us
+	je	.LBB2_14
+.LBB2_12:                               # %do_loop
                                         #   Parent Loop BB2_9 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB2_44 Depth 3
-                                        #         Child Loop BB2_23 Depth 4
+                                        #       Child Loop BB2_26 Depth 3
+                                        #         Child Loop BB2_29 Depth 4
+                                        #       Child Loop BB2_49 Depth 3
                                         #       Child Loop BB2_41 Depth 3
-                                        #       Child Loop BB2_32 Depth 3
-                                        #         Child Loop BB2_36 Depth 4
-	movl	%edi, 44(%rsp)          # 4-byte Spill
+                                        #         Child Loop BB2_44 Depth 4
+                                        #       Child Loop BB2_50 Depth 3
+	movl	%edi, 36(%rsp)          # 4-byte Spill
 	leaq	29056(%rsp), %rdi
 	leaq	384(%rsp), %rsi
-	movl	%r15d, %edx
+	movl	%r13d, %edx
 	callq	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	testl	%r13d, %r13d
+	je	.LBB2_13
+# %bb.25:                               # %for_loop67.lr.ph.us.preheader
+                                        #   in Loop: Header=BB2_12 Depth=2
 	movl	$1, %eax
 	xorl	%ecx, %ecx
-	vmovdqa64	64(%rsp), %zmm6 # 64-byte Reload
-	jmp	.LBB2_44
+	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
+	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
+	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	vmovdqa64	64(%rsp), %zmm14 # 64-byte Reload
+	jmp	.LBB2_26
 	.p2align	4, 0x90
-.LBB2_45:                               #   in Loop: Header=BB2_44 Depth=3
+.LBB2_27:                               #   in Loop: Header=BB2_26 Depth=3
 	vpxor	%xmm3, %xmm3, %xmm3
 	xorl	%esi, %esi
-.LBB2_25:                               # %for_loop59.us.epil.preheader
-                                        #   in Loop: Header=BB2_44 Depth=3
+.LBB2_31:                               # %for_loop67.us.epil.preheader
+                                        #   in Loop: Header=BB2_26 Depth=3
 	movq	%rsi, %rdx
 	shlq	$6, %rdx
 	vpmovzxdq	8576(%rsp,%rdx), %zmm4 # zmm4 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -1652,25 +1671,25 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm0, %zmm3, %zmm0
 	vpaddq	29056(%rsp,%rsi), %zmm2, %zmm2
 	vpaddq	%zmm1, %zmm2, %zmm1
-	vpandd	%zmm13, %zmm0, %zmm2
-	vpandd	%zmm13, %zmm1, %zmm3
+	vpandd	%zmm14, %zmm0, %zmm2
+	vpandd	%zmm14, %zmm1, %zmm3
 	vmovdqa64	%zmm3, 29056(%rsp,%rsi)
 	vmovdqa64	%zmm2, 29120(%rsp,%rsi)
 	vpsrlq	$32, %zmm0, %zmm3
 	vpsrlq	$32, %zmm1, %zmm2
-.LBB2_26:                               # %for_exit61.us
-                                        #   in Loop: Header=BB2_44 Depth=3
+.LBB2_32:                               # %for_exit69.us
+                                        #   in Loop: Header=BB2_26 Depth=3
 	vmovdqa64	%zmm3, 448(%rsp,%r8)
 	vmovdqa64	%zmm2, 384(%rsp,%r8)
 	addq	$1, %rcx
 	addq	$1, %rax
 	cmpq	%r14, %rcx
-	je	.LBB2_27
-.LBB2_44:                               # %for_loop59.lr.ph.us
+	je	.LBB2_33
+.LBB2_26:                               # %for_loop67.lr.ph.us
                                         #   Parent Loop BB2_9 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
+                                        #     Parent Loop BB2_12 Depth=2
                                         # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_23 Depth 4
+                                        #         Child Loop BB2_29 Depth 4
 	movq	%rcx, %r8
 	shlq	$7, %r8
 	vmovdqa64	29056(%rsp,%r8), %zmm0
@@ -1678,23 +1697,23 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpmovqd	%zmm0, %ymm0
 	vpmovqd	%zmm1, %ymm1
 	vinserti64x4	$1, %ymm1, %zmm0, %zmm0
-	vpmulld	%zmm0, %zmm6, %zmm1
+	vpmulld	%zmm0, %zmm12, %zmm1
 	vextracti64x4	$1, %zmm1, %ymm0
 	vpmovzxdq	%ymm0, %zmm0    # zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
 	vpmovzxdq	%ymm1, %zmm1    # zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero
 	vpxor	%xmm2, %xmm2, %xmm2
 	testl	%r12d, %r12d
-	je	.LBB2_45
-# %bb.22:                               # %for_loop59.lr.ph.us.new
-                                        #   in Loop: Header=BB2_44 Depth=3
-	movq	%r13, %rdi
+	je	.LBB2_27
+# %bb.28:                               # %for_loop67.lr.ph.us.new
+                                        #   in Loop: Header=BB2_26 Depth=3
+	movq	%r15, %rdi
 	xorl	%esi, %esi
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB2_23:                               # %for_loop59.us
+.LBB2_29:                               # %for_loop67.us
                                         #   Parent Loop BB2_9 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        #       Parent Loop BB2_44 Depth=3
+                                        #     Parent Loop BB2_12 Depth=2
+                                        #       Parent Loop BB2_26 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
 	vpmovzxdq	-32(%rdi), %zmm4 # zmm4 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
 	vpmovzxdq	-64(%rdi), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -1706,8 +1725,8 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	29120(%rsp,%rdx), %zmm3, %zmm3
 	vpaddq	%zmm5, %zmm2, %zmm2
 	vpaddq	%zmm4, %zmm3, %zmm3
-	vpandd	%zmm13, %zmm2, %zmm4
-	vpandd	%zmm13, %zmm3, %zmm5
+	vpandd	%zmm14, %zmm2, %zmm4
+	vpandd	%zmm14, %zmm3, %zmm5
 	vmovdqa64	%zmm5, 29120(%rsp,%rdx)
 	vmovdqa64	%zmm4, 29056(%rsp,%rdx)
 	vpsrlq	$32, %zmm2, %zmm2
@@ -1722,25 +1741,30 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm5, %zmm3, %zmm3
 	vpaddq	29056(%rsp,%rdx), %zmm2, %zmm2
 	vpaddq	%zmm4, %zmm2, %zmm2
-	vpandd	%zmm13, %zmm2, %zmm4
+	vpandd	%zmm14, %zmm2, %zmm4
 	vmovdqa64	%zmm4, 29056(%rsp,%rdx)
-	vpandd	%zmm13, %zmm3, %zmm4
+	vpandd	%zmm14, %zmm3, %zmm4
 	vmovdqa64	%zmm4, 29120(%rsp,%rdx)
 	vpsrlq	$32, %zmm3, %zmm3
 	vpsrlq	$32, %zmm2, %zmm2
 	addq	$2, %rsi
 	subq	$-128, %rdi
 	cmpl	%esi, %ebx
-	jne	.LBB2_23
-# %bb.24:                               # %for_test58.for_exit61_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_44 Depth=3
-	testb	$1, %r15b
-	jne	.LBB2_25
-	jmp	.LBB2_26
+	jne	.LBB2_29
+# %bb.30:                               # %for_test66.for_exit69_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_26 Depth=3
+	testb	$1, %r13b
+	jne	.LBB2_31
+	jmp	.LBB2_32
 	.p2align	4, 0x90
-.LBB2_27:                               # %for_loop89.lr.ph
-                                        #   in Loop: Header=BB2_43 Depth=2
-	movl	44(%rsp), %edi          # 4-byte Reload
+.LBB2_33:                               # %for_test96.preheader
+                                        #   in Loop: Header=BB2_12 Depth=2
+	testl	%r13d, %r13d
+	kmovw	30(%rsp), %k5           # 2-byte Reload
+	je	.LBB2_34
+# %bb.35:                               # %for_loop97.lr.ph
+                                        #   in Loop: Header=BB2_12 Depth=2
+	movl	36(%rsp), %edi          # 4-byte Reload
 	vpbroadcastd	%edi, %zmm0
 	vptestmd	320(%rsp), %zmm0, %k1 # 64-byte Folded Reload
 	vpternlogq	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
@@ -1748,22 +1772,19 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	kshiftrw	$8, %k1, %k1
 	vpternlogq	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
 	vpsrlq	$63, %zmm0, %zmm3
-	testl	%r12d, %r12d
-	kmovw	30(%rsp), %k5           # 2-byte Reload
-	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
-	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
 	vpxor	%xmm0, %xmm0, %xmm0
-	je	.LBB2_28
-# %bb.40:                               # %for_loop89.lr.ph.new
-                                        #   in Loop: Header=BB2_43 Depth=2
-	movl	%r15d, %ecx
+	testl	%r12d, %r12d
+	je	.LBB2_36
+# %bb.48:                               # %for_loop97.lr.ph.new
+                                        #   in Loop: Header=BB2_12 Depth=2
+	movl	%r13d, %ecx
 	leaq	512(%rsp), %rdx
 	xorl	%eax, %eax
 	vpxor	%xmm1, %xmm1, %xmm1
 	.p2align	4, 0x90
-.LBB2_41:                               # %for_loop89
+.LBB2_49:                               # %for_loop97
                                         #   Parent Loop BB2_9 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
+                                        #     Parent Loop BB2_12 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	movl	%ecx, %esi
 	shlq	$7, %rsi
@@ -1775,8 +1796,8 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm0, %zmm4, %zmm0
 	vpsllvq	%zmm3, %zmm5, %zmm4
 	vpaddq	%zmm1, %zmm4, %zmm1
-	vpandd	%zmm13, %zmm0, %zmm4
-	vpandd	%zmm13, %zmm1, %zmm5
+	vpandd	%zmm14, %zmm0, %zmm4
+	vpandd	%zmm14, %zmm1, %zmm5
 	vmovdqa64	%zmm5, -64(%rdx)
 	vmovdqa64	%zmm4, -128(%rdx)
 	vpsrlq	$32, %zmm1, %zmm1
@@ -1791,8 +1812,8 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm1, %zmm4, %zmm1
 	vpsllvq	%zmm2, %zmm5, %zmm4
 	vpaddq	%zmm0, %zmm4, %zmm0
-	vpandd	%zmm13, %zmm1, %zmm4
-	vpandd	%zmm13, %zmm0, %zmm5
+	vpandd	%zmm14, %zmm1, %zmm4
+	vpandd	%zmm14, %zmm0, %zmm5
 	vmovdqa64	%zmm5, (%rdx)
 	vmovdqa64	%zmm4, 64(%rdx)
 	vpsrlq	$32, %zmm1, %zmm1
@@ -1801,21 +1822,37 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	addq	$256, %rdx              # imm = 0x100
 	addl	$2, %ecx
 	cmpl	%eax, %ebx
-	jne	.LBB2_41
-# %bb.29:                               # %for_test88.for_test124.preheader_crit_edge.unr-lcssa
-                                        #   in Loop: Header=BB2_43 Depth=2
-	testb	$1, %r15b
-	jne	.LBB2_30
-	jmp	.LBB2_31
+	jne	.LBB2_49
+# %bb.37:                               # %for_test96.for_test132.preheader_crit_edge.unr-lcssa
+                                        #   in Loop: Header=BB2_12 Depth=2
+	testb	$1, %r13b
+	jne	.LBB2_38
+	jmp	.LBB2_39
 	.p2align	4, 0x90
-.LBB2_28:                               #   in Loop: Header=BB2_43 Depth=2
+.LBB2_13:                               #   in Loop: Header=BB2_12 Depth=2
+	vpxor	%xmm0, %xmm0, %xmm0
+	vpxor	%xmm1, %xmm1, %xmm1
+	kmovw	30(%rsp), %k5           # 2-byte Reload
+	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
+	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
+	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	movl	36(%rsp), %edi          # 4-byte Reload
+	vmovdqa64	64(%rsp), %zmm14 # 64-byte Reload
+	jmp	.LBB2_39
+	.p2align	4, 0x90
+.LBB2_34:                               #   in Loop: Header=BB2_12 Depth=2
+	vpxor	%xmm0, %xmm0, %xmm0
+	vpxor	%xmm1, %xmm1, %xmm1
+	movl	36(%rsp), %edi          # 4-byte Reload
+	jmp	.LBB2_39
+.LBB2_36:                               #   in Loop: Header=BB2_12 Depth=2
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
-.LBB2_30:                               # %for_loop89.epil.preheader
-                                        #   in Loop: Header=BB2_43 Depth=2
+.LBB2_38:                               # %for_loop97.epil.preheader
+                                        #   in Loop: Header=BB2_12 Depth=2
 	movq	%rax, %rcx
 	shlq	$7, %rcx
-	addl	%r15d, %eax
+	addl	%r13d, %eax
 	shlq	$7, %rax
 	vmovdqa64	29056(%rsp,%rax), %zmm4
 	vmovdqa64	29120(%rsp,%rax), %zmm5
@@ -1825,26 +1862,43 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm1, %zmm3, %zmm1
 	vpsllvq	%zmm2, %zmm4, %zmm2
 	vpaddq	%zmm0, %zmm2, %zmm0
-	vpandd	%zmm13, %zmm1, %zmm2
-	vpandd	%zmm13, %zmm0, %zmm3
+	vpandd	%zmm14, %zmm1, %zmm2
+	vpandd	%zmm14, %zmm0, %zmm3
 	vmovdqa64	%zmm3, 384(%rsp,%rcx)
 	vmovdqa64	%zmm2, 448(%rsp,%rcx)
 	vpsrlq	$32, %zmm1, %zmm1
 	vpsrlq	$32, %zmm0, %zmm0
-.LBB2_31:                               # %for_test124.preheader
-                                        #   in Loop: Header=BB2_43 Depth=2
+.LBB2_39:                               # %for_test132.preheader
+                                        #   in Loop: Header=BB2_12 Depth=2
 	vptestmq	%zmm0, %zmm0, %k0
 	vptestmq	%zmm1, %zmm1, %k1
 	kunpckbw	%k0, %k1, %k1
-	jmp	.LBB2_32
+	kandw	%k5, %k1, %k0
+	kortestw	%k0, %k0
+	je	.LBB2_51
+# %bb.40:                               # %for_test146.preheader.lr.ph
+                                        #   in Loop: Header=BB2_12 Depth=2
+	testl	%r13d, %r13d
+	kmovw	%k1, %k0
+	jne	.LBB2_41
 	.p2align	4, 0x90
-.LBB2_34:                               #   in Loop: Header=BB2_32 Depth=3
+.LBB2_50:                               # %for_exit149
+                                        #   Parent Loop BB2_9 Depth=1
+                                        #     Parent Loop BB2_12 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	kandw	%k0, %k1, %k0
+	kandw	%k5, %k0, %k2
+	kortestw	%k2, %k2
+	jne	.LBB2_50
+	jmp	.LBB2_51
+	.p2align	4, 0x90
+.LBB2_42:                               #   in Loop: Header=BB2_41 Depth=3
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpxor	%xmm4, %xmm4, %xmm4
 	xorl	%eax, %eax
-.LBB2_38:                               # %for_loop139.us.epil.preheader
-                                        #   in Loop: Header=BB2_32 Depth=3
+.LBB2_46:                               # %for_loop147.us.epil.preheader
+                                        #   in Loop: Header=BB2_41 Depth=3
 	movq	%rax, %rcx
 	shlq	$7, %rcx
 	vmovdqa64	384(%rsp,%rcx), %zmm5
@@ -1860,14 +1914,14 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm3, %zmm4, %zmm3
 	vpsubq	%zmm7, %zmm5, %zmm4
 	vpaddq	%zmm2, %zmm4, %zmm2
-	vpandq	%zmm13, %zmm3, %zmm6 {%k2}
-	vpandq	%zmm13, %zmm2, %zmm5 {%k1}
+	vpandq	%zmm14, %zmm3, %zmm6 {%k2}
+	vpandq	%zmm14, %zmm2, %zmm5 {%k1}
 	vmovdqa64	%zmm5, 384(%rsp,%rcx)
 	vmovdqa64	%zmm6, 448(%rsp,%rcx)
 	vpsraq	$32, %zmm3, %zmm3
 	vpsraq	$32, %zmm2, %zmm2
-.LBB2_39:                               # %for_exit141.us
-                                        #   in Loop: Header=BB2_32 Depth=3
+.LBB2_47:                               # %for_exit149.us
+                                        #   in Loop: Header=BB2_41 Depth=3
 	vmovdqa64	%zmm2, %zmm2 {%k1}{z}
 	vpaddq	%zmm0, %zmm2, %zmm0
 	vmovdqa64	%zmm3, %zmm2 {%k2}{z}
@@ -1876,36 +1930,34 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vptestmq	%zmm1, %zmm1, %k2
 	kunpckbw	%k0, %k2, %k0
 	kandw	%k1, %k0, %k1
-.LBB2_32:                               # %for_test124.preheader
-                                        #   Parent Loop BB2_9 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB2_36 Depth 4
 	kandw	%k5, %k1, %k0
 	kortestw	%k0, %k0
-	je	.LBB2_42
-# %bb.33:                               # %for_loop139.lr.ph.us
-                                        #   in Loop: Header=BB2_32 Depth=3
+	je	.LBB2_51
+.LBB2_41:                               # %for_loop147.lr.ph.us
+                                        #   Parent Loop BB2_9 Depth=1
+                                        #     Parent Loop BB2_12 Depth=2
+                                        # =>    This Loop Header: Depth=3
+                                        #         Child Loop BB2_44 Depth 4
 	testl	%r12d, %r12d
 	kshiftrw	$8, %k1, %k2
-	je	.LBB2_34
-# %bb.35:                               # %for_loop139.lr.ph.us.new
-                                        #   in Loop: Header=BB2_32 Depth=3
+	je	.LBB2_42
+# %bb.43:                               # %for_loop147.lr.ph.us.new
+                                        #   in Loop: Header=BB2_41 Depth=3
 	vpxor	%xmm4, %xmm4, %xmm4
 	movl	$64, %ecx
 	xorl	%eax, %eax
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB2_36:                               # %for_loop139.us
+.LBB2_44:                               # %for_loop147.us
                                         #   Parent Loop BB2_9 Depth=1
-                                        #     Parent Loop BB2_43 Depth=2
-                                        #       Parent Loop BB2_32 Depth=3
+                                        #     Parent Loop BB2_12 Depth=2
+                                        #       Parent Loop BB2_41 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
 	vmovdqa64	8512(%rsp,%rcx), %zmm5
 	vpsllvd	%zmm11, %zmm5, %zmm6
 	vpord	%zmm4, %zmm6, %zmm4
-	vpsrlvd	%zmm12, %zmm5, %zmm5
+	vpsrlvd	%zmm13, %zmm5, %zmm5
 	vpmovzxdq	%ymm4, %zmm6    # zmm6 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
 	vextracti64x4	$1, %zmm4, %ymm4
 	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
@@ -1917,14 +1969,14 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm3, %zmm4, %zmm3
 	vpsubq	%zmm6, %zmm7, %zmm4
 	vpaddq	%zmm2, %zmm4, %zmm2
-	vpandq	%zmm13, %zmm3, %zmm8 {%k2}
-	vpandq	%zmm13, %zmm2, %zmm7 {%k1}
+	vpandq	%zmm14, %zmm3, %zmm8 {%k2}
+	vpandq	%zmm14, %zmm2, %zmm7 {%k1}
 	vmovdqa64	%zmm7, 256(%rsp,%rcx,2)
 	vmovdqa64	%zmm8, 320(%rsp,%rcx,2)
 	vmovdqa64	8576(%rsp,%rcx), %zmm4
 	vpsllvd	%zmm11, %zmm4, %zmm6
 	vpsraq	$32, %zmm3, %zmm3
-	vpsrlvd	%zmm12, %zmm4, %zmm4
+	vpsrlvd	%zmm13, %zmm4, %zmm4
 	vpsraq	$32, %zmm2, %zmm2
 	vpord	%zmm5, %zmm6, %zmm5
 	vpmovzxdq	%ymm5, %zmm6    # zmm6 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
@@ -1934,51 +1986,42 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpaddq	%zmm3, %zmm5, %zmm3
 	vpsubq	%zmm6, %zmm9, %zmm5
 	vpaddq	%zmm2, %zmm5, %zmm2
-	vpandq	%zmm13, %zmm2, %zmm9 {%k1}
+	vpandq	%zmm14, %zmm2, %zmm9 {%k1}
 	vmovdqa64	%zmm9, 384(%rsp,%rcx,2)
-	vpandq	%zmm13, %zmm3, %zmm10 {%k2}
+	vpandq	%zmm14, %zmm3, %zmm10 {%k2}
 	vmovdqa64	%zmm10, 448(%rsp,%rcx,2)
 	vpsraq	$32, %zmm3, %zmm3
 	vpsraq	$32, %zmm2, %zmm2
 	addq	$2, %rax
 	subq	$-128, %rcx
 	cmpl	%eax, %ebx
-	jne	.LBB2_36
-# %bb.37:                               # %for_test138.for_exit141_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_32 Depth=3
-	testb	$1, %r15b
-	jne	.LBB2_38
-	jmp	.LBB2_39
-.LBB2_13:                               # %for_test186.preheader
-	testl	%r15d, %r15d
-	je	.LBB2_14
-# %bb.15:                               # %for_loop187.lr.ph
-	leal	-1(%r15), %r8d
-	movl	%r15d, %ecx
+	jne	.LBB2_44
+# %bb.45:                               # %for_test146.for_exit149_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_41 Depth=3
+	testb	$1, %r13b
+	jne	.LBB2_46
+	jmp	.LBB2_47
+.LBB2_15:                               # %for_test194.preheader
+	kxorw	%k0, %k0, %k1
+	testl	%r13d, %r13d
+	je	.LBB2_68
+# %bb.16:                               # %for_loop195.lr.ph
+	leal	-1(%r13), %r8d
+	movl	%r13d, %ecx
 	andl	$3, %ecx
 	cmpl	$3, %r8d
-	jae	.LBB2_57
-# %bb.16:
+	jae	.LBB2_60
+# %bb.17:
 	xorl	%edx, %edx
-	kxorw	%k0, %k0, %k2
-	jmp	.LBB2_17
-.LBB2_14:
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	24(%rsp), %r9d          # 4-byte Reload
-	kxorw	%k0, %k0, %k2
-	kandw	%k5, %k2, %k0
-	kortestw	%k0, %k0
-	jne	.LBB2_66
-	jmp	.LBB2_71
-.LBB2_57:                               # %for_loop187.lr.ph.new
-	movl	%r15d, %eax
+	jmp	.LBB2_18
+.LBB2_60:                               # %for_loop195.lr.ph.new
+	movl	%r13d, %eax
 	subl	%ecx, %eax
 	movl	$384, %esi              # imm = 0x180
 	xorl	%edx, %edx
 	vpxor	%xmm0, %xmm0, %xmm0
-	kxorw	%k0, %k0, %k2
 	.p2align	4, 0x90
-.LBB2_58:                               # %for_loop187
+.LBB2_61:                               # %for_loop195
                                         # =>This Inner Loop Header: Depth=1
 	vmovaps	(%rsp,%rsi), %zmm1
 	vmovaps	64(%rsp,%rsi), %zmm2
@@ -2016,17 +2059,16 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	addq	$4, %rdx
 	addq	$512, %rsi              # imm = 0x200
 	cmpl	%edx, %eax
-	jne	.LBB2_58
-.LBB2_17:                               # %for_test186.for_test204.preheader_crit_edge.unr-lcssa
+	jne	.LBB2_61
+.LBB2_18:                               # %for_test194.for_test212.preheader_crit_edge.unr-lcssa
 	testl	%ecx, %ecx
-	vmovdqa64	64(%rsp), %zmm7 # 64-byte Reload
-	je	.LBB2_20
-# %bb.18:                               # %for_loop187.epil.preheader
-	leal	(%r15,%rdx), %eax
+	je	.LBB2_21
+# %bb.19:                               # %for_loop195.epil.preheader
+	leal	(%rdx,%r13), %eax
 	shlq	$7, %rdx
 	vpxor	%xmm0, %xmm0, %xmm0
 	.p2align	4, 0x90
-.LBB2_19:                               # %for_loop187.epil
+.LBB2_20:                               # %for_loop195.epil
                                         # =>This Inner Loop Header: Depth=1
 	vmovdqa64	384(%rsp,%rdx), %zmm1
 	vmovdqa64	448(%rsp,%rdx), %zmm2
@@ -2039,24 +2081,24 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	addl	$1, %eax
 	subq	$-128, %rdx
 	addl	$-1, %ecx
-	jne	.LBB2_19
-.LBB2_20:                               # %for_test204.preheader
-	testl	%r15d, %r15d
-	je	.LBB2_21
-# %bb.46:                               # %for_loop205.lr.ph.split.us
+	jne	.LBB2_20
+.LBB2_21:                               # %for_test212.preheader
+	testl	%r13d, %r13d
+	je	.LBB2_68
+# %bb.22:                               # %for_loop213.lr.ph.split.us
 	leaq	8640(%rsp), %r9
-	movl	%r15d, %edx
+	movl	%r13d, %edx
 	andl	$-2, %edx
 	movl	$1, %esi
 	xorl	%edi, %edi
 	vpbroadcastq	.LCPI2_1(%rip), %zmm0 # zmm0 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	jmp	.LBB2_47
+	jmp	.LBB2_23
 	.p2align	4, 0x90
-.LBB2_48:                               #   in Loop: Header=BB2_47 Depth=1
+.LBB2_24:                               #   in Loop: Header=BB2_23 Depth=1
 	vpxor	%xmm4, %xmm4, %xmm4
 	xorl	%eax, %eax
-.LBB2_52:                               # %for_loop221.us.epil.preheader
-                                        #   in Loop: Header=BB2_47 Depth=1
+.LBB2_55:                               # %for_loop229.us.epil.preheader
+                                        #   in Loop: Header=BB2_23 Depth=1
 	movq	%rax, %rcx
 	shlq	$6, %rcx
 	vpmovzxdq	8576(%rsp,%rcx), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -2075,17 +2117,17 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vmovdqa64	%zmm3, 12736(%rsp,%rax)
 	vpsrlq	$32, %zmm1, %zmm4
 	vpsrlq	$32, %zmm2, %zmm3
-.LBB2_53:                               # %for_exit223.us
-                                        #   in Loop: Header=BB2_47 Depth=1
+.LBB2_56:                               # %for_exit231.us
+                                        #   in Loop: Header=BB2_23 Depth=1
 	vmovdqa64	%zmm4, 448(%rsp,%r10)
 	vmovdqa64	%zmm3, 384(%rsp,%r10)
 	addq	$1, %rdi
 	addq	$1, %rsi
 	cmpq	%r14, %rdi
-	je	.LBB2_54
-.LBB2_47:                               # %for_loop221.lr.ph.us
+	je	.LBB2_57
+.LBB2_23:                               # %for_loop229.lr.ph.us
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_50 Depth 2
+                                        #     Child Loop BB2_53 Depth 2
 	movq	%rdi, %r10
 	shlq	$7, %r10
 	vmovdqa64	12672(%rsp,%r10), %zmm1
@@ -2093,21 +2135,21 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpmovqd	%zmm1, %ymm1
 	vpmovqd	%zmm2, %ymm2
 	vinserti64x4	$1, %ymm2, %zmm1, %zmm1
-	vpmulld	%zmm1, %zmm7, %zmm2
+	vpmulld	%zmm1, %zmm12, %zmm2
 	vextracti64x4	$1, %zmm2, %ymm1
 	vpmovzxdq	%ymm1, %zmm1    # zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero
 	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
 	vpxor	%xmm3, %xmm3, %xmm3
-	cmpl	$1, %r15d
-	je	.LBB2_48
-# %bb.49:                               # %for_loop221.lr.ph.us.new
-                                        #   in Loop: Header=BB2_47 Depth=1
+	cmpl	$1, %r13d
+	je	.LBB2_24
+# %bb.52:                               # %for_loop229.lr.ph.us.new
+                                        #   in Loop: Header=BB2_23 Depth=1
 	movq	%r9, %rcx
 	xorl	%eax, %eax
 	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB2_50:                               # %for_loop221.us
-                                        #   Parent Loop BB2_47 Depth=1
+.LBB2_53:                               # %for_loop229.us
+                                        #   Parent Loop BB2_23 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	vpmovzxdq	-32(%rcx), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
 	vpmovzxdq	-64(%rcx), %zmm6 # zmm6 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -2144,263 +2186,35 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	addq	$2, %rax
 	subq	$-128, %rcx
 	cmpl	%eax, %edx
-	jne	.LBB2_50
-# %bb.51:                               # %for_test220.for_exit223_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB2_47 Depth=1
-	testb	$1, %r15b
-	jne	.LBB2_52
-	jmp	.LBB2_53
-.LBB2_54:                               # %for_test253.preheader
-	testl	%r15d, %r15d
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	24(%rsp), %r9d          # 4-byte Reload
-	je	.LBB2_65
-# %bb.55:                               # %for_loop254.lr.ph
-	movl	%r15d, %r10d
-	andl	$3, %r10d
+	jne	.LBB2_53
+# %bb.54:                               # %for_test228.for_exit231_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB2_23 Depth=1
+	testb	$1, %r13b
+	jne	.LBB2_55
+	jmp	.LBB2_56
+.LBB2_57:                               # %for_test261.preheader
+	testl	%r13d, %r13d
+	je	.LBB2_68
+# %bb.58:                               # %for_loop262.lr.ph
+	movl	%r13d, %ecx
+	andl	$3, %ecx
 	cmpl	$3, %r8d
-	jae	.LBB2_59
-# %bb.56:
+	jae	.LBB2_62
+# %bb.59:
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
 	vpxor	%xmm2, %xmm2, %xmm2
-	jmp	.LBB2_61
-.LBB2_21:
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	24(%rsp), %r9d          # 4-byte Reload
-.LBB2_65:                               # %for_exit256
-	kandw	%k5, %k2, %k0
-	kortestw	%k0, %k0
-	je	.LBB2_71
-.LBB2_66:                               # %for_exit256
-	testl	%r15d, %r15d
-	je	.LBB2_71
-# %bb.67:                               # %for_loop289.lr.ph
-	vpbroadcastd	%r9d, %zmm0
-	cmpl	$1, %r15d
-	kshiftrw	$8, %k2, %k1
-	jne	.LBB2_82
-# %bb.68:
-	vpxor	%xmm2, %xmm2, %xmm2
-	xorl	%eax, %eax
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpxor	%xmm3, %xmm3, %xmm3
-	jmp	.LBB2_70
-.LBB2_82:                               # %for_loop289.lr.ph.new
-	movl	$32, %eax
-	subl	%r9d, %eax
-	vpbroadcastd	%eax, %zmm1
-	movl	%r15d, %edi
-	andl	$1, %edi
-	movl	%r15d, %edx
-	subl	%edi, %edx
-	vpxor	%xmm3, %xmm3, %xmm3
-	movl	$64, %esi
-	xorl	%eax, %eax
-	vpbroadcastq	.LCPI2_1(%rip), %zmm4 # zmm4 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm5, %xmm5, %xmm5
-	.p2align	4, 0x90
-.LBB2_83:                               # %for_loop289
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqa64	8512(%rsp,%rsi), %zmm6
-	vpsllvd	%zmm0, %zmm6, %zmm7
-	vpord	%zmm3, %zmm7, %zmm3
-	vpsrlvd	%zmm1, %zmm6, %zmm6
-	vpmovzxdq	%ymm3, %zmm7    # zmm7 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vextracti64x4	$1, %zmm3, %ymm3
-	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vmovdqa64	256(%rsp,%rsi,2), %zmm8
-	vmovdqa64	320(%rsp,%rsi,2), %zmm9
-	vmovdqa64	384(%rsp,%rsi,2), %zmm10
-	vmovdqa64	448(%rsp,%rsi,2), %zmm11
-	vpsubq	%zmm3, %zmm9, %zmm3
-	vpaddq	%zmm5, %zmm3, %zmm3
-	vpsubq	%zmm7, %zmm8, %zmm5
-	vpaddq	%zmm2, %zmm5, %zmm2
-	vpandq	%zmm4, %zmm3, %zmm9 {%k1}
-	vpandq	%zmm4, %zmm2, %zmm8 {%k2}
-	vmovdqa64	%zmm8, 256(%rsp,%rsi,2)
-	vmovdqa64	%zmm9, 320(%rsp,%rsi,2)
-	vmovdqa64	8576(%rsp,%rsi), %zmm5
-	vpsllvd	%zmm0, %zmm5, %zmm7
-	vpsraq	$32, %zmm3, %zmm8
-	vpsrlvd	%zmm1, %zmm5, %zmm3
-	vpsraq	$32, %zmm2, %zmm2
-	vpord	%zmm6, %zmm7, %zmm5
-	vpmovzxdq	%ymm5, %zmm6    # zmm6 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
-	vextracti64x4	$1, %zmm5, %ymm5
-	vpmovzxdq	%ymm5, %zmm5    # zmm5 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
-	vpsubq	%zmm5, %zmm11, %zmm5
-	vpaddq	%zmm8, %zmm5, %zmm5
-	vpsubq	%zmm6, %zmm10, %zmm6
-	vpaddq	%zmm2, %zmm6, %zmm2
-	vpandq	%zmm4, %zmm2, %zmm10 {%k2}
-	vmovdqa64	%zmm10, 384(%rsp,%rsi,2)
-	vpandq	%zmm4, %zmm5, %zmm11 {%k1}
-	vmovdqa64	%zmm11, 448(%rsp,%rsi,2)
-	vpsraq	$32, %zmm5, %zmm5
-	vpsraq	$32, %zmm2, %zmm2
-	addq	$2, %rax
-	subq	$-128, %rsi
-	cmpl	%eax, %edx
-	jne	.LBB2_83
-# %bb.69:                               # %for_test288.safe_if_after_true.loopexit_crit_edge.unr-lcssa
-	testl	%edi, %edi
-	je	.LBB2_71
-.LBB2_70:                               # %for_loop289.epil.preheader
-	movq	%rax, %rdx
-	shlq	$7, %rdx
-	vmovdqa64	384(%rsp,%rdx), %zmm1
-	vmovdqa64	448(%rsp,%rdx), %zmm4
-	shlq	$6, %rax
-	vmovdqa64	8576(%rsp,%rax), %zmm6
-	vpsllvd	%zmm0, %zmm6, %zmm0
-	vpord	%zmm3, %zmm0, %zmm0
-	vpmovzxdq	%ymm0, %zmm3    # zmm3 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
-	vextracti64x4	$1, %zmm0, %ymm0
-	vpmovzxdq	%ymm0, %zmm0    # zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
-	vpsubq	%zmm0, %zmm4, %zmm0
-	vpaddq	%zmm5, %zmm0, %zmm0
-	vpsubq	%zmm3, %zmm1, %zmm3
-	vpaddq	%zmm2, %zmm3, %zmm2
-	vpbroadcastq	.LCPI2_1(%rip), %zmm3 # zmm3 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	vpandq	%zmm3, %zmm0, %zmm4 {%k1}
-	vpandq	%zmm3, %zmm2, %zmm1 {%k2}
-	vmovdqa64	%zmm1, 384(%rsp,%rdx)
-	vmovdqa64	%zmm4, 448(%rsp,%rdx)
-.LBB2_71:                               # %safe_if_after_true
-	leal	-1(%r15), %eax
-	shlq	$7, %rax
-	vmovdqa64	384(%rsp,%rax), %zmm0
-	vmovdqa64	448(%rsp,%rax), %zmm1
-	vptestmq	%zmm0, %zmm0, %k0
-	vptestmq	%zmm1, %zmm1, %k1
-	kunpckbw	%k0, %k1, %k1
-	kandw	%k5, %k1, %k0
-	vpcmpeqd	%xmm2, %xmm2, %xmm2
-	kortestw	%k0, %k0
-	je	.LBB2_76
-# %bb.72:                               # %for_test347.preheader
-	xorl	%eax, %eax
-	cmpl	%r15d, %eax
-	movl	$0, %edx
-	sbbw	%dx, %dx
-	kmovw	%edx, %k0
-	kandw	%k0, %k1, %k2
-	kandw	%k5, %k2, %k0
-	kortestw	%k0, %k0
-	je	.LBB2_76
-# %bb.73:                               # %for_loop348.preheader
-	vpbroadcastd	.LCPI2_2(%rip), %zmm2 # zmm2 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-	kxnorw	%k0, %k0, %k3
-	.p2align	4, 0x90
-.LBB2_74:                               # %for_loop348
-                                        # =>This Inner Loop Header: Depth=1
-	movl	%eax, %esi
-	movq	%rsi, %rdx
-	shlq	$6, %rdx
-	vmovdqa64	8576(%rsp,%rdx), %zmm3
-	vpaddd	%zmm2, %zmm3, %zmm4
-	vpcmpltud	%zmm3, %zmm4, %k4
-	vpternlogd	$255, %zmm3, %zmm3, %zmm3 {%k4}{z}
-	vpsrld	$31, %zmm3, %zmm2 {%k2}
-	shlq	$7, %rsi
-	vextracti64x4	$1, %zmm4, %ymm3
-	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
-	vpcmpneqq	384(%rsp,%rsi), %zmm4, %k0
-	vpcmpneqq	448(%rsp,%rsi), %zmm3, %k4
-	kunpckbw	%k0, %k4, %k0
-	kandw	%k2, %k0, %k0
-	kxorw	%k3, %k0, %k3
-	addl	$1, %eax
-	cmpl	%r15d, %eax
-	sbbw	%dx, %dx
-	kmovw	%edx, %k0
-	kandw	%k0, %k2, %k0
-	kandw	%k0, %k3, %k2
-	kandw	%k5, %k2, %k0
-	kortestw	%k0, %k0
-	jne	.LBB2_74
-# %bb.75:                               # %for_test347.safe_if_after_true339.loopexit_crit_edge
-	vpternlogd	$255, %zmm2, %zmm2, %zmm2 {%k3}{z}
-	vpmovdb	%zmm2, %xmm2
-.LBB2_76:                               # %safe_if_after_true339
-	vptestnmq	%zmm0, %zmm0, %k0
-	vptestnmq	%zmm1, %zmm1, %k2
-	kunpckbw	%k0, %k2, %k0
-	kandw	%k5, %k0, %k2
-	kortestw	%k2, %k2
-	je	.LBB2_81
-# %bb.77:                               # %safe_if_run_false405
-	vpbroadcastq	.LCPI2_3(%rip), %zmm0 # zmm0 = [1,1,1,1,1,1,1,1]
-	vpcmpeqq	384(%rsp), %zmm0, %k2
-	vpcmpeqq	448(%rsp), %zmm0, %k3
-	kunpckbw	%k2, %k3, %k2
-	vpmovsxbd	%xmm2, %zmm0
-	vpslld	$31, %zmm0, %zmm0
-	kandnw	%k2, %k1, %k2
-	vptestmd	%zmm0, %zmm0, %k1 {%k1}
-	korw	%k2, %k1, %k1
-	xorl	%eax, %eax
-	cmpl	$1, %r15d
-	movl	$65535, %edx            # imm = 0xFFFF
-	cmovbel	%eax, %edx
-	kmovw	%edx, %k2
-	kandw	%k0, %k1, %k0
-	kandw	%k2, %k0, %k0
-	kandw	%k5, %k0, %k2
-	kortestw	%k2, %k2
-	je	.LBB2_80
-# %bb.78:                               # %for_loop421.preheader
-	movl	$1, %eax
-	.p2align	4, 0x90
-.LBB2_79:                               # %for_loop421
-                                        # =>This Inner Loop Header: Depth=1
-	movl	%eax, %edx
-	shlq	$7, %rdx
-	vmovdqa64	384(%rsp,%rdx), %zmm0
-	vmovdqa64	448(%rsp,%rdx), %zmm1
-	vptestmq	%zmm0, %zmm0, %k2
-	vptestmq	%zmm1, %zmm1, %k3
-	kunpckbw	%k2, %k3, %k2
-	kandw	%k0, %k2, %k2
-	kxorw	%k1, %k2, %k1
-	addl	$1, %eax
-	cmpl	%r15d, %eax
-	sbbw	%dx, %dx
-	kmovw	%edx, %k2
-	kandw	%k2, %k0, %k0
-	kandw	%k0, %k1, %k0
-	kandw	%k5, %k0, %k2
-	kortestw	%k2, %k2
-	jne	.LBB2_79
-.LBB2_80:                               # %if_done338.loopexit
-	vpternlogd	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
-	vpmovdb	%zmm0, %xmm2
-.LBB2_81:                               # %if_done338
-	vpand	.LCPI2_4(%rip), %xmm2, %xmm0
-	vpmovzxbd	%xmm0, %zmm0    # zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero,xmm0[8],zero,zero,zero,xmm0[9],zero,zero,zero,xmm0[10],zero,zero,zero,xmm0[11],zero,zero,zero,xmm0[12],zero,zero,zero,xmm0[13],zero,zero,zero,xmm0[14],zero,zero,zero,xmm0[15],zero,zero,zero
-	vmovdqu32	%zmm0, (%rcx) {%k5}
-	leaq	-40(%rbp), %rsp
-	popq	%rbx
-	popq	%r12
-	popq	%r13
-	popq	%r14
-	popq	%r15
-	popq	%rbp
-	retq
-.LBB2_59:                               # %for_loop254.lr.ph.new
+	jmp	.LBB2_64
+.LBB2_62:                               # %for_loop262.lr.ph.new
 	leaq	768(%rsp), %rdx
-	movl	%r15d, %esi
-	subl	%r10d, %esi
+	movl	%r13d, %esi
+	subl	%ecx, %esi
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
-	movl	%r15d, %edi
+	movl	%r13d, %edi
 	vpxor	%xmm2, %xmm2, %xmm2
 	.p2align	4, 0x90
-.LBB2_60:                               # %for_loop254
+.LBB2_63:                               # %for_loop262
                                         # =>This Inner Loop Header: Depth=1
 	vpaddq	-320(%rdx), %zmm2, %zmm2
 	vpaddq	-384(%rdx), %zmm1, %zmm1
@@ -2454,17 +2268,17 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	addq	$512, %rdx              # imm = 0x200
 	addl	$4, %edi
 	cmpl	%eax, %esi
-	jne	.LBB2_60
-.LBB2_61:                               # %for_test253.for_exit256_crit_edge.unr-lcssa
-	testl	%r10d, %r10d
-	je	.LBB2_64
-# %bb.62:                               # %for_loop254.epil.preheader
-	leal	(%r15,%rax), %edx
+	jne	.LBB2_63
+.LBB2_64:                               # %for_test261.for_exit264_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB2_67
+# %bb.65:                               # %for_loop262.epil.preheader
+	leal	(%rax,%r13), %edx
 	shlq	$7, %rax
 	addq	%rsp, %rax
 	addq	$384, %rax              # imm = 0x180
 	.p2align	4, 0x90
-.LBB2_63:                               # %for_loop254.epil
+.LBB2_66:                               # %for_loop262.epil
                                         # =>This Inner Loop Header: Depth=1
 	vpaddq	64(%rax), %zmm2, %zmm2
 	vpaddq	(%rax), %zmm1, %zmm1
@@ -2480,16 +2294,235 @@ fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu: # @
 	vpsrlq	$32, %zmm1, %zmm1
 	addl	$1, %edx
 	subq	$-128, %rax
-	addl	$-1, %r10d
-	jne	.LBB2_63
-.LBB2_64:                               # %for_test253.for_exit256_crit_edge
+	addl	$-1, %ecx
+	jne	.LBB2_66
+.LBB2_67:                               # %for_test261.for_exit264_crit_edge
 	vptestmq	%zmm1, %zmm1, %k0
 	vptestmq	%zmm2, %zmm2, %k1
-	kunpckbw	%k0, %k1, %k2
+	kunpckbw	%k0, %k1, %k1
+.LBB2_68:                               # %for_exit264
+	kandw	%k5, %k1, %k0
+	kortestw	%k0, %k0
+	je	.LBB2_74
+# %bb.69:                               # %for_exit264
+	testl	%r13d, %r13d
+	je	.LBB2_74
+# %bb.70:                               # %for_loop297.lr.ph
+	cmpl	$1, %r13d
+	kshiftrw	$8, %k1, %k2
+	jne	.LBB2_85
+# %bb.71:
+	vpxor	%xmm1, %xmm1, %xmm1
+	xorl	%eax, %eax
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm2, %xmm2, %xmm2
+	jmp	.LBB2_73
+.LBB2_85:                               # %for_loop297.lr.ph.new
+	movl	$32, %eax
+	subl	32(%rsp), %eax          # 4-byte Folded Reload
+	vpbroadcastd	%eax, %zmm0
+	movl	%r13d, %ecx
+	andl	$1, %ecx
+	movl	%r13d, %edx
+	subl	%ecx, %edx
+	vpxor	%xmm2, %xmm2, %xmm2
+	movl	$64, %esi
+	xorl	%eax, %eax
+	vpbroadcastq	.LCPI2_1(%rip), %zmm3 # zmm3 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
+	vpxor	%xmm1, %xmm1, %xmm1
+	vpxor	%xmm4, %xmm4, %xmm4
+	.p2align	4, 0x90
+.LBB2_86:                               # %for_loop297
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqa64	8512(%rsp,%rsi), %zmm5
+	vpsllvd	%zmm11, %zmm5, %zmm6
+	vpord	%zmm2, %zmm6, %zmm2
+	vpsrlvd	%zmm0, %zmm5, %zmm5
+	vpmovzxdq	%ymm2, %zmm6    # zmm6 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vextracti64x4	$1, %zmm2, %ymm2
+	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vmovdqa64	256(%rsp,%rsi,2), %zmm7
+	vmovdqa64	320(%rsp,%rsi,2), %zmm8
+	vmovdqa64	384(%rsp,%rsi,2), %zmm9
+	vmovdqa64	448(%rsp,%rsi,2), %zmm10
+	vpsubq	%zmm2, %zmm8, %zmm2
+	vpaddq	%zmm4, %zmm2, %zmm2
+	vpsubq	%zmm6, %zmm7, %zmm4
+	vpaddq	%zmm1, %zmm4, %zmm1
+	vpandq	%zmm3, %zmm2, %zmm8 {%k2}
+	vpandq	%zmm3, %zmm1, %zmm7 {%k1}
+	vmovdqa64	%zmm7, 256(%rsp,%rsi,2)
+	vmovdqa64	%zmm8, 320(%rsp,%rsi,2)
+	vmovdqa64	8576(%rsp,%rsi), %zmm4
+	vpsllvd	%zmm11, %zmm4, %zmm6
+	vpsraq	$32, %zmm2, %zmm7
+	vpsrlvd	%zmm0, %zmm4, %zmm2
+	vpsraq	$32, %zmm1, %zmm1
+	vpord	%zmm5, %zmm6, %zmm4
+	vpmovzxdq	%ymm4, %zmm5    # zmm5 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vextracti64x4	$1, %zmm4, %ymm4
+	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vpsubq	%zmm4, %zmm10, %zmm4
+	vpaddq	%zmm7, %zmm4, %zmm4
+	vpsubq	%zmm5, %zmm9, %zmm5
+	vpaddq	%zmm1, %zmm5, %zmm1
+	vpandq	%zmm3, %zmm1, %zmm9 {%k1}
+	vmovdqa64	%zmm9, 384(%rsp,%rsi,2)
+	vpandq	%zmm3, %zmm4, %zmm10 {%k2}
+	vmovdqa64	%zmm10, 448(%rsp,%rsi,2)
+	vpsraq	$32, %zmm4, %zmm4
+	vpsraq	$32, %zmm1, %zmm1
+	addq	$2, %rax
+	subq	$-128, %rsi
+	cmpl	%eax, %edx
+	jne	.LBB2_86
+# %bb.72:                               # %for_test296.safe_if_after_true.loopexit_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB2_74
+.LBB2_73:                               # %for_loop297.epil.preheader
+	movq	%rax, %rcx
+	shlq	$7, %rcx
+	vmovdqa64	384(%rsp,%rcx), %zmm0
+	vmovdqa64	448(%rsp,%rcx), %zmm3
+	shlq	$6, %rax
+	vmovdqa64	8576(%rsp,%rax), %zmm5
+	vpsllvd	%zmm11, %zmm5, %zmm5
+	vpord	%zmm2, %zmm5, %zmm2
+	vpmovzxdq	%ymm2, %zmm5    # zmm5 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vextracti64x4	$1, %zmm2, %ymm2
+	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vpsubq	%zmm2, %zmm3, %zmm2
+	vpaddq	%zmm4, %zmm2, %zmm2
+	vpsubq	%zmm5, %zmm0, %zmm4
+	vpaddq	%zmm1, %zmm4, %zmm1
+	vpbroadcastq	.LCPI2_1(%rip), %zmm4 # zmm4 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
+	vpandq	%zmm4, %zmm2, %zmm3 {%k2}
+	vpandq	%zmm4, %zmm1, %zmm0 {%k1}
+	vmovdqa64	%zmm0, 384(%rsp,%rcx)
+	vmovdqa64	%zmm3, 448(%rsp,%rcx)
+.LBB2_74:                               # %safe_if_after_true
+	leal	-1(%r13), %eax
+	shlq	$7, %rax
+	vmovdqa64	384(%rsp,%rax), %zmm0
+	vmovdqa64	448(%rsp,%rax), %zmm1
+	vptestmq	%zmm0, %zmm0, %k0
+	vptestmq	%zmm1, %zmm1, %k1
+	kunpckbw	%k0, %k1, %k1
+	kandw	%k5, %k1, %k0
+	vpcmpeqd	%xmm2, %xmm2, %xmm2
+	kortestw	%k0, %k0
+	je	.LBB2_79
+# %bb.75:                               # %for_test355.preheader
+	xorl	%eax, %eax
+	cmpl	%r13d, %eax
+	movl	$0, %ecx
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k0
+	kandw	%k0, %k1, %k2
 	kandw	%k5, %k2, %k0
 	kortestw	%k0, %k0
-	jne	.LBB2_66
-	jmp	.LBB2_71
+	je	.LBB2_79
+# %bb.76:                               # %for_loop356.preheader
+	vpbroadcastd	.LCPI2_2(%rip), %zmm2 # zmm2 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+	kxnorw	%k0, %k0, %k3
+	.p2align	4, 0x90
+.LBB2_77:                               # %for_loop356
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	movq	%rcx, %rdx
+	shlq	$6, %rdx
+	vmovdqa64	8576(%rsp,%rdx), %zmm3
+	vpaddd	%zmm2, %zmm3, %zmm4
+	vpcmpltud	%zmm3, %zmm4, %k4
+	vpternlogd	$255, %zmm3, %zmm3, %zmm3 {%k4}{z}
+	vpsrld	$31, %zmm3, %zmm2 {%k2}
+	shlq	$7, %rcx
+	vextracti64x4	$1, %zmm4, %ymm3
+	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
+	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vpcmpneqq	384(%rsp,%rcx), %zmm4, %k0
+	vpcmpneqq	448(%rsp,%rcx), %zmm3, %k4
+	kunpckbw	%k0, %k4, %k0
+	kandw	%k2, %k0, %k0
+	kxorw	%k3, %k0, %k3
+	addl	$1, %eax
+	cmpl	%r13d, %eax
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k0
+	kandw	%k0, %k2, %k0
+	kandw	%k0, %k3, %k2
+	kandw	%k5, %k2, %k0
+	kortestw	%k0, %k0
+	jne	.LBB2_77
+# %bb.78:                               # %for_test355.safe_if_after_true347.loopexit_crit_edge
+	vpternlogd	$255, %zmm2, %zmm2, %zmm2 {%k3}{z}
+	vpmovdb	%zmm2, %xmm2
+.LBB2_79:                               # %safe_if_after_true347
+	vptestnmq	%zmm0, %zmm0, %k0
+	vptestnmq	%zmm1, %zmm1, %k2
+	kunpckbw	%k0, %k2, %k0
+	kandw	%k5, %k0, %k2
+	kortestw	%k2, %k2
+	je	.LBB2_84
+# %bb.80:                               # %safe_if_run_false413
+	vpbroadcastq	.LCPI2_3(%rip), %zmm0 # zmm0 = [1,1,1,1,1,1,1,1]
+	vpcmpeqq	384(%rsp), %zmm0, %k2
+	vpcmpeqq	448(%rsp), %zmm0, %k3
+	kunpckbw	%k2, %k3, %k2
+	vpmovsxbd	%xmm2, %zmm0
+	vpslld	$31, %zmm0, %zmm0
+	kandnw	%k2, %k1, %k2
+	vptestmd	%zmm0, %zmm0, %k1 {%k1}
+	korw	%k2, %k1, %k1
+	xorl	%eax, %eax
+	cmpl	$1, %r13d
+	movl	$65535, %ecx            # imm = 0xFFFF
+	cmovbel	%eax, %ecx
+	kmovw	%ecx, %k2
+	kandw	%k0, %k1, %k0
+	kandw	%k2, %k0, %k0
+	kandw	%k5, %k0, %k2
+	kortestw	%k2, %k2
+	je	.LBB2_83
+# %bb.81:                               # %for_loop429.preheader
+	movl	$1, %eax
+	.p2align	4, 0x90
+.LBB2_82:                               # %for_loop429
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	shlq	$7, %rcx
+	vmovdqa64	384(%rsp,%rcx), %zmm0
+	vmovdqa64	448(%rsp,%rcx), %zmm1
+	vptestmq	%zmm0, %zmm0, %k2
+	vptestmq	%zmm1, %zmm1, %k3
+	kunpckbw	%k2, %k3, %k2
+	kandw	%k0, %k2, %k2
+	kxorw	%k1, %k2, %k1
+	addl	$1, %eax
+	cmpl	%r13d, %eax
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k2
+	kandw	%k2, %k0, %k0
+	kandw	%k0, %k1, %k0
+	kandw	%k5, %k0, %k2
+	kortestw	%k2, %k2
+	jne	.LBB2_82
+.LBB2_83:                               # %if_done346.loopexit
+	vpternlogd	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
+	vpmovdb	%zmm0, %xmm2
+.LBB2_84:                               # %if_done346
+	movq	40(%rsp), %rax          # 8-byte Reload
+	vpand	.LCPI2_4(%rip), %xmm2, %xmm0
+	vpmovzxbd	%xmm0, %zmm0    # zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero,xmm0[8],zero,zero,zero,xmm0[9],zero,zero,zero,xmm0[10],zero,zero,zero,xmm0[11],zero,zero,zero,xmm0[12],zero,zero,zero,xmm0[13],zero,zero,zero,xmm0[14],zero,zero,zero,xmm0[15],zero,zero,zero
+	vmovdqu32	%zmm0, (%rax) {%k5}
+	leaq	-40(%rbp), %rsp
+	popq	%rbx
+	popq	%r12
+	popq	%r13
+	popq	%r14
+	popq	%r15
+	popq	%rbp
+	retq
 .Lfunc_end2:
 	.size	fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu, .Lfunc_end2-fermat_test512___un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_un_3C_unu_3E_unuunu
                                         # -- End function
@@ -2541,24 +2574,23 @@ fermat_test512:                            # @fermat_test512
 	pushq	%rbx
 	andq	$-128, %rsp
 	subq	$45568, %rsp            # imm = 0xB200
-	movl	%r8d, %r15d
-	kxorw	%k0, %k0, %k2
+	movl	%r9d, 32(%rsp)          # 4-byte Spill
+	movl	%r8d, %r13d
+	movq	%rcx, 40(%rsp)          # 8-byte Spill
 	testl	%r8d, %r8d
-	je	.LBB3_65
+	je	.LBB3_7
 # %bb.1:                                # %for_loop.lr.ph
-	vpbroadcastd	%r15d, %zmm0
+	vpbroadcastd	%r13d, %zmm0
 	vpmulld	.LCPI3_0(%rip), %zmm0, %zmm0
-	cmpl	$1, %r15d
-	movq	%rcx, 32(%rsp)          # 8-byte Spill
-	movl	%r9d, 28(%rsp)          # 4-byte Spill
+	cmpl	$1, %r13d
 	jne	.LBB3_3
 # %bb.2:
 	xorl	%eax, %eax
 	jmp	.LBB3_6
 .LBB3_3:                                # %for_loop.lr.ph.new
-	movl	%r15d, %r8d
+	movl	%r13d, %r8d
 	andl	$1, %r8d
-	movl	%r15d, %r9d
+	movl	%r13d, %r9d
 	subl	%r8d, %r9d
 	movl	$64, %ecx
 	xorl	%eax, %eax
@@ -2568,12 +2600,12 @@ fermat_test512:                            # @fermat_test512
 	vpbroadcastd	%eax, %zmm1
 	vpaddd	%zmm0, %zmm1, %zmm1
 	vpslld	$2, %zmm1, %zmm1
-	vpxor	%xmm2, %xmm2, %xmm2
 	kxnorw	%k0, %k0, %k1
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdi,%zmm1), %zmm2 {%k1}
 	vmovdqa64	%zmm2, 8512(%rsp,%rcx)
-	vpxor	%xmm2, %xmm2, %xmm2
 	kxnorw	%k0, %k0, %k1
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdx,%zmm1), %zmm2 {%k1}
 	vpmovzxdq	%ymm2, %zmm1    # zmm1 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
 	vextracti64x4	$1, %zmm2, %ymm2
@@ -2584,12 +2616,12 @@ fermat_test512:                            # @fermat_test512
 	vpbroadcastd	%ebx, %zmm1
 	vpaddd	%zmm0, %zmm1, %zmm1
 	vpslld	$2, %zmm1, %zmm1
-	vpxor	%xmm2, %xmm2, %xmm2
 	kxnorw	%k0, %k0, %k1
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdi,%zmm1), %zmm2 {%k1}
 	vmovdqa64	%zmm2, 8576(%rsp,%rcx)
-	vpxor	%xmm2, %xmm2, %xmm2
 	kxnorw	%k0, %k0, %k1
+	vpxor	%xmm2, %xmm2, %xmm2
 	vpgatherdd	(%rdx,%zmm1), %zmm2 {%k1}
 	vpmovzxdq	%ymm2, %zmm1    # zmm1 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
 	vextracti64x4	$1, %zmm2, %ymm2
@@ -2611,8 +2643,8 @@ fermat_test512:                            # @fermat_test512
 	vpslld	$2, %zmm0, %zmm0
 	kxnorw	%k0, %k0, %k1
 	vpxor	%xmm1, %xmm1, %xmm1
-	kxnorw	%k0, %k0, %k2
 	vpxor	%xmm2, %xmm2, %xmm2
+	kxnorw	%k0, %k0, %k2
 	vpgatherdd	(%rdi,%zmm0), %zmm2 {%k2}
 	vmovdqa64	%zmm2, 8576(%rsp,%rcx)
 	shlq	$7, %rax
@@ -2623,44 +2655,57 @@ fermat_test512:                            # @fermat_test512
 	vmovdqa64	%zmm1, 448(%rsp,%rax)
 	vmovdqa64	%zmm0, 384(%rsp,%rax)
 .LBB3_7:                                # %for_exit
-	vmovdqu64	(%rsi), %zmm0
-	vmovdqa64	%zmm0, 64(%rsp) # 64-byte Spill
-	testl	%r15d, %r15d
-	movl	%r15d, %r14d
-	jle	.LBB3_13
-# %bb.8:                                # %for_loop31.lr.ph
-	movl	$-2147483648, %eax      # imm = 0x80000000
-	movl	28(%rsp), %ecx          # 4-byte Reload
-	shrxl	%ecx, %eax, %edi
-	vpbroadcastd	%ecx, %zmm11
-	movl	$32, %eax
+	xorl	%ecx, %ecx
+	movl	32(%rsp), %edx          # 4-byte Reload
+	cmpl	$23, %edx
+	seta	%cl
+	movl	%r13d, %eax
 	subl	%ecx, %eax
-	vpbroadcastd	%eax, %zmm12
-	leal	-1(%r15), %r12d
-	leaq	8640(%rsp), %r13
-	movl	%r15d, %ebx
+	vmovdqu64	(%rsi), %zmm12
+	testl	%eax, %eax
+	vpbroadcastd	%edx, %zmm11
+	movl	%r13d, %r14d
+	jle	.LBB3_15
+# %bb.8:                                # %for_loop35.lr.ph
+	xorl	%ecx, %ecx
+	movl	32(%rsp), %esi          # 4-byte Reload
+	cmpl	$24, %esi
+	setb	%cl
+	shll	$5, %ecx
+	addl	%esi, %ecx
+	addb	$-24, %cl
+	movl	$-2147483648, %edx      # imm = 0x80000000
+	shrxl	%ecx, %edx, %edi
+	movl	$32, %ecx
+	subl	%esi, %ecx
+	vpbroadcastd	%ecx, %zmm13
+	leal	-1(%r13), %r12d
+	movl	%eax, %eax
+	leaq	8640(%rsp), %r15
+	movl	%r13d, %ebx
 	andl	$-2, %ebx
-	vpbroadcastq	.LCPI3_1(%rip), %zmm13 # zmm13 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	movq	%r14, %rax
+	vpbroadcastq	.LCPI3_1(%rip), %zmm14 # zmm14 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
 	vmovdqa64	%zmm11, 256(%rsp) # 64-byte Spill
 	vmovdqa64	%zmm12, 192(%rsp) # 64-byte Spill
 	vmovdqa64	%zmm13, 128(%rsp) # 64-byte Spill
+	vmovdqa64	%zmm14, 64(%rsp) # 64-byte Spill
 	jmp	.LBB3_9
 	.p2align	4, 0x90
-.LBB3_12:                               # %for_test30.loopexit
+.LBB3_14:                               # %for_test34.loopexit
                                         #   in Loop: Header=BB3_9 Depth=1
 	movl	$-2147483648, %edi      # imm = 0x80000000
 	cmpq	$1, 56(%rsp)            # 8-byte Folded Reload
 	movq	48(%rsp), %rax          # 8-byte Reload
-	jle	.LBB3_13
-.LBB3_9:                                # %for_loop31
+	jle	.LBB3_15
+.LBB3_9:                                # %for_loop35
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB3_43 Depth 2
-                                        #       Child Loop BB3_44 Depth 3
-                                        #         Child Loop BB3_23 Depth 4
+                                        #     Child Loop BB3_12 Depth 2
+                                        #       Child Loop BB3_26 Depth 3
+                                        #         Child Loop BB3_29 Depth 4
+                                        #       Child Loop BB3_49 Depth 3
                                         #       Child Loop BB3_41 Depth 3
-                                        #       Child Loop BB3_32 Depth 3
-                                        #         Child Loop BB3_36 Depth 4
+                                        #         Child Loop BB3_44 Depth 4
+                                        #       Child Loop BB3_50 Depth 3
 	movq	%rax, 56(%rsp)          # 8-byte Spill
 	leaq	-1(%rax), %rcx
 	movq	%rcx, %rax
@@ -2669,43 +2714,50 @@ fermat_test512:                            # @fermat_test512
 	testq	%rcx, %rcx
 	vpternlogd	$255, %zmm0, %zmm0, %zmm0
 	je	.LBB3_11
-# %bb.10:                               # %for_loop31
+# %bb.10:                               # %for_loop35
                                         #   in Loop: Header=BB3_9 Depth=1
 	vpxor	%xmm0, %xmm0, %xmm0
-.LBB3_11:                               # %for_loop31
+.LBB3_11:                               # %for_loop35
                                         #   in Loop: Header=BB3_9 Depth=1
 	vpaddd	8576(%rsp,%rax), %zmm0, %zmm0
 	vmovdqa64	%zmm0, 320(%rsp) # 64-byte Spill
-	jmp	.LBB3_43
+	jmp	.LBB3_12
 	.p2align	4, 0x90
-.LBB3_42:                               # %for_exit127
-                                        #   in Loop: Header=BB3_43 Depth=2
+.LBB3_51:                               # %for_exit135
+                                        #   in Loop: Header=BB3_12 Depth=2
 	shrl	%edi
-	je	.LBB3_12
-.LBB3_43:                               # %for_loop48.lr.ph.split.us
+	je	.LBB3_14
+.LBB3_12:                               # %do_loop
                                         #   Parent Loop BB3_9 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB3_44 Depth 3
-                                        #         Child Loop BB3_23 Depth 4
+                                        #       Child Loop BB3_26 Depth 3
+                                        #         Child Loop BB3_29 Depth 4
+                                        #       Child Loop BB3_49 Depth 3
                                         #       Child Loop BB3_41 Depth 3
-                                        #       Child Loop BB3_32 Depth 3
-                                        #         Child Loop BB3_36 Depth 4
-	movl	%edi, 44(%rsp)          # 4-byte Spill
+                                        #         Child Loop BB3_44 Depth 4
+                                        #       Child Loop BB3_50 Depth 3
+	movl	%edi, 36(%rsp)          # 4-byte Spill
 	leaq	29056(%rsp), %rdi
 	leaq	384(%rsp), %rsi
-	movl	%r15d, %edx
+	movl	%r13d, %edx
 	callq	toom2SquareFull___UM_un_3C_vyU_3E_un_3C_CvyU_3E_unu
-	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	testl	%r13d, %r13d
+	je	.LBB3_13
+# %bb.25:                               # %for_loop67.lr.ph.us.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
 	movl	$1, %eax
 	xorl	%ecx, %ecx
-	vmovdqa64	64(%rsp), %zmm6 # 64-byte Reload
-	jmp	.LBB3_44
+	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
+	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
+	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	vmovdqa64	64(%rsp), %zmm14 # 64-byte Reload
+	jmp	.LBB3_26
 	.p2align	4, 0x90
-.LBB3_45:                               #   in Loop: Header=BB3_44 Depth=3
+.LBB3_27:                               #   in Loop: Header=BB3_26 Depth=3
 	vpxor	%xmm3, %xmm3, %xmm3
 	xorl	%esi, %esi
-.LBB3_25:                               # %for_loop59.us.epil.preheader
-                                        #   in Loop: Header=BB3_44 Depth=3
+.LBB3_31:                               # %for_loop67.us.epil.preheader
+                                        #   in Loop: Header=BB3_26 Depth=3
 	movq	%rsi, %rdx
 	shlq	$6, %rdx
 	vpmovzxdq	8576(%rsp,%rdx), %zmm4 # zmm4 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -2718,25 +2770,25 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm0, %zmm3, %zmm0
 	vpaddq	29056(%rsp,%rsi), %zmm2, %zmm2
 	vpaddq	%zmm1, %zmm2, %zmm1
-	vpandd	%zmm13, %zmm0, %zmm2
-	vpandd	%zmm13, %zmm1, %zmm3
+	vpandd	%zmm14, %zmm0, %zmm2
+	vpandd	%zmm14, %zmm1, %zmm3
 	vmovdqa64	%zmm3, 29056(%rsp,%rsi)
 	vmovdqa64	%zmm2, 29120(%rsp,%rsi)
 	vpsrlq	$32, %zmm0, %zmm3
 	vpsrlq	$32, %zmm1, %zmm2
-.LBB3_26:                               # %for_exit61.us
-                                        #   in Loop: Header=BB3_44 Depth=3
+.LBB3_32:                               # %for_exit69.us
+                                        #   in Loop: Header=BB3_26 Depth=3
 	vmovdqa64	%zmm3, 448(%rsp,%r8)
 	vmovdqa64	%zmm2, 384(%rsp,%r8)
 	addq	$1, %rcx
 	addq	$1, %rax
 	cmpq	%r14, %rcx
-	je	.LBB3_27
-.LBB3_44:                               # %for_loop59.lr.ph.us
+	je	.LBB3_33
+.LBB3_26:                               # %for_loop67.lr.ph.us
                                         #   Parent Loop BB3_9 Depth=1
-                                        #     Parent Loop BB3_43 Depth=2
+                                        #     Parent Loop BB3_12 Depth=2
                                         # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB3_23 Depth 4
+                                        #         Child Loop BB3_29 Depth 4
 	movq	%rcx, %r8
 	shlq	$7, %r8
 	vmovdqa64	29056(%rsp,%r8), %zmm0
@@ -2744,23 +2796,23 @@ fermat_test512:                            # @fermat_test512
 	vpmovqd	%zmm0, %ymm0
 	vpmovqd	%zmm1, %ymm1
 	vinserti64x4	$1, %ymm1, %zmm0, %zmm0
-	vpmulld	%zmm0, %zmm6, %zmm1
+	vpmulld	%zmm0, %zmm12, %zmm1
 	vextracti64x4	$1, %zmm1, %ymm0
 	vpmovzxdq	%ymm0, %zmm0    # zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
 	vpmovzxdq	%ymm1, %zmm1    # zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero
 	vpxor	%xmm2, %xmm2, %xmm2
 	testl	%r12d, %r12d
-	je	.LBB3_45
-# %bb.22:                               # %for_loop59.lr.ph.us.new
-                                        #   in Loop: Header=BB3_44 Depth=3
-	movq	%r13, %rdi
+	je	.LBB3_27
+# %bb.28:                               # %for_loop67.lr.ph.us.new
+                                        #   in Loop: Header=BB3_26 Depth=3
+	movq	%r15, %rdi
 	xorl	%esi, %esi
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB3_23:                               # %for_loop59.us
+.LBB3_29:                               # %for_loop67.us
                                         #   Parent Loop BB3_9 Depth=1
-                                        #     Parent Loop BB3_43 Depth=2
-                                        #       Parent Loop BB3_44 Depth=3
+                                        #     Parent Loop BB3_12 Depth=2
+                                        #       Parent Loop BB3_26 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
 	vpmovzxdq	-32(%rdi), %zmm4 # zmm4 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
 	vpmovzxdq	-64(%rdi), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -2772,8 +2824,8 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	29120(%rsp,%rdx), %zmm3, %zmm3
 	vpaddq	%zmm5, %zmm2, %zmm2
 	vpaddq	%zmm4, %zmm3, %zmm3
-	vpandd	%zmm13, %zmm2, %zmm4
-	vpandd	%zmm13, %zmm3, %zmm5
+	vpandd	%zmm14, %zmm2, %zmm4
+	vpandd	%zmm14, %zmm3, %zmm5
 	vmovdqa64	%zmm5, 29120(%rsp,%rdx)
 	vmovdqa64	%zmm4, 29056(%rsp,%rdx)
 	vpsrlq	$32, %zmm2, %zmm2
@@ -2788,25 +2840,29 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm5, %zmm3, %zmm3
 	vpaddq	29056(%rsp,%rdx), %zmm2, %zmm2
 	vpaddq	%zmm4, %zmm2, %zmm2
-	vpandd	%zmm13, %zmm2, %zmm4
+	vpandd	%zmm14, %zmm2, %zmm4
 	vmovdqa64	%zmm4, 29056(%rsp,%rdx)
-	vpandd	%zmm13, %zmm3, %zmm4
+	vpandd	%zmm14, %zmm3, %zmm4
 	vmovdqa64	%zmm4, 29120(%rsp,%rdx)
 	vpsrlq	$32, %zmm3, %zmm3
 	vpsrlq	$32, %zmm2, %zmm2
 	addq	$2, %rsi
 	subq	$-128, %rdi
 	cmpl	%esi, %ebx
-	jne	.LBB3_23
-# %bb.24:                               # %for_test58.for_exit61_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB3_44 Depth=3
-	testb	$1, %r15b
-	jne	.LBB3_25
-	jmp	.LBB3_26
+	jne	.LBB3_29
+# %bb.30:                               # %for_test66.for_exit69_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB3_26 Depth=3
+	testb	$1, %r13b
+	jne	.LBB3_31
+	jmp	.LBB3_32
 	.p2align	4, 0x90
-.LBB3_27:                               # %for_loop89.lr.ph
-                                        #   in Loop: Header=BB3_43 Depth=2
-	movl	44(%rsp), %edi          # 4-byte Reload
+.LBB3_33:                               # %for_test96.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
+	testl	%r13d, %r13d
+	je	.LBB3_34
+# %bb.35:                               # %for_loop97.lr.ph
+                                        #   in Loop: Header=BB3_12 Depth=2
+	movl	36(%rsp), %edi          # 4-byte Reload
 	vpbroadcastd	%edi, %zmm0
 	vptestmd	320(%rsp), %zmm0, %k1 # 64-byte Folded Reload
 	vpternlogq	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
@@ -2814,21 +2870,19 @@ fermat_test512:                            # @fermat_test512
 	kshiftrw	$8, %k1, %k1
 	vpternlogq	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
 	vpsrlq	$63, %zmm0, %zmm3
-	testl	%r12d, %r12d
-	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
-	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
 	vpxor	%xmm0, %xmm0, %xmm0
-	je	.LBB3_28
-# %bb.40:                               # %for_loop89.lr.ph.new
-                                        #   in Loop: Header=BB3_43 Depth=2
-	movl	%r15d, %ecx
+	testl	%r12d, %r12d
+	je	.LBB3_36
+# %bb.48:                               # %for_loop97.lr.ph.new
+                                        #   in Loop: Header=BB3_12 Depth=2
+	movl	%r13d, %ecx
 	leaq	512(%rsp), %rdx
 	xorl	%eax, %eax
 	vpxor	%xmm1, %xmm1, %xmm1
 	.p2align	4, 0x90
-.LBB3_41:                               # %for_loop89
+.LBB3_49:                               # %for_loop97
                                         #   Parent Loop BB3_9 Depth=1
-                                        #     Parent Loop BB3_43 Depth=2
+                                        #     Parent Loop BB3_12 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	movl	%ecx, %esi
 	shlq	$7, %rsi
@@ -2840,8 +2894,8 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm0, %zmm4, %zmm0
 	vpsllvq	%zmm3, %zmm5, %zmm4
 	vpaddq	%zmm1, %zmm4, %zmm1
-	vpandd	%zmm13, %zmm0, %zmm4
-	vpandd	%zmm13, %zmm1, %zmm5
+	vpandd	%zmm14, %zmm0, %zmm4
+	vpandd	%zmm14, %zmm1, %zmm5
 	vmovdqa64	%zmm5, -64(%rdx)
 	vmovdqa64	%zmm4, -128(%rdx)
 	vpsrlq	$32, %zmm1, %zmm1
@@ -2856,8 +2910,8 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm1, %zmm4, %zmm1
 	vpsllvq	%zmm2, %zmm5, %zmm4
 	vpaddq	%zmm0, %zmm4, %zmm0
-	vpandd	%zmm13, %zmm1, %zmm4
-	vpandd	%zmm13, %zmm0, %zmm5
+	vpandd	%zmm14, %zmm1, %zmm4
+	vpandd	%zmm14, %zmm0, %zmm5
 	vmovdqa64	%zmm5, (%rdx)
 	vmovdqa64	%zmm4, 64(%rdx)
 	vpsrlq	$32, %zmm1, %zmm1
@@ -2866,21 +2920,36 @@ fermat_test512:                            # @fermat_test512
 	addq	$256, %rdx              # imm = 0x100
 	addl	$2, %ecx
 	cmpl	%eax, %ebx
-	jne	.LBB3_41
-# %bb.29:                               # %for_test88.for_test124.preheader_crit_edge.unr-lcssa
-                                        #   in Loop: Header=BB3_43 Depth=2
-	testb	$1, %r15b
-	jne	.LBB3_30
-	jmp	.LBB3_31
+	jne	.LBB3_49
+# %bb.37:                               # %for_test96.for_test132.preheader_crit_edge.unr-lcssa
+                                        #   in Loop: Header=BB3_12 Depth=2
+	testb	$1, %r13b
+	jne	.LBB3_38
+	jmp	.LBB3_39
 	.p2align	4, 0x90
-.LBB3_28:                               #   in Loop: Header=BB3_43 Depth=2
+.LBB3_13:                               #   in Loop: Header=BB3_12 Depth=2
+	vpxor	%xmm0, %xmm0, %xmm0
+	vpxor	%xmm1, %xmm1, %xmm1
+	vmovdqa64	256(%rsp), %zmm11 # 64-byte Reload
+	vmovdqa64	192(%rsp), %zmm12 # 64-byte Reload
+	vmovdqa64	128(%rsp), %zmm13 # 64-byte Reload
+	movl	36(%rsp), %edi          # 4-byte Reload
+	vmovdqa64	64(%rsp), %zmm14 # 64-byte Reload
+	jmp	.LBB3_39
+	.p2align	4, 0x90
+.LBB3_34:                               #   in Loop: Header=BB3_12 Depth=2
+	vpxor	%xmm0, %xmm0, %xmm0
+	vpxor	%xmm1, %xmm1, %xmm1
+	movl	36(%rsp), %edi          # 4-byte Reload
+	jmp	.LBB3_39
+.LBB3_36:                               #   in Loop: Header=BB3_12 Depth=2
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
-.LBB3_30:                               # %for_loop89.epil.preheader
-                                        #   in Loop: Header=BB3_43 Depth=2
+.LBB3_38:                               # %for_loop97.epil.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
 	movq	%rax, %rcx
 	shlq	$7, %rcx
-	addl	%r15d, %eax
+	addl	%r13d, %eax
 	shlq	$7, %rax
 	vmovdqa64	29056(%rsp,%rax), %zmm4
 	vmovdqa64	29120(%rsp,%rax), %zmm5
@@ -2890,26 +2959,41 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm1, %zmm3, %zmm1
 	vpsllvq	%zmm2, %zmm4, %zmm2
 	vpaddq	%zmm0, %zmm2, %zmm0
-	vpandd	%zmm13, %zmm1, %zmm2
-	vpandd	%zmm13, %zmm0, %zmm3
+	vpandd	%zmm14, %zmm1, %zmm2
+	vpandd	%zmm14, %zmm0, %zmm3
 	vmovdqa64	%zmm3, 384(%rsp,%rcx)
 	vmovdqa64	%zmm2, 448(%rsp,%rcx)
 	vpsrlq	$32, %zmm1, %zmm1
 	vpsrlq	$32, %zmm0, %zmm0
-.LBB3_31:                               # %for_test124.preheader
-                                        #   in Loop: Header=BB3_43 Depth=2
+.LBB3_39:                               # %for_test132.preheader
+                                        #   in Loop: Header=BB3_12 Depth=2
 	vptestmq	%zmm0, %zmm0, %k0
 	vptestmq	%zmm1, %zmm1, %k1
 	kunpckbw	%k0, %k1, %k1
-	jmp	.LBB3_32
+	kortestw	%k1, %k1
+	je	.LBB3_51
+# %bb.40:                               # %for_test146.preheader.lr.ph
+                                        #   in Loop: Header=BB3_12 Depth=2
+	testl	%r13d, %r13d
+	kmovw	%k1, %k0
+	jne	.LBB3_41
 	.p2align	4, 0x90
-.LBB3_34:                               #   in Loop: Header=BB3_32 Depth=3
+.LBB3_50:                               # %for_exit149
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	kandw	%k0, %k1, %k0
+	kortestw	%k0, %k0
+	jne	.LBB3_50
+	jmp	.LBB3_51
+	.p2align	4, 0x90
+.LBB3_42:                               #   in Loop: Header=BB3_41 Depth=3
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	vpxor	%xmm4, %xmm4, %xmm4
 	xorl	%eax, %eax
-.LBB3_38:                               # %for_loop139.us.epil.preheader
-                                        #   in Loop: Header=BB3_32 Depth=3
+.LBB3_46:                               # %for_loop147.us.epil.preheader
+                                        #   in Loop: Header=BB3_41 Depth=3
 	movq	%rax, %rcx
 	shlq	$7, %rcx
 	vmovdqa64	384(%rsp,%rcx), %zmm5
@@ -2925,14 +3009,14 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm3, %zmm4, %zmm3
 	vpsubq	%zmm7, %zmm5, %zmm4
 	vpaddq	%zmm2, %zmm4, %zmm2
-	vpandq	%zmm13, %zmm3, %zmm6 {%k2}
-	vpandq	%zmm13, %zmm2, %zmm5 {%k1}
+	vpandq	%zmm14, %zmm3, %zmm6 {%k2}
+	vpandq	%zmm14, %zmm2, %zmm5 {%k1}
 	vmovdqa64	%zmm5, 384(%rsp,%rcx)
 	vmovdqa64	%zmm6, 448(%rsp,%rcx)
 	vpsraq	$32, %zmm3, %zmm3
 	vpsraq	$32, %zmm2, %zmm2
-.LBB3_39:                               # %for_exit141.us
-                                        #   in Loop: Header=BB3_32 Depth=3
+.LBB3_47:                               # %for_exit149.us
+                                        #   in Loop: Header=BB3_41 Depth=3
 	vmovdqa64	%zmm2, %zmm2 {%k1}{z}
 	vpaddq	%zmm0, %zmm2, %zmm0
 	vmovdqa64	%zmm3, %zmm2 {%k2}{z}
@@ -2941,35 +3025,33 @@ fermat_test512:                            # @fermat_test512
 	vptestmq	%zmm1, %zmm1, %k2
 	kunpckbw	%k0, %k2, %k0
 	kandw	%k1, %k0, %k1
-.LBB3_32:                               # %for_test124.preheader
-                                        #   Parent Loop BB3_9 Depth=1
-                                        #     Parent Loop BB3_43 Depth=2
-                                        # =>    This Loop Header: Depth=3
-                                        #         Child Loop BB3_36 Depth 4
 	kortestw	%k1, %k1
-	je	.LBB3_42
-# %bb.33:                               # %for_loop139.lr.ph.us
-                                        #   in Loop: Header=BB3_32 Depth=3
+	je	.LBB3_51
+.LBB3_41:                               # %for_loop147.lr.ph.us
+                                        #   Parent Loop BB3_9 Depth=1
+                                        #     Parent Loop BB3_12 Depth=2
+                                        # =>    This Loop Header: Depth=3
+                                        #         Child Loop BB3_44 Depth 4
 	testl	%r12d, %r12d
 	kshiftrw	$8, %k1, %k2
-	je	.LBB3_34
-# %bb.35:                               # %for_loop139.lr.ph.us.new
-                                        #   in Loop: Header=BB3_32 Depth=3
+	je	.LBB3_42
+# %bb.43:                               # %for_loop147.lr.ph.us.new
+                                        #   in Loop: Header=BB3_41 Depth=3
 	vpxor	%xmm4, %xmm4, %xmm4
 	movl	$64, %ecx
 	xorl	%eax, %eax
 	vpxor	%xmm2, %xmm2, %xmm2
 	vpxor	%xmm3, %xmm3, %xmm3
 	.p2align	4, 0x90
-.LBB3_36:                               # %for_loop139.us
+.LBB3_44:                               # %for_loop147.us
                                         #   Parent Loop BB3_9 Depth=1
-                                        #     Parent Loop BB3_43 Depth=2
-                                        #       Parent Loop BB3_32 Depth=3
+                                        #     Parent Loop BB3_12 Depth=2
+                                        #       Parent Loop BB3_41 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
 	vmovdqa64	8512(%rsp,%rcx), %zmm5
 	vpsllvd	%zmm11, %zmm5, %zmm6
 	vpord	%zmm4, %zmm6, %zmm4
-	vpsrlvd	%zmm12, %zmm5, %zmm5
+	vpsrlvd	%zmm13, %zmm5, %zmm5
 	vpmovzxdq	%ymm4, %zmm6    # zmm6 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
 	vextracti64x4	$1, %zmm4, %ymm4
 	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
@@ -2981,14 +3063,14 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm3, %zmm4, %zmm3
 	vpsubq	%zmm6, %zmm7, %zmm4
 	vpaddq	%zmm2, %zmm4, %zmm2
-	vpandq	%zmm13, %zmm3, %zmm8 {%k2}
-	vpandq	%zmm13, %zmm2, %zmm7 {%k1}
+	vpandq	%zmm14, %zmm3, %zmm8 {%k2}
+	vpandq	%zmm14, %zmm2, %zmm7 {%k1}
 	vmovdqa64	%zmm7, 256(%rsp,%rcx,2)
 	vmovdqa64	%zmm8, 320(%rsp,%rcx,2)
 	vmovdqa64	8576(%rsp,%rcx), %zmm4
 	vpsllvd	%zmm11, %zmm4, %zmm6
 	vpsraq	$32, %zmm3, %zmm3
-	vpsrlvd	%zmm12, %zmm4, %zmm4
+	vpsrlvd	%zmm13, %zmm4, %zmm4
 	vpsraq	$32, %zmm2, %zmm2
 	vpord	%zmm5, %zmm6, %zmm5
 	vpmovzxdq	%ymm5, %zmm6    # zmm6 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
@@ -2998,50 +3080,42 @@ fermat_test512:                            # @fermat_test512
 	vpaddq	%zmm3, %zmm5, %zmm3
 	vpsubq	%zmm6, %zmm9, %zmm5
 	vpaddq	%zmm2, %zmm5, %zmm2
-	vpandq	%zmm13, %zmm2, %zmm9 {%k1}
+	vpandq	%zmm14, %zmm2, %zmm9 {%k1}
 	vmovdqa64	%zmm9, 384(%rsp,%rcx,2)
-	vpandq	%zmm13, %zmm3, %zmm10 {%k2}
+	vpandq	%zmm14, %zmm3, %zmm10 {%k2}
 	vmovdqa64	%zmm10, 448(%rsp,%rcx,2)
 	vpsraq	$32, %zmm3, %zmm3
 	vpsraq	$32, %zmm2, %zmm2
 	addq	$2, %rax
 	subq	$-128, %rcx
 	cmpl	%eax, %ebx
-	jne	.LBB3_36
-# %bb.37:                               # %for_test138.for_exit141_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB3_32 Depth=3
-	testb	$1, %r15b
-	jne	.LBB3_38
-	jmp	.LBB3_39
-.LBB3_13:                               # %for_test186.preheader
-	testl	%r15d, %r15d
-	je	.LBB3_14
-# %bb.15:                               # %for_loop187.lr.ph
-	leal	-1(%r15), %r8d
-	movl	%r15d, %ecx
+	jne	.LBB3_44
+# %bb.45:                               # %for_test146.for_exit149_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB3_41 Depth=3
+	testb	$1, %r13b
+	jne	.LBB3_46
+	jmp	.LBB3_47
+.LBB3_15:                               # %for_test194.preheader
+	kxorw	%k0, %k0, %k1
+	testl	%r13d, %r13d
+	je	.LBB3_68
+# %bb.16:                               # %for_loop195.lr.ph
+	leal	-1(%r13), %r8d
+	movl	%r13d, %ecx
 	andl	$3, %ecx
 	cmpl	$3, %r8d
-	jae	.LBB3_57
-# %bb.16:
+	jae	.LBB3_60
+# %bb.17:
 	xorl	%edx, %edx
-	kxorw	%k0, %k0, %k2
-	jmp	.LBB3_17
-.LBB3_14:
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	28(%rsp), %r9d          # 4-byte Reload
-	kxorw	%k0, %k0, %k2
-	kortestw	%k2, %k2
-	jne	.LBB3_66
-	jmp	.LBB3_71
-.LBB3_57:                               # %for_loop187.lr.ph.new
-	movl	%r15d, %eax
+	jmp	.LBB3_18
+.LBB3_60:                               # %for_loop195.lr.ph.new
+	movl	%r13d, %eax
 	subl	%ecx, %eax
 	movl	$384, %esi              # imm = 0x180
 	xorl	%edx, %edx
 	vpxor	%xmm0, %xmm0, %xmm0
-	kxorw	%k0, %k0, %k2
 	.p2align	4, 0x90
-.LBB3_58:                               # %for_loop187
+.LBB3_61:                               # %for_loop195
                                         # =>This Inner Loop Header: Depth=1
 	vmovaps	(%rsp,%rsi), %zmm1
 	vmovaps	64(%rsp,%rsi), %zmm2
@@ -3079,17 +3153,16 @@ fermat_test512:                            # @fermat_test512
 	addq	$4, %rdx
 	addq	$512, %rsi              # imm = 0x200
 	cmpl	%edx, %eax
-	jne	.LBB3_58
-.LBB3_17:                               # %for_test186.for_test204.preheader_crit_edge.unr-lcssa
+	jne	.LBB3_61
+.LBB3_18:                               # %for_test194.for_test212.preheader_crit_edge.unr-lcssa
 	testl	%ecx, %ecx
-	vmovdqa64	64(%rsp), %zmm7 # 64-byte Reload
-	je	.LBB3_20
-# %bb.18:                               # %for_loop187.epil.preheader
-	leal	(%r15,%rdx), %eax
+	je	.LBB3_21
+# %bb.19:                               # %for_loop195.epil.preheader
+	leal	(%rdx,%r13), %eax
 	shlq	$7, %rdx
 	vpxor	%xmm0, %xmm0, %xmm0
 	.p2align	4, 0x90
-.LBB3_19:                               # %for_loop187.epil
+.LBB3_20:                               # %for_loop195.epil
                                         # =>This Inner Loop Header: Depth=1
 	vmovdqa64	384(%rsp,%rdx), %zmm1
 	vmovdqa64	448(%rsp,%rdx), %zmm2
@@ -3102,24 +3175,24 @@ fermat_test512:                            # @fermat_test512
 	addl	$1, %eax
 	subq	$-128, %rdx
 	addl	$-1, %ecx
-	jne	.LBB3_19
-.LBB3_20:                               # %for_test204.preheader
-	testl	%r15d, %r15d
-	je	.LBB3_21
-# %bb.46:                               # %for_loop205.lr.ph.split.us
+	jne	.LBB3_20
+.LBB3_21:                               # %for_test212.preheader
+	testl	%r13d, %r13d
+	je	.LBB3_68
+# %bb.22:                               # %for_loop213.lr.ph.split.us
 	leaq	8640(%rsp), %r9
-	movl	%r15d, %edx
+	movl	%r13d, %edx
 	andl	$-2, %edx
 	movl	$1, %esi
 	xorl	%edi, %edi
 	vpbroadcastq	.LCPI3_1(%rip), %zmm0 # zmm0 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	jmp	.LBB3_47
+	jmp	.LBB3_23
 	.p2align	4, 0x90
-.LBB3_48:                               #   in Loop: Header=BB3_47 Depth=1
+.LBB3_24:                               #   in Loop: Header=BB3_23 Depth=1
 	vpxor	%xmm4, %xmm4, %xmm4
 	xorl	%eax, %eax
-.LBB3_52:                               # %for_loop221.us.epil.preheader
-                                        #   in Loop: Header=BB3_47 Depth=1
+.LBB3_55:                               # %for_loop229.us.epil.preheader
+                                        #   in Loop: Header=BB3_23 Depth=1
 	movq	%rax, %rcx
 	shlq	$6, %rcx
 	vpmovzxdq	8576(%rsp,%rcx), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -3138,17 +3211,17 @@ fermat_test512:                            # @fermat_test512
 	vmovdqa64	%zmm3, 12736(%rsp,%rax)
 	vpsrlq	$32, %zmm1, %zmm4
 	vpsrlq	$32, %zmm2, %zmm3
-.LBB3_53:                               # %for_exit223.us
-                                        #   in Loop: Header=BB3_47 Depth=1
+.LBB3_56:                               # %for_exit231.us
+                                        #   in Loop: Header=BB3_23 Depth=1
 	vmovdqa64	%zmm4, 448(%rsp,%r10)
 	vmovdqa64	%zmm3, 384(%rsp,%r10)
 	addq	$1, %rdi
 	addq	$1, %rsi
 	cmpq	%r14, %rdi
-	je	.LBB3_54
-.LBB3_47:                               # %for_loop221.lr.ph.us
+	je	.LBB3_57
+.LBB3_23:                               # %for_loop229.lr.ph.us
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB3_50 Depth 2
+                                        #     Child Loop BB3_53 Depth 2
 	movq	%rdi, %r10
 	shlq	$7, %r10
 	vmovdqa64	12672(%rsp,%r10), %zmm1
@@ -3156,21 +3229,21 @@ fermat_test512:                            # @fermat_test512
 	vpmovqd	%zmm1, %ymm1
 	vpmovqd	%zmm2, %ymm2
 	vinserti64x4	$1, %ymm2, %zmm1, %zmm1
-	vpmulld	%zmm1, %zmm7, %zmm2
+	vpmulld	%zmm1, %zmm12, %zmm2
 	vextracti64x4	$1, %zmm2, %ymm1
 	vpmovzxdq	%ymm1, %zmm1    # zmm1 = ymm1[0],zero,ymm1[1],zero,ymm1[2],zero,ymm1[3],zero,ymm1[4],zero,ymm1[5],zero,ymm1[6],zero,ymm1[7],zero
 	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
 	vpxor	%xmm3, %xmm3, %xmm3
-	cmpl	$1, %r15d
-	je	.LBB3_48
-# %bb.49:                               # %for_loop221.lr.ph.us.new
-                                        #   in Loop: Header=BB3_47 Depth=1
+	cmpl	$1, %r13d
+	je	.LBB3_24
+# %bb.52:                               # %for_loop229.lr.ph.us.new
+                                        #   in Loop: Header=BB3_23 Depth=1
 	movq	%r9, %rcx
 	xorl	%eax, %eax
 	vpxor	%xmm4, %xmm4, %xmm4
 	.p2align	4, 0x90
-.LBB3_50:                               # %for_loop221.us
-                                        #   Parent Loop BB3_47 Depth=1
+.LBB3_53:                               # %for_loop229.us
+                                        #   Parent Loop BB3_23 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	vpmovzxdq	-32(%rcx), %zmm5 # zmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
 	vpmovzxdq	-64(%rcx), %zmm6 # zmm6 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
@@ -3207,256 +3280,35 @@ fermat_test512:                            # @fermat_test512
 	addq	$2, %rax
 	subq	$-128, %rcx
 	cmpl	%eax, %edx
-	jne	.LBB3_50
-# %bb.51:                               # %for_test220.for_exit223_crit_edge.us.unr-lcssa
-                                        #   in Loop: Header=BB3_47 Depth=1
-	testb	$1, %r15b
-	jne	.LBB3_52
-	jmp	.LBB3_53
-.LBB3_54:                               # %for_test253.preheader
-	testl	%r15d, %r15d
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	28(%rsp), %r9d          # 4-byte Reload
-	je	.LBB3_65
-# %bb.55:                               # %for_loop254.lr.ph
-	movl	%r15d, %r10d
-	andl	$3, %r10d
+	jne	.LBB3_53
+# %bb.54:                               # %for_test228.for_exit231_crit_edge.us.unr-lcssa
+                                        #   in Loop: Header=BB3_23 Depth=1
+	testb	$1, %r13b
+	jne	.LBB3_55
+	jmp	.LBB3_56
+.LBB3_57:                               # %for_test261.preheader
+	testl	%r13d, %r13d
+	je	.LBB3_68
+# %bb.58:                               # %for_loop262.lr.ph
+	movl	%r13d, %ecx
+	andl	$3, %ecx
 	cmpl	$3, %r8d
-	jae	.LBB3_59
-# %bb.56:
+	jae	.LBB3_62
+# %bb.59:
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
 	vpxor	%xmm2, %xmm2, %xmm2
-	jmp	.LBB3_61
-.LBB3_21:
-	movq	32(%rsp), %rcx          # 8-byte Reload
-	movl	28(%rsp), %r9d          # 4-byte Reload
-.LBB3_65:                               # %for_exit256
-	kortestw	%k2, %k2
-	je	.LBB3_71
-.LBB3_66:                               # %for_exit256
-	testl	%r15d, %r15d
-	je	.LBB3_71
-# %bb.67:                               # %for_loop289.lr.ph
-	vpbroadcastd	%r9d, %zmm0
-	cmpl	$1, %r15d
-	kshiftrw	$8, %k2, %k1
-	jne	.LBB3_82
-# %bb.68:
-	vpxor	%xmm2, %xmm2, %xmm2
-	xorl	%eax, %eax
-	vpxor	%xmm5, %xmm5, %xmm5
-	vpxor	%xmm3, %xmm3, %xmm3
-	jmp	.LBB3_70
-.LBB3_82:                               # %for_loop289.lr.ph.new
-	movl	$32, %eax
-	subl	%r9d, %eax
-	vpbroadcastd	%eax, %zmm1
-	movl	%r15d, %edi
-	andl	$1, %edi
-	movl	%r15d, %edx
-	subl	%edi, %edx
-	vpxor	%xmm3, %xmm3, %xmm3
-	movl	$64, %esi
-	xorl	%eax, %eax
-	vpbroadcastq	.LCPI3_1(%rip), %zmm4 # zmm4 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	vpxor	%xmm2, %xmm2, %xmm2
-	vpxor	%xmm5, %xmm5, %xmm5
-	.p2align	4, 0x90
-.LBB3_83:                               # %for_loop289
-                                        # =>This Inner Loop Header: Depth=1
-	vmovdqa64	8512(%rsp,%rsi), %zmm6
-	vpsllvd	%zmm0, %zmm6, %zmm7
-	vpord	%zmm3, %zmm7, %zmm3
-	vpsrlvd	%zmm1, %zmm6, %zmm6
-	vpmovzxdq	%ymm3, %zmm7    # zmm7 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vextracti64x4	$1, %zmm3, %ymm3
-	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vmovdqa64	256(%rsp,%rsi,2), %zmm8
-	vmovdqa64	320(%rsp,%rsi,2), %zmm9
-	vmovdqa64	384(%rsp,%rsi,2), %zmm10
-	vmovdqa64	448(%rsp,%rsi,2), %zmm11
-	vpsubq	%zmm3, %zmm9, %zmm3
-	vpaddq	%zmm5, %zmm3, %zmm3
-	vpsubq	%zmm7, %zmm8, %zmm5
-	vpaddq	%zmm2, %zmm5, %zmm2
-	vpandq	%zmm4, %zmm3, %zmm9 {%k1}
-	vpandq	%zmm4, %zmm2, %zmm8 {%k2}
-	vmovdqa64	%zmm8, 256(%rsp,%rsi,2)
-	vmovdqa64	%zmm9, 320(%rsp,%rsi,2)
-	vmovdqa64	8576(%rsp,%rsi), %zmm5
-	vpsllvd	%zmm0, %zmm5, %zmm7
-	vpsraq	$32, %zmm3, %zmm8
-	vpsrlvd	%zmm1, %zmm5, %zmm3
-	vpsraq	$32, %zmm2, %zmm2
-	vpord	%zmm6, %zmm7, %zmm5
-	vpmovzxdq	%ymm5, %zmm6    # zmm6 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
-	vextracti64x4	$1, %zmm5, %ymm5
-	vpmovzxdq	%ymm5, %zmm5    # zmm5 = ymm5[0],zero,ymm5[1],zero,ymm5[2],zero,ymm5[3],zero,ymm5[4],zero,ymm5[5],zero,ymm5[6],zero,ymm5[7],zero
-	vpsubq	%zmm5, %zmm11, %zmm5
-	vpaddq	%zmm8, %zmm5, %zmm5
-	vpsubq	%zmm6, %zmm10, %zmm6
-	vpaddq	%zmm2, %zmm6, %zmm2
-	vpandq	%zmm4, %zmm2, %zmm10 {%k2}
-	vmovdqa64	%zmm10, 384(%rsp,%rsi,2)
-	vpandq	%zmm4, %zmm5, %zmm11 {%k1}
-	vmovdqa64	%zmm11, 448(%rsp,%rsi,2)
-	vpsraq	$32, %zmm5, %zmm5
-	vpsraq	$32, %zmm2, %zmm2
-	addq	$2, %rax
-	subq	$-128, %rsi
-	cmpl	%eax, %edx
-	jne	.LBB3_83
-# %bb.69:                               # %for_test288.safe_if_after_true.loopexit_crit_edge.unr-lcssa
-	testl	%edi, %edi
-	je	.LBB3_71
-.LBB3_70:                               # %for_loop289.epil.preheader
-	movq	%rax, %rdx
-	shlq	$7, %rdx
-	vmovdqa64	384(%rsp,%rdx), %zmm1
-	vmovdqa64	448(%rsp,%rdx), %zmm4
-	shlq	$6, %rax
-	vmovdqa64	8576(%rsp,%rax), %zmm6
-	vpsllvd	%zmm0, %zmm6, %zmm0
-	vpord	%zmm3, %zmm0, %zmm0
-	vpmovzxdq	%ymm0, %zmm3    # zmm3 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
-	vextracti64x4	$1, %zmm0, %ymm0
-	vpmovzxdq	%ymm0, %zmm0    # zmm0 = ymm0[0],zero,ymm0[1],zero,ymm0[2],zero,ymm0[3],zero,ymm0[4],zero,ymm0[5],zero,ymm0[6],zero,ymm0[7],zero
-	vpsubq	%zmm0, %zmm4, %zmm0
-	vpaddq	%zmm5, %zmm0, %zmm0
-	vpsubq	%zmm3, %zmm1, %zmm3
-	vpaddq	%zmm2, %zmm3, %zmm2
-	vpbroadcastq	.LCPI3_1(%rip), %zmm3 # zmm3 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
-	vpandq	%zmm3, %zmm0, %zmm4 {%k1}
-	vpandq	%zmm3, %zmm2, %zmm1 {%k2}
-	vmovdqa64	%zmm1, 384(%rsp,%rdx)
-	vmovdqa64	%zmm4, 448(%rsp,%rdx)
-.LBB3_71:                               # %safe_if_after_true
-	leal	-1(%r15), %eax
-	shlq	$7, %rax
-	vmovdqa64	384(%rsp,%rax), %zmm0
-	vmovdqa64	448(%rsp,%rax), %zmm1
-	vptestmq	%zmm0, %zmm0, %k0
-	vptestmq	%zmm1, %zmm1, %k1
-	kunpckbw	%k0, %k1, %k1
-	vpcmpeqd	%xmm2, %xmm2, %xmm2
-	kortestw	%k1, %k1
-	je	.LBB3_76
-# %bb.72:                               # %for_test347.preheader
-	xorl	%eax, %eax
-	cmpl	%r15d, %eax
-	movl	$0, %edx
-	sbbw	%dx, %dx
-	kmovw	%edx, %k0
-	kandw	%k0, %k1, %k2
-	kortestw	%k2, %k2
-	je	.LBB3_76
-# %bb.73:                               # %for_loop348.preheader
-	vpbroadcastd	.LCPI3_2(%rip), %zmm2 # zmm2 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-	kxnorw	%k0, %k0, %k3
-	.p2align	4, 0x90
-.LBB3_74:                               # %for_loop348
-                                        # =>This Inner Loop Header: Depth=1
-	movl	%eax, %esi
-	movq	%rsi, %rdx
-	shlq	$6, %rdx
-	vmovdqa64	8576(%rsp,%rdx), %zmm3
-	vpaddd	%zmm2, %zmm3, %zmm4
-	vpcmpltud	%zmm3, %zmm4, %k4
-	vpternlogd	$255, %zmm3, %zmm3, %zmm3 {%k4}{z}
-	vpsrld	$31, %zmm3, %zmm2 {%k2}
-	shlq	$7, %rsi
-	vextracti64x4	$1, %zmm4, %ymm3
-	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
-	vpcmpneqq	384(%rsp,%rsi), %zmm4, %k0
-	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
-	vpcmpneqq	448(%rsp,%rsi), %zmm3, %k4
-	kunpckbw	%k0, %k4, %k0
-	kandw	%k2, %k0, %k0
-	kxorw	%k3, %k0, %k3
-	addl	$1, %eax
-	cmpl	%r15d, %eax
-	sbbw	%dx, %dx
-	kmovw	%edx, %k0
-	kandw	%k0, %k2, %k0
-	kandw	%k0, %k3, %k2
-	kortestw	%k2, %k2
-	jne	.LBB3_74
-# %bb.75:                               # %for_test347.safe_if_after_true339.loopexit_crit_edge
-	vpternlogd	$255, %zmm2, %zmm2, %zmm2 {%k3}{z}
-	vpmovdb	%zmm2, %xmm2
-.LBB3_76:                               # %safe_if_after_true339
-	vptestnmq	%zmm0, %zmm0, %k0
-	vptestnmq	%zmm1, %zmm1, %k2
-	kunpckbw	%k0, %k2, %k0
-	kortestw	%k0, %k0
-	je	.LBB3_81
-# %bb.77:                               # %safe_if_run_false405
-	vpbroadcastq	.LCPI3_3(%rip), %zmm0 # zmm0 = [1,1,1,1,1,1,1,1]
-	vpcmpeqq	384(%rsp), %zmm0, %k2
-	vpcmpeqq	448(%rsp), %zmm0, %k3
-	kunpckbw	%k2, %k3, %k2
-	vpmovsxbd	%xmm2, %zmm0
-	vpslld	$31, %zmm0, %zmm0
-	kandnw	%k2, %k1, %k2
-	vptestmd	%zmm0, %zmm0, %k1 {%k1}
-	xorl	%eax, %eax
-	cmpl	$1, %r15d
-	movl	$65535, %edx            # imm = 0xFFFF
-	cmovbel	%eax, %edx
-	korw	%k2, %k1, %k1
-	kmovw	%edx, %k2
-	kandw	%k0, %k1, %k0
-	kandw	%k2, %k0, %k0
-	kortestw	%k0, %k0
-	je	.LBB3_80
-# %bb.78:                               # %for_loop421.preheader
-	movl	$1, %eax
-	.p2align	4, 0x90
-.LBB3_79:                               # %for_loop421
-                                        # =>This Inner Loop Header: Depth=1
-	movl	%eax, %edx
-	shlq	$7, %rdx
-	vmovdqa64	384(%rsp,%rdx), %zmm0
-	vmovdqa64	448(%rsp,%rdx), %zmm1
-	vptestmq	%zmm0, %zmm0, %k2
-	vptestmq	%zmm1, %zmm1, %k3
-	kunpckbw	%k2, %k3, %k2
-	kandw	%k0, %k2, %k2
-	kxorw	%k1, %k2, %k1
-	addl	$1, %eax
-	cmpl	%r15d, %eax
-	sbbw	%dx, %dx
-	kmovw	%edx, %k2
-	kandw	%k2, %k0, %k0
-	kandw	%k0, %k1, %k0
-	kortestw	%k0, %k0
-	jne	.LBB3_79
-.LBB3_80:                               # %if_done338.loopexit
-	vpternlogd	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
-	vpmovdb	%zmm0, %xmm2
-.LBB3_81:                               # %if_done338
-	vpand	.LCPI3_4(%rip), %xmm2, %xmm0
-	vpmovzxbd	%xmm0, %zmm0    # zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero,xmm0[8],zero,zero,zero,xmm0[9],zero,zero,zero,xmm0[10],zero,zero,zero,xmm0[11],zero,zero,zero,xmm0[12],zero,zero,zero,xmm0[13],zero,zero,zero,xmm0[14],zero,zero,zero,xmm0[15],zero,zero,zero
-	vmovdqu64	%zmm0, (%rcx)
-	leaq	-40(%rbp), %rsp
-	popq	%rbx
-	popq	%r12
-	popq	%r13
-	popq	%r14
-	popq	%r15
-	popq	%rbp
-	retq
-.LBB3_59:                               # %for_loop254.lr.ph.new
+	jmp	.LBB3_64
+.LBB3_62:                               # %for_loop262.lr.ph.new
 	leaq	768(%rsp), %rdx
-	movl	%r15d, %esi
-	subl	%r10d, %esi
+	movl	%r13d, %esi
+	subl	%ecx, %esi
 	vpxor	%xmm1, %xmm1, %xmm1
 	xorl	%eax, %eax
-	movl	%r15d, %edi
+	movl	%r13d, %edi
 	vpxor	%xmm2, %xmm2, %xmm2
 	.p2align	4, 0x90
-.LBB3_60:                               # %for_loop254
+.LBB3_63:                               # %for_loop262
                                         # =>This Inner Loop Header: Depth=1
 	vpaddq	-320(%rdx), %zmm2, %zmm2
 	vpaddq	-384(%rdx), %zmm1, %zmm1
@@ -3510,17 +3362,17 @@ fermat_test512:                            # @fermat_test512
 	addq	$512, %rdx              # imm = 0x200
 	addl	$4, %edi
 	cmpl	%eax, %esi
-	jne	.LBB3_60
-.LBB3_61:                               # %for_test253.for_exit256_crit_edge.unr-lcssa
-	testl	%r10d, %r10d
-	je	.LBB3_64
-# %bb.62:                               # %for_loop254.epil.preheader
-	leal	(%r15,%rax), %edx
+	jne	.LBB3_63
+.LBB3_64:                               # %for_test261.for_exit264_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB3_67
+# %bb.65:                               # %for_loop262.epil.preheader
+	leal	(%rax,%r13), %edx
 	shlq	$7, %rax
 	addq	%rsp, %rax
 	addq	$384, %rax              # imm = 0x180
 	.p2align	4, 0x90
-.LBB3_63:                               # %for_loop254.epil
+.LBB3_66:                               # %for_loop262.epil
                                         # =>This Inner Loop Header: Depth=1
 	vpaddq	64(%rax), %zmm2, %zmm2
 	vpaddq	(%rax), %zmm1, %zmm1
@@ -3536,15 +3388,228 @@ fermat_test512:                            # @fermat_test512
 	vpsrlq	$32, %zmm1, %zmm1
 	addl	$1, %edx
 	subq	$-128, %rax
-	addl	$-1, %r10d
-	jne	.LBB3_63
-.LBB3_64:                               # %for_test253.for_exit256_crit_edge
+	addl	$-1, %ecx
+	jne	.LBB3_66
+.LBB3_67:                               # %for_test261.for_exit264_crit_edge
 	vptestmq	%zmm1, %zmm1, %k0
 	vptestmq	%zmm2, %zmm2, %k1
-	kunpckbw	%k0, %k1, %k2
+	kunpckbw	%k0, %k1, %k1
+.LBB3_68:                               # %for_exit264
+	kortestw	%k1, %k1
+	je	.LBB3_74
+# %bb.69:                               # %for_exit264
+	testl	%r13d, %r13d
+	je	.LBB3_74
+# %bb.70:                               # %for_loop297.lr.ph
+	cmpl	$1, %r13d
+	kshiftrw	$8, %k1, %k2
+	jne	.LBB3_85
+# %bb.71:
+	vpxor	%xmm1, %xmm1, %xmm1
+	xorl	%eax, %eax
+	vpxor	%xmm4, %xmm4, %xmm4
+	vpxor	%xmm2, %xmm2, %xmm2
+	jmp	.LBB3_73
+.LBB3_85:                               # %for_loop297.lr.ph.new
+	movl	$32, %eax
+	subl	32(%rsp), %eax          # 4-byte Folded Reload
+	vpbroadcastd	%eax, %zmm0
+	movl	%r13d, %ecx
+	andl	$1, %ecx
+	movl	%r13d, %edx
+	subl	%ecx, %edx
+	vpxor	%xmm2, %xmm2, %xmm2
+	movl	$64, %esi
+	xorl	%eax, %eax
+	vpbroadcastq	.LCPI3_1(%rip), %zmm3 # zmm3 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
+	vpxor	%xmm1, %xmm1, %xmm1
+	vpxor	%xmm4, %xmm4, %xmm4
+	.p2align	4, 0x90
+.LBB3_86:                               # %for_loop297
+                                        # =>This Inner Loop Header: Depth=1
+	vmovdqa64	8512(%rsp,%rsi), %zmm5
+	vpsllvd	%zmm11, %zmm5, %zmm6
+	vpord	%zmm2, %zmm6, %zmm2
+	vpsrlvd	%zmm0, %zmm5, %zmm5
+	vpmovzxdq	%ymm2, %zmm6    # zmm6 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vextracti64x4	$1, %zmm2, %ymm2
+	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vmovdqa64	256(%rsp,%rsi,2), %zmm7
+	vmovdqa64	320(%rsp,%rsi,2), %zmm8
+	vmovdqa64	384(%rsp,%rsi,2), %zmm9
+	vmovdqa64	448(%rsp,%rsi,2), %zmm10
+	vpsubq	%zmm2, %zmm8, %zmm2
+	vpaddq	%zmm4, %zmm2, %zmm2
+	vpsubq	%zmm6, %zmm7, %zmm4
+	vpaddq	%zmm1, %zmm4, %zmm1
+	vpandq	%zmm3, %zmm2, %zmm8 {%k2}
+	vpandq	%zmm3, %zmm1, %zmm7 {%k1}
+	vmovdqa64	%zmm7, 256(%rsp,%rsi,2)
+	vmovdqa64	%zmm8, 320(%rsp,%rsi,2)
+	vmovdqa64	8576(%rsp,%rsi), %zmm4
+	vpsllvd	%zmm11, %zmm4, %zmm6
+	vpsraq	$32, %zmm2, %zmm7
+	vpsrlvd	%zmm0, %zmm4, %zmm2
+	vpsraq	$32, %zmm1, %zmm1
+	vpord	%zmm5, %zmm6, %zmm4
+	vpmovzxdq	%ymm4, %zmm5    # zmm5 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vextracti64x4	$1, %zmm4, %ymm4
+	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vpsubq	%zmm4, %zmm10, %zmm4
+	vpaddq	%zmm7, %zmm4, %zmm4
+	vpsubq	%zmm5, %zmm9, %zmm5
+	vpaddq	%zmm1, %zmm5, %zmm1
+	vpandq	%zmm3, %zmm1, %zmm9 {%k1}
+	vmovdqa64	%zmm9, 384(%rsp,%rsi,2)
+	vpandq	%zmm3, %zmm4, %zmm10 {%k2}
+	vmovdqa64	%zmm10, 448(%rsp,%rsi,2)
+	vpsraq	$32, %zmm4, %zmm4
+	vpsraq	$32, %zmm1, %zmm1
+	addq	$2, %rax
+	subq	$-128, %rsi
+	cmpl	%eax, %edx
+	jne	.LBB3_86
+# %bb.72:                               # %for_test296.safe_if_after_true.loopexit_crit_edge.unr-lcssa
+	testl	%ecx, %ecx
+	je	.LBB3_74
+.LBB3_73:                               # %for_loop297.epil.preheader
+	movq	%rax, %rcx
+	shlq	$7, %rcx
+	vmovdqa64	384(%rsp,%rcx), %zmm0
+	vmovdqa64	448(%rsp,%rcx), %zmm3
+	shlq	$6, %rax
+	vmovdqa64	8576(%rsp,%rax), %zmm5
+	vpsllvd	%zmm11, %zmm5, %zmm5
+	vpord	%zmm2, %zmm5, %zmm2
+	vpmovzxdq	%ymm2, %zmm5    # zmm5 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vextracti64x4	$1, %zmm2, %ymm2
+	vpmovzxdq	%ymm2, %zmm2    # zmm2 = ymm2[0],zero,ymm2[1],zero,ymm2[2],zero,ymm2[3],zero,ymm2[4],zero,ymm2[5],zero,ymm2[6],zero,ymm2[7],zero
+	vpsubq	%zmm2, %zmm3, %zmm2
+	vpaddq	%zmm4, %zmm2, %zmm2
+	vpsubq	%zmm5, %zmm0, %zmm4
+	vpaddq	%zmm1, %zmm4, %zmm1
+	vpbroadcastq	.LCPI3_1(%rip), %zmm4 # zmm4 = [4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295,4294967295]
+	vpandq	%zmm4, %zmm2, %zmm3 {%k2}
+	vpandq	%zmm4, %zmm1, %zmm0 {%k1}
+	vmovdqa64	%zmm0, 384(%rsp,%rcx)
+	vmovdqa64	%zmm3, 448(%rsp,%rcx)
+.LBB3_74:                               # %safe_if_after_true
+	leal	-1(%r13), %eax
+	shlq	$7, %rax
+	vmovdqa64	384(%rsp,%rax), %zmm0
+	vmovdqa64	448(%rsp,%rax), %zmm1
+	vptestmq	%zmm0, %zmm0, %k0
+	vptestmq	%zmm1, %zmm1, %k1
+	kunpckbw	%k0, %k1, %k1
+	vpcmpeqd	%xmm2, %xmm2, %xmm2
+	kortestw	%k1, %k1
+	je	.LBB3_79
+# %bb.75:                               # %for_test355.preheader
+	xorl	%eax, %eax
+	cmpl	%r13d, %eax
+	movl	$0, %ecx
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k0
+	kandw	%k0, %k1, %k2
 	kortestw	%k2, %k2
-	jne	.LBB3_66
-	jmp	.LBB3_71
+	je	.LBB3_79
+# %bb.76:                               # %for_loop356.preheader
+	vpbroadcastd	.LCPI3_2(%rip), %zmm2 # zmm2 = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+	kxnorw	%k0, %k0, %k3
+	.p2align	4, 0x90
+.LBB3_77:                               # %for_loop356
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	movq	%rcx, %rdx
+	shlq	$6, %rdx
+	vmovdqa64	8576(%rsp,%rdx), %zmm3
+	vpaddd	%zmm2, %zmm3, %zmm4
+	vpcmpltud	%zmm3, %zmm4, %k4
+	vpternlogd	$255, %zmm3, %zmm3, %zmm3 {%k4}{z}
+	vpsrld	$31, %zmm3, %zmm2 {%k2}
+	shlq	$7, %rcx
+	vextracti64x4	$1, %zmm4, %ymm3
+	vpmovzxdq	%ymm4, %zmm4    # zmm4 = ymm4[0],zero,ymm4[1],zero,ymm4[2],zero,ymm4[3],zero,ymm4[4],zero,ymm4[5],zero,ymm4[6],zero,ymm4[7],zero
+	vpcmpneqq	384(%rsp,%rcx), %zmm4, %k0
+	vpmovzxdq	%ymm3, %zmm3    # zmm3 = ymm3[0],zero,ymm3[1],zero,ymm3[2],zero,ymm3[3],zero,ymm3[4],zero,ymm3[5],zero,ymm3[6],zero,ymm3[7],zero
+	vpcmpneqq	448(%rsp,%rcx), %zmm3, %k4
+	kunpckbw	%k0, %k4, %k0
+	kandw	%k2, %k0, %k0
+	kxorw	%k3, %k0, %k3
+	addl	$1, %eax
+	cmpl	%r13d, %eax
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k0
+	kandw	%k0, %k2, %k0
+	kandw	%k0, %k3, %k2
+	kortestw	%k2, %k2
+	jne	.LBB3_77
+# %bb.78:                               # %for_test355.safe_if_after_true347.loopexit_crit_edge
+	vpternlogd	$255, %zmm2, %zmm2, %zmm2 {%k3}{z}
+	vpmovdb	%zmm2, %xmm2
+.LBB3_79:                               # %safe_if_after_true347
+	vptestnmq	%zmm0, %zmm0, %k0
+	vptestnmq	%zmm1, %zmm1, %k2
+	kunpckbw	%k0, %k2, %k0
+	kortestw	%k0, %k0
+	je	.LBB3_84
+# %bb.80:                               # %safe_if_run_false413
+	vpbroadcastq	.LCPI3_3(%rip), %zmm0 # zmm0 = [1,1,1,1,1,1,1,1]
+	vpcmpeqq	384(%rsp), %zmm0, %k2
+	vpcmpeqq	448(%rsp), %zmm0, %k3
+	kunpckbw	%k2, %k3, %k2
+	vpmovsxbd	%xmm2, %zmm0
+	vpslld	$31, %zmm0, %zmm0
+	kandnw	%k2, %k1, %k2
+	vptestmd	%zmm0, %zmm0, %k1 {%k1}
+	xorl	%eax, %eax
+	cmpl	$1, %r13d
+	movl	$65535, %ecx            # imm = 0xFFFF
+	cmovbel	%eax, %ecx
+	korw	%k2, %k1, %k1
+	kmovw	%ecx, %k2
+	kandw	%k0, %k1, %k0
+	kandw	%k2, %k0, %k0
+	kortestw	%k0, %k0
+	je	.LBB3_83
+# %bb.81:                               # %for_loop429.preheader
+	movl	$1, %eax
+	.p2align	4, 0x90
+.LBB3_82:                               # %for_loop429
+                                        # =>This Inner Loop Header: Depth=1
+	movl	%eax, %ecx
+	shlq	$7, %rcx
+	vmovdqa64	384(%rsp,%rcx), %zmm0
+	vmovdqa64	448(%rsp,%rcx), %zmm1
+	vptestmq	%zmm0, %zmm0, %k2
+	vptestmq	%zmm1, %zmm1, %k3
+	kunpckbw	%k2, %k3, %k2
+	kandw	%k0, %k2, %k2
+	kxorw	%k1, %k2, %k1
+	addl	$1, %eax
+	cmpl	%r13d, %eax
+	sbbw	%cx, %cx
+	kmovw	%ecx, %k2
+	kandw	%k2, %k0, %k0
+	kandw	%k0, %k1, %k0
+	kortestw	%k0, %k0
+	jne	.LBB3_82
+.LBB3_83:                               # %if_done346.loopexit
+	vpternlogd	$255, %zmm0, %zmm0, %zmm0 {%k1}{z}
+	vpmovdb	%zmm0, %xmm2
+.LBB3_84:                               # %if_done346
+	movq	40(%rsp), %rax          # 8-byte Reload
+	vpand	.LCPI3_4(%rip), %xmm2, %xmm0
+	vpmovzxbd	%xmm0, %zmm0    # zmm0 = xmm0[0],zero,zero,zero,xmm0[1],zero,zero,zero,xmm0[2],zero,zero,zero,xmm0[3],zero,zero,zero,xmm0[4],zero,zero,zero,xmm0[5],zero,zero,zero,xmm0[6],zero,zero,zero,xmm0[7],zero,zero,zero,xmm0[8],zero,zero,zero,xmm0[9],zero,zero,zero,xmm0[10],zero,zero,zero,xmm0[11],zero,zero,zero,xmm0[12],zero,zero,zero,xmm0[13],zero,zero,zero,xmm0[14],zero,zero,zero,xmm0[15],zero,zero,zero
+	vmovdqu64	%zmm0, (%rax)
+	leaq	-40(%rbp), %rsp
+	popq	%rbx
+	popq	%r12
+	popq	%r13
+	popq	%r14
+	popq	%r15
+	popq	%rbp
+	retq
 .Lfunc_end3:
 	.size	fermat_test512, .Lfunc_end3-fermat_test512
                                         # -- End function


### PR DESCRIPTION
In order to reduce memory usage, I've split the primes and modular inverses arrays into 32-bit and 64-bit segments.  This doesn't make a noticeable difference to performance, but reduces memory usage.

Other minor fixes:
- Cached the value of sieve.additionalFactorsToEliminateCounts[sieveIteration] in a loop in doSieveTask.  Because it's an atomic it's expensive to access
- Switched away from using std::array for the thread_local factorsCache.  This considerably improved performance of the presieve on Windows.
- Changed the fix to AVX2 support, allowing the old hand edited assembly code to be used, which is a few % faster than what ISPC produces.